### PR TITLE
Add chart repo to source

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.8.1
+version: 9.8.2
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -10,6 +10,7 @@ keywords:
 home: https://traefik.io/
 sources:
   - https://github.com/traefik/traefik
+  - https://github.com/traefik/traefik-helm-chart
 maintainers:
   - name: emilevauge
     email: emile@vauge.com


### PR DESCRIPTION
Adding chart repo to the source, so that can easily to find `values.yaml` from [ArtifactHub](https://artifacthub.io/packages/helm/traefik/traefik)

<img width="1253" alt="Screenshot 2020-10-27 at 11 30 02 PM" src="https://user-images.githubusercontent.com/23547929/97324178-8208fa00-18ac-11eb-82b2-2813c2bfcdb7.png">

