### PR TITLE
Specify IngressClass resource when checking for cluster capability

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.10.0
+version: 9.10.1
 appVersion: 2.3.1
 keywords:
   - traefik

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.ingressClass.enabled (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass" }}
 apiVersion: networking.k8s.io/v1beta1
   {{- else }}
     {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}


### PR DESCRIPTION
When installing the latest chart version on a 1.18.9 cluster, the capability check passes on having networking.k8s.io/v1, although in 1.18, the IngressClass resource was still in networking.k8s.io/v1beta1.

Now checking specifically for the IngressClass capability in the two api versions.

Resolves #287