### PR TITLE
 using Acme allows configuration of multiple replicas

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.8.2
+version: 9.8.4
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.8.3
+version: 9.8.4
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -3,7 +3,9 @@
     {{- with .Values.additionalArguments -}}
       {{- range . -}}
         {{- if contains ".acme." . -}}
-          {{- fail (printf "You can not enabled acme if you set more than one traefik replica") -}}
+          {{- if not $.Values.persistence.enabled }}
+            {{- fail (printf "You can not enabled acme if you set more than one traefik replica") -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
When `persistence.enabled: true`, using `Acme `allows configuration of multiple `replicas`