### PR TITLE
Allow to specify custom labels on Service

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.3.0
+version: 9.4.0
 appVersion: 2.3.0
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -23,6 +23,9 @@ items:
         helm.sh/chart: {{ template "traefik.chart" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
       {{- with .Values.service.annotations }}
       {{- toYaml . | nindent 8 }}

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -28,6 +28,16 @@ tests:
       - equal:
           path: items[0].metadata.annotations.azure-load-balancer-internal
           value: true
+  - it: should have customized labels when specified via values
+    set:
+      service:
+        labels:
+          custom-label: custom-value
+    asserts:
+      - equal:
+          path: items[0].metadata.labels.custom-label
+          value: custom-value
+
   - it: should have custom spec elements when specified via values
     set:
       service:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -221,6 +221,8 @@ service:
   type: LoadBalancer
   # Additional annotations (e.g. for cloud provider specific config)
   annotations: {}
+  # Additional service labels (e.g. for filtering Service by custom labels)
+  labels: {}
   # Additional entries here will be added to the service spec. Cannot contains
   # type, selector or ports entries.
   spec: {}


### PR DESCRIPTION
For some usages, adding labels to kubernetes service could be useful.

FYI, I'm using Datadog as monitoring service and putting labels on Service allow to gather more data.