### PR TITLE
add podLabels - custom labels

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.10.2
+version: 9.11.0
 appVersion: 2.3.3
 keywords:
   - traefik

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
         helm.sh/chart: {{ template "traefik.chart" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.deployment.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.deployment.imagePullSecrets }}
       imagePullSecrets:

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -175,7 +175,7 @@ tests:
   - it: should have imagePullSecrets with specified value
     set:
       deployment:
-        imagePullSecrets: 
+        imagePullSecrets:
           - name: myRegistryKeySecretName
     asserts:
       - equal:
@@ -184,7 +184,7 @@ tests:
   - it: should have multiple imagePullSecrets with specified value
     set:
       deployment:
-        imagePullSecrets: 
+        imagePullSecrets:
           - name: myRegistryKeySecretName
           - name: myOtherRegistryKeySecretName
     asserts:
@@ -194,4 +194,12 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[1].name
           value: myOtherRegistryKeySecretName
-
+  - it: should have customized labels when specified via values
+    set:
+      deployment:
+        podLabels:
+          custom-label: custom-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.custom-label
+          value: custom-value

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -16,6 +16,8 @@ deployment:
   annotations: {}
   # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
   podAnnotations: {}
+  # Additional Pod labels (e.g. for filtering Pod by custom labels)
+  podLabels: {}
   # Additional containers (e.g. for metric offloading sidecars)
   additionalContainers: []
     # https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=host


### PR DESCRIPTION
This PR will address adding custom labels to Pods, like the service.labels, until all labels are moved to _helper.tpl.