### PR TITLE
Add basic auth for the exposed dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,32 +57,24 @@ kubectl apply -f traefik/crds
 
 ### Exposing the Traefik dashboard
 
-This HelmChart does not expose the Traefik dashboard by default, for security concerns.
-Thus, there are multiple ways to expose the dashboard.
-For instance, the dashboard access could be achieved through a port-forward :
-
-```
-kubectl port-forward $(kubectl get pods --selector "app.kubernetes.io/name=traefik" --output=name) 9000:9000
-```
-
-Another way would be to apply your own configuration, for instance,
-by defining and applying an IngressRoute CRD (`kubectl apply -f dashboard.yaml`):
+This Helm Chart does not expose the Traefik dashboard by default, for security concerns.
+To expose the Traefik dashboard you need to configure it on `values.yaml`:
 
 ```yaml
-# dashboard.yaml
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  name: dashboard
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`traefik.localhost`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
-      kind: Rule
-      services:
-        - name: api@internal
-          kind: TraefikService
+# values.yaml
+ports:
+  traefik:
+    expose: true
+```
+
+Traefik dashboard will be protected using basic auth by default using basic auth with the credential admin:password.
+To change default credential you can generate credential using `htpasswd -nb <user> <password>` and put the result in `values.yaml`:
+
+```yaml
+# values.yaml
+ingressRoute:
+  dashboard:
+    userData: admin:$apr1$xTMExMm7$KlDuMHTGK7VvRHn3mgCKx.
 ```
 
 ## Contributing

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.9.0
+version: 8.10.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -57,32 +57,24 @@ kubectl apply -f traefik/crds
 
 ### Exposing the Traefik dashboard
 
-This HelmChart does not expose the Traefik dashboard by default, for security concerns.
-Thus, there are multiple ways to expose the dashboard. 
-For instance, the dashboard access could be achieved through a port-forward :
-
-```
-kubectl port-forward $(kubectl get pods --selector "app.kubernetes.io/name=traefik" --output=name) 9000:9000
-```
-
-Another way would be to apply your own configuration, for instance,
-by defining and applying an IngressRoute CRD (`kubectl apply -f dashboard.yaml`):
+This Helm Chart does not expose the Traefik dashboard by default, for security concerns.
+To expose the Traefik dashboard you need to configure it on `values.yaml`:
 
 ```yaml
-# dashboard.yaml
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  name: dashboard
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`traefik.localhost`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
-      kind: Rule
-      services:
-        - name: api@internal
-          kind: TraefikService
+# values.yaml
+ports:
+  traefik:
+    expose: true
+```
+
+Traefik dashboard will be protected using basic auth by default using basic auth with the credential admin:password.
+To change default credential you can generate credential using `htpasswd -nb <user> <password>` and put the result in `values.yaml`:
+
+```yaml
+# values.yaml
+ingressRoute:
+  dashboard:
+    userData: admin:$apr1$xTMExMm7$KlDuMHTGK7VvRHn3mgCKx.
 ```
 
 ## Contributing

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -45,5 +45,5 @@ Dashboard basic auth data
 {{- define "traefik.secret.auth" -}}
 {{- $username := .Values.ingressRoute.dashboard.username -}}
 {{- $password := .Values.ingressRoute.dashboard.password -}}
-{{- printf "%s:%s" $username (sha1sum $password) -}}
+{{- htpasswd $username $password -}}
 {{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -38,12 +38,3 @@ The name of the service account to use
 {{- define "traefik.serviceAccountName" -}}
 {{- default (include "traefik.fullname" .) .Values.serviceAccount.name -}}
 {{- end -}}
-
-{{/*
-Dashboard basic auth data
-*/}}
-{{- define "traefik.secret.auth" -}}
-{{- $username := .Values.ingressRoute.dashboard.username -}}
-{{- $password := .Values.ingressRoute.dashboard.password -}}
-{{- htpasswd $username $password -}}
-{{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -43,6 +43,7 @@ The name of the service account to use
 Dashboard basic auth data
 */}}
 {{- define "traefik.secret.auth" -}}
-{{- $password := default (randAlphaNum 10) .Values.ingressRoute.dashboard.password -}}
-{{- printf "%s:%s" .Values.ingressRoute.dashboard.username (sha1sum $password) -}}
+{{- $username := .Values.ingressRoute.dashboard.username -}}
+{{- $password := .Values.ingressRoute.dashboard.password -}}
+{{- printf "%s:%s" $username (sha1sum $password) -}}
 {{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -38,3 +38,11 @@ The name of the service account to use
 {{- define "traefik.serviceAccountName" -}}
 {{- default (include "traefik.fullname" .) .Values.serviceAccount.name -}}
 {{- end -}}
+
+{{/*
+Dashboard basic auth data
+*/}}
+{{- define "traefik.secret.auth" -}}
+{{- $password := default (randAlphaNum 10) .Values.ingressRoute.dashboard.password -}}
+{{- printf "%s:%s" .Values.ingressRoute.dashboard.username (sha1sum $password) -}}
+{{- end -}}

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -18,13 +18,13 @@ metadata:
     {{- end }}
 spec:
   entryPoints:
-    - traefik
+    - web
   routes:
   - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
     kind: Rule
     services:
     - name: api@internal
       kind: TraefikService
-  middlewares:
+    middlewares:
     - name: {{ template "traefik.fullname" . }}-dashboard-auth-middleware
 {{- end -}}

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -25,4 +25,6 @@ spec:
     services:
     - name: api@internal
       kind: TraefikService
+  middlewares:
+    - name: {{ template "traefik.fullname" . }}-dashboard-auth-middleware
 {{- end -}}

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
 spec:
   entryPoints:
-    - web
+    - traefik
   routes:
   - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
     kind: Rule

--- a/traefik/templates/dashboard-hook-middleware.yaml
+++ b/traefik/templates/dashboard-hook-middleware.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingressRoute.dashboard.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ template "traefik.fullname" . }}-dashboard-auth-middleware
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "-5"
+  labels:
+    app.kubernetes.io/name: {{ template "traefik.name" . }}
+    helm.sh/chart: {{ template "traefik.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  basicAuth:
+    secret: {{ template "traefik.fullname" . }}-dashboard-auth-secret
+{{- end -}}

--- a/traefik/templates/dashboard-hook-secret.yaml
+++ b/traefik/templates/dashboard-hook-secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingressRoute.dashboard.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}-dashboard-auth-secret
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/name: {{ template "traefik.name" . }}
+    helm.sh/chart: {{ template "traefik.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+data:
+  auth: {{ include "traefik.secret.auth" . | b64enc | quote }}
+{{- end -}}

--- a/traefik/templates/dashboard-hook-secret.yaml
+++ b/traefik/templates/dashboard-hook-secret.yaml
@@ -13,5 +13,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 data:
-  auth: {{ include "traefik.secret.auth" . | b64enc | quote }}
+  users: {{ include "traefik.secret.auth" . | b64enc | quote }}
 {{- end -}}

--- a/traefik/templates/dashboard-hook-secret.yaml
+++ b/traefik/templates/dashboard-hook-secret.yaml
@@ -13,5 +13,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
 data:
-  users: {{ include "traefik.secret.auth" . | b64enc | quote }}
+  users: {{ .Values.ingressRoute.dashboard.userData | b64enc | quote }}
 {{- end -}}

--- a/traefik/tests/dashboard-ingress-config_test.yaml
+++ b/traefik/tests/dashboard-ingress-config_test.yaml
@@ -13,5 +13,5 @@ tests:
   - it: should specify basic auth middleware
     asserts:
       - matchRegex:
-          path: spec.middlewares[0].name
+          path: spec.routes[0].middlewares[0].name
           pattern: "-dashboard-auth-middleware$"

--- a/traefik/tests/dashboard-ingress-config_test.yaml
+++ b/traefik/tests/dashboard-ingress-config_test.yaml
@@ -1,0 +1,17 @@
+suite: Dashboard Ingress configuration
+templates:
+  - dashboard-hook-ingressroute.yaml
+tests:
+  - it: should not render when dashboard is disabled
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should specify basic auth middleware
+    asserts:
+      - matchRegex:
+          path: spec.middlewares[0].name
+          pattern: "-dashboard-auth-middleware$"

--- a/traefik/tests/dashboard-middleware-config_test.yaml
+++ b/traefik/tests/dashboard-middleware-config_test.yaml
@@ -1,0 +1,22 @@
+suite: Dashboard Middleware configuration
+templates:
+  - dashboard-hook-middleware.yaml
+tests:
+  - it: should not render when dashboard is disabled
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should use correct name
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "-dashboard-auth-middleware$"
+  - it: should specify basic auth secret
+    asserts:
+      - matchRegex:
+          path: spec.basicAuth.secret
+          pattern: "-dashboard-auth-secret$"

--- a/traefik/tests/dashboard-secret-config_test.yaml
+++ b/traefik/tests/dashboard-secret-config_test.yaml
@@ -15,8 +15,8 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: -dashboard-auth-secret$
-  - it: should generate default auth secret
+  - it: should use default auth secret
     asserts:
       - equal:
           path: data.users
-          value: "YWRtaW46JDJhJDEwJFFadUhLYURDd0xWQWkucVQuZEJHcHVwdTBIRHE1T05TWkVpYWFvYlN5UUZsa1cwR3VlZy9p"
+          value: "YWRtaW46JGFwcjEkeFRNRXhNbTckS2xEdU1IVEdLN1Z2UkhuM21nQ0t4Lg=="

--- a/traefik/tests/dashboard-secret-config_test.yaml
+++ b/traefik/tests/dashboard-secret-config_test.yaml
@@ -18,6 +18,5 @@ tests:
   - it: should generate default auth secret
     asserts:
       - equal:
-          path: data.auth
-          # base64 encode of admin:sha1sum(password)
-          value: "YWRtaW46NWJhYTYxZTRjOWI5M2YzZjA2ODIyNTBiNmNmODMzMWI3ZWU2OGZkOA=="
+          path: data.users
+          value: "YWRtaW46JDJhJDEwJFFadUhLYURDd0xWQWkucVQuZEJHcHVwdTBIRHE1T05TWkVpYWFvYlN5UUZsa1cwR3VlZy9p"

--- a/traefik/tests/dashboard-secret-config_test.yaml
+++ b/traefik/tests/dashboard-secret-config_test.yaml
@@ -1,0 +1,32 @@
+suite: Dashboard basic auth secret configuration
+templates:
+  - dashboard-hook-secret.yaml
+tests:
+  - it: should not render when dashboard is disabled
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should use correct name
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: -dashboard-auth-secret$
+  - it: should generate default auth secret
+    asserts:
+      - matchRegex:
+          path: data.auth
+          pattern: "^YWRtaW4" #base64 encode data which begin with admin:
+  - it: should generate correct auth when username and password is specified
+    set:
+      ingressRoute:
+        dashboard:
+          username: user
+          password: password
+    asserts:
+      - equal:
+          path: data.auth
+          value: "dXNlcjo1YmFhNjFlNGM5YjkzZjNmMDY4MjI1MGI2Y2Y4MzMxYjdlZTY4ZmQ4"

--- a/traefik/tests/dashboard-secret-config_test.yaml
+++ b/traefik/tests/dashboard-secret-config_test.yaml
@@ -17,16 +17,7 @@ tests:
           pattern: -dashboard-auth-secret$
   - it: should generate default auth secret
     asserts:
-      - matchRegex:
-          path: data.auth
-          pattern: "^YWRtaW4" #base64 encode data which begin with admin:
-  - it: should generate correct auth when username and password is specified
-    set:
-      ingressRoute:
-        dashboard:
-          username: user
-          password: password
-    asserts:
       - equal:
           path: data.auth
-          value: "dXNlcjo1YmFhNjFlNGM5YjkzZjNmMDY4MjI1MGI2Y2Y4MzMxYjdlZTY4ZmQ4"
+          # base64 encode of admin:sha1sum(password)
+          value: "YWRtaW46NWJhYTYxZTRjOWI5M2YzZjA2ODIyNTBiNmNmODMzMWI3ZWU2OGZkOA=="

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -37,6 +37,11 @@ podDisruptionBudget:
 ingressRoute:
   dashboard:
     enabled: true
+    # Username for dashboard
+    username: admin
+    # Password for dashboard. Default to random string
+    # password: password
+
     # Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)
     annotations: {}
     # Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -39,8 +39,8 @@ ingressRoute:
     enabled: true
     # Username for dashboard
     username: admin
-    # Password for dashboard. Default to random string
-    # password: password
+    # Password for dashboard
+    password: password
 
     # Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)
     annotations: {}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -37,10 +37,9 @@ podDisruptionBudget:
 ingressRoute:
   dashboard:
     enabled: true
-    # Username for dashboard
-    username: admin
-    # Password for dashboard
-    password: password
+    # Username and password for dashboard.
+    # Default value generated from command `htpasswd -nb admin password`
+    userData: admin:$apr1$xTMExMm7$KlDuMHTGK7VvRHn3mgCKx.
 
     # Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)
     annotations: {}


### PR DESCRIPTION
Users will be able to specify the username and password used to login to the dashboard.
Setting the username and password is mandatory when the user chooses to expose the dashboard.

This PR will help #186 