### PR TITLE
Add list of watched provider namespaces

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -4,6 +4,7 @@ description: A Traefik based Kubernetes ingress controller
 type: application
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 version: 9.9.0
 =======
 version: 9.8.3
@@ -11,6 +12,9 @@ version: 9.8.3
 =======
 version: 9.8.4
 >>>>>>> Increment chart version
+=======
+version: 9.10.0
+>>>>>>> bump version of chart
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,10 +3,14 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 <<<<<<< HEAD
+<<<<<<< HEAD
 version: 9.9.0
 =======
 version: 9.8.3
 >>>>>>> Bump chart version
+=======
+version: 9.8.4
+>>>>>>> Increment chart version
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
+<<<<<<< HEAD
 version: 9.9.0
+=======
+version: 9.8.3
+>>>>>>> Bump chart version
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,19 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-version: 9.9.0
-=======
-version: 9.8.3
->>>>>>> Bump chart version
-=======
-version: 9.8.4
->>>>>>> Increment chart version
-=======
 version: 9.10.0
->>>>>>> bump version of chart
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -50,3 +50,13 @@ Users can provide an override for an explicit service they want bound via `.Valu
 {{- $servicePath := default $defServiceName .Values.providers.kubernetesIngress.publishedService.pathOverride }}
 {{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Construct a comma-separated list of watched namespaces
+*/}}
+{{- define "providers.kubernetesIngress.namespaces" -}}
+{{- join "," .Values.providers.kubernetesIngress.namespaces }}
+{{- end -}}
+{{- define "providers.kubernetesCRD.namespaces" -}}
+{{- join "," .Values.providers.kubernetesCRD.namespaces }}
+{{- end -}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -52,11 +52,11 @@ Users can provide an override for an explicit service they want bound via `.Valu
 {{- end -}}
 
 {{/*
-Construct a comma-separated list of watched namespaces
+Construct a comma-separated list of whitelisted namespaces
 */}}
 {{- define "providers.kubernetesIngress.namespaces" -}}
-{{- join "," .Values.providers.kubernetesIngress.namespaces }}
+{{- default .Release.Namespace (join "," .Values.providers.kubernetesIngress.namespaces) }}
 {{- end -}}
 {{- define "providers.kubernetesCRD.namespaces" -}}
-{{- join "," .Values.providers.kubernetesCRD.namespaces }}
-{{- end -}
+{{- default .Release.Namespace (join "," .Values.providers.kubernetesCRD.namespaces) }}
+{{- end -}}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -151,8 +151,8 @@ spec:
           {{- end }}
           {{- end }}
           {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
-          - "--providers.kubernetescrd.namespaces={{ .Release.Namespace }}"
-          - "--providers.kubernetesingress.namespaces={{ .Release.Namespace }}"
+          - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" . | default .Release.Namespace }}"
+          - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" . | default .Release.Namespace }}"
           {{- end }}
           {{- range $entrypoint, $config := $.Values.ports }}
           {{- if $config.redirectTo }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -151,8 +151,8 @@ spec:
           {{- end }}
           {{- end }}
           {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
-          - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" . | default .Release.Namespace }}"
-          - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" . | default .Release.Namespace }}"
+          - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" . }}"
+          - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" . }}"
           {{- end }}
           {{- range $entrypoint, $config := $.Values.ports }}
           {{- if $config.redirectTo }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -21,6 +21,28 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.namespaces=NAMESPACE"
+  - it: should have a custom string of watched namespaces when specified in configuration
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesCRD:
+          enabled: true
+          namespaces:
+          - "foo"
+          - "bar"
+        kubernetesIngress:
+          enabled: true
+          namespaces:
+          - "foo"
+          - "bar"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.namespaces=foo,bar"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.namespaces=foo,bar"
   - it: should have disable published Kubernetes service when default configuration
     asserts:
       - notContains:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -88,8 +88,12 @@ rollingUpdate:
 providers:
   kubernetesCRD:
     enabled: true
+    namespaces: []
+      # - "default"
   kubernetesIngress:
     enabled: true
+    namespaces: []
+      # - "default"
     # IP used for Kubernetes Ingress endpoints
     publishedService:
       enabled: false


### PR DESCRIPTION
If `rbac.namespaced` is `true`, the kubernetesIngress and kubernetesCRD providers need to be provided with a list of namespaces to watch, which right now defaults to the namespace the chart is installed in. Additional namespaces can be provided in `additionalArguments`, but this change allows them to be specified in the Values file the same way they would be in config.yaml.