### PR TITLE
Replace extensions with policy because of deprecation

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.5.1
+version: 9.5.2
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -52,7 +52,7 @@ rules:
       - watch
 {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:
-      - extensions
+      - policy
     resourceNames:
       - {{ template "traefik.fullname" . }}
     resources:


### PR DESCRIPTION
Deprecation Info:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

The current docs also show the policy apiGroup:
https://kubernetes.io/docs/concepts/policy/pod-security-policy/#via-rbac