### PR TITLE
Add additional volumes for init and additional containers

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.5.2
+version: 9.6.0
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -226,6 +226,9 @@ spec:
             name: {{ tpl (.name) $root }}
           {{- end }}
         {{- end }}
+        {{- if .Values.deployment.additionalVolumes }}
+          {{- toYaml .Values.deployment.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -146,6 +146,20 @@ tests:
         - equal:
             path: spec.additionalContainers[0].name
             value: bar
+  - it: should have additional volumes
+    set:
+      deployment:
+        additionalVolumes:
+          - hostpath:
+              path: /foo
+            name: bar
+      asserts:
+        - equal:
+            path: spec.template.spec.volumes[4].hostpath.path
+            value: /foo
+        - equal:
+            path: spec.template.spec.volumes[4].name
+            value: bar
   - it: should have imagePullPolicy with specified value
     set:
       image:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -17,6 +17,8 @@ deployment:
   podAnnotations: {}
   # Additional containers (e.g. for metric offloading sidecars)
   additionalContainers: []
+  # Additional volumes available for use with initContainers and additionalContainers
+  additionalVolumes: []
   # Additional initContainers (e.g. for setting file permission as shown below)
   initContainers: []
     # The "volume-permissions" init container is required if you run into permission issues.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -17,8 +17,18 @@ deployment:
   podAnnotations: {}
   # Additional containers (e.g. for metric offloading sidecars)
   additionalContainers: []
+    # https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=host
+    # - name: socat-proxy
+    # image: alpine/socat:1.0.5
+    # args: ["-s", "-u", "udp-recv:8125", "unix-sendto:/socket/socket"]
+    # volumeMounts:
+    #   - name: dsdsocket
+    #     mountPath: /socket
   # Additional volumes available for use with initContainers and additionalContainers
   additionalVolumes: []
+    # - name: dsdsocket
+    #   hostPath:
+    #   path: /var/run/statsd-exporter
   # Additional initContainers (e.g. for setting file permission as shown below)
   initContainers: []
     # The "volume-permissions" init container is required if you run into permission issues.


### PR DESCRIPTION
This increases the flexibility of the init and additional containers, I ran into the issue where I needed to mount a volume that was not a configMap or a secret to a sidecar. 