### PR TITLE
Template custom volume name

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.6.0
+version: 8.6.1
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -96,8 +96,9 @@ spec:
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
+          {{- $root := . }}
           {{- range .Values.volumes }}
-          - name: {{ .name }}
+          - name: {{ tpl (.name) $root }}
             mountPath: {{ .mountPath }}
             readOnly: true
           {{- end }}
@@ -139,14 +140,15 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- $root := . }}
         {{- range .Values.volumes }}
-        - name: {{ .name }}
+        - name: {{ tpl (.name) $root }}
           {{- if eq .type "secret" }}
           secret:
-            secretName: {{ .name }}
+            secretName: {{ tpl (.name) $root }}
           {{- else if eq .type "configMap" }}
           configMap:
-            name: {{ .name }}
+            name: {{ tpl (.name) $root }}
           {{- end }}
         {{- end }}
       {{- with .Values.affinity }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -70,13 +70,13 @@ tests:
           type: configMap
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[1].name
+          path: spec.template.spec.containers[0].volumeMounts[2].name
           value: "RELEASE-NAME-custom-config"
       - equal:
-          path: spec.template.spec.volumes[1].name
+          path: spec.template.spec.volumes[2].name
           value: "RELEASE-NAME-custom-config"
       - equal:
-          path: spec.template.spec.volumes[1].configMap.name
+          path: spec.template.spec.volumes[2].configMap.name
           value: "RELEASE-NAME-custom-config"
   - it: should have templated secret volume
     set:
@@ -86,11 +86,11 @@ tests:
           type: secret
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[1].name
+          path: spec.template.spec.containers[0].volumeMounts[2].name
           value: "RELEASE-NAME-custom-secret"
       - equal:
-          path: spec.template.spec.volumes[1].name
+          path: spec.template.spec.volumes[2].name
           value: "RELEASE-NAME-custom-secret"
       - equal:
-          path: spec.template.spec.volumes[1].secret.secretName
+          path: spec.template.spec.volumes[2].secret.secretName
           value: "RELEASE-NAME-custom-secret"

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -62,7 +62,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].subPath
           value: "subdir/traefik"
-  - it: should have templated configMap volume
+  - it: should have templated config map volume
     set:
       volumes:
         - name: '{{ printf "%s-custom-config" .Release.Name }}'

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -62,3 +62,35 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].subPath
           value: "subdir/traefik"
+  - it: should have templated configMap volume
+    set:
+      volumes:
+        - name: '{{ printf "%s-custom-config" .Release.Name }}'
+          mountPath: /etc/traefik
+          type: configMap
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: "RELEASE-NAME-custom-config"
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: "RELEASE-NAME-custom-config"
+      - equal:
+          path: spec.template.spec.volumes[1].configMap.name
+          value: "RELEASE-NAME-custom-config"
+  - it: should have templated secret volume
+    set:
+      volumes:
+        - name: '{{ printf "%s-custom-secret" .Release.Name }}'
+          mountPath: /etc/secret
+          type: secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: "RELEASE-NAME-custom-secret"
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: "RELEASE-NAME-custom-secret"
+      - equal:
+          path: spec.template.spec.volumes[1].secret.secretName
+          value: "RELEASE-NAME-custom-secret"

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -68,16 +68,28 @@ tests:
         - name: '{{ printf "%s-custom-config" .Release.Name }}'
           mountPath: /etc/traefik
           type: configMap
+        - name: 'non-templated'
+          mountPath: /etc/non-templated
+          type: configMap
     asserts:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].name
           value: "RELEASE-NAME-custom-config"
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: "non-templated"
       - equal:
           path: spec.template.spec.volumes[2].name
           value: "RELEASE-NAME-custom-config"
       - equal:
           path: spec.template.spec.volumes[2].configMap.name
           value: "RELEASE-NAME-custom-config"
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: "non-templated"
+      - equal:
+          path: spec.template.spec.volumes[3].configMap.name
+          value: "non-templated"
   - it: should have templated secret volume
     set:
       volumes:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -35,7 +35,7 @@ rollingUpdate:
   maxSurge: 1
 
 #
-# Add volumes to the traefik pod.
+# Add volumes to the traefik pod. The volume name will be passed to tpl.
 # This can be used to mount a cert pair or a configmap that holds a config.toml file.
 # After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg:
 # additionalArguments:
@@ -44,7 +44,7 @@ volumes: []
 # - name: public-cert
 #   mountPath: "/certs"
 #   type: secret
-# - name: configs
+# - name: '{{ printf "%s-configs" .Release.Name }}'
 #   mountPath: "/config"
 #   type: configMap
 


### PR DESCRIPTION
This passes `volumes[].name` through tpl so it can be templated. This is necessary because the extra volumes name is either a ConfigMap or Secret and those usually contain the dynamic Helm release name. For example:
```yaml
  volumes:
    - name: '{{ printf "%s-traefik" .Release.Name }}'
      mountPath: /etc/traefik/
      type: configMap
```