### PR TITLE
feat: added lifecycle hook to container

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.8.0
+version: 8.10.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.7.2
+version: 8.8.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.lifecycle }}
+        lifecycle:
+          {{- toYaml .Values.lifecycle | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.path }}
@@ -119,7 +123,7 @@ spec:
           {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
-          {{- end }}          
+          {{- end }}
           {{- if and .Values.rbac.enabled .Values.rbac.namespaced}}
           - "--providers.kubernetescrd.namespaces={{ .Release.Namespace }}"
           - "--providers.kubernetesingress.namespaces={{ .Release.Namespace }}"

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
         {{- end }}
         {{- with .Values.lifecycle }}
         lifecycle:
-          {{- toYaml .Values.lifecycle | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
           - name: data

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -244,3 +244,10 @@ securityContext:
 
 podSecurityContext:
   fsGroup: 65532
+
+# Container lifecycle hook
+# https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle: {}
+#  preStop:
+#    exec:
+#      command: ["/bin/sh", "-c", "sleep 30"]


### PR DESCRIPTION
This change adds the lifecycle to the container, that can be useful with the `preStop` hook, used to avoid aborting ongoing requests ([here is why](https://blog.sebastian-daschner.com/entries/zero-downtime-updates-kubernetes)). This is also useful as `traefik` supports custom values for [graceful timeouts](https://docs.traefik.io/routing/entrypoints/#lifecycle).