### PR TITLE
Fix dashboard ingress route

### DIFF
--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  tls: {}
   entryPoints:
     - traefik
   routes:


### PR DESCRIPTION
This PR fixes default dashboard ingressroute. In current configuration Traefik is trying to talk to dashboard back-end via TLS which doesn't work as it is listening on plain HTTP.