### PR TITLE
Add Artifact Hub repository metadata file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ deploy: global-requirements $(DIST_DIR) $(HELM_REPO)
 	@rm -rf $(CURDIR)/gh-pages.zip
 	@curl -sSLO https://$(PROJECT)/archive/gh-pages.zip
 	@unzip -oj $(CURDIR)/gh-pages.zip -d $(HELM_REPO)/
-	@cp $(DIST_DIR)/*tgz $(HELM_REPO)/
+	@cp $(DIST_DIR)/*tgz $(CURDIR)/artifacthub-repo.yml $(HELM_REPO)/
 	@helm repo index --merge $(HELM_REPO)/index.yaml --url https://helm.traefik.io/traefik/ $(HELM_REPO)
 	@echo "== Deploying Finished"
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ deploy: global-requirements $(DIST_DIR) $(HELM_REPO)
 	@curl -sSLO https://$(PROJECT)/archive/gh-pages.zip
 	@unzip -oj $(CURDIR)/gh-pages.zip -d $(HELM_REPO)/
 	@cp $(DIST_DIR)/*tgz $(CURDIR)/artifacthub-repo.yml $(HELM_REPO)/
+	@cp $(CURDIR)/README.md $(HELM_REPO)/index.md
 	@helm repo index --merge $(HELM_REPO)/index.yaml --url https://helm.traefik.io/traefik/ $(HELM_REPO)
 	@echo "== Deploying Finished"
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,3 @@
+# Artifact Hub repository metadata file.
+# The ID of the Artifact Hub repository where the packages will be published to (enables verified publisher).
+repositoryID: 5cf43a0d-3e93-4959-8973-54824aafa423

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.4.1
+version: 9.4.2
 appVersion: 2.3.0
 keywords:
   - traefik


### PR DESCRIPTION
This PR:

- Adds Artifact Hub repository metadata file to be a verified publisher
- Updates the `Makefile` to use the root `README` as the Helm repository`index.md`