### PR TITLE
Add additionalVolumeMounts for traefik container

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.8.0
+version: 9.9.0
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -121,6 +121,9 @@ spec:
           - name: plugins
             mountPath: "/plugins-storage"
           {{- end }}
+          {{- if .Values.additionalVolumeMounts }}
+            {{- toYaml .Values.additionalVolumeMounts | nindent 10 }}
+          {{- end }}
         args:
           {{- with .Values.globalArguments }}
           {{- range . }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -102,5 +102,5 @@ tests:
             path: spec.template.spec.containers[0].volumeMounts[3].name
             value: foo-logs
         - equal:
-            path: spec.template.spec.volumes[4].mountPath
+            path: spec.template.spec.containers[0].volumeMounts[3].mountPath
             value: /var/log/traefik

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -92,3 +92,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.websecure.http.tls.domains[0].sans=alt1.domain.tld,alt2.domain.tld"
+  - it: should have additional volumeMounts
+    set:
+      additionalVolumeMounts:
+        - name: foo-logs
+          mountPath: /var/log/traefik
+      asserts:
+        - equal:
+            path: spec.template.spec.containers[0].volumeMounts[3].name
+            value: foo-logs
+        - equal:
+            path: spec.template.spec.volumes[4].mountPath
+            value: /var/log/traefik

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -107,6 +107,12 @@ volumes: []
 #   mountPath: "/config"
 #   type: configMap
 
+# Additional volumeMounts to add to the Traefik container
+additionalVolumeMounts: []
+  # For instance when using a logshipper for access logs
+  # - name: traefik-logs
+  #   mountPath: /var/log/traefik
+
 # Logs
 # https://docs.traefik.io/observability/logs/
 logs:


### PR DESCRIPTION
Add ability to add volumeMounts to the Traefik container.
This is useful if for instance you want to ship access logs with a sidecar.