### PR TITLE
Revert split LoadBalancers to single LoadBalancer with mixed protocols

### DIFF
--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -1,112 +1,49 @@
 {{- if .Values.service.enabled -}}
-
-{{ $tcpPorts := dict }}
-{{ $udpPorts := dict }}
-{{- range $name, $config := .Values.ports }}
-  {{- if eq (toString $config.protocol) "UDP" }}
-    {{ $_ := set $udpPorts $name $config }}
-  {{- else }}
-    {{ $_ := set $tcpPorts $name $config }}
-  {{- end }}
-{{- end }}
-
 apiVersion: v1
-kind: List
-items:
-{{- if  $tcpPorts }}
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      name: {{ template "traefik.fullname" . }}
-      labels:
-        app.kubernetes.io/name: {{ template "traefik.name" . }}
-        helm.sh/chart: {{ template "traefik.chart" . }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- with .Values.service.labels }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-      annotations:
-      {{- with .Values.service.annotations }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-    spec:
-      {{- $type := default "LoadBalancer" .Values.service.type }}
-      type: {{ $type }}
-      {{- with .Values.service.spec }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-      selector:
-        app.kubernetes.io/name: {{ template "traefik.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-      ports:
-      {{- range $name, $config := $tcpPorts }}
-      {{- if $config.expose }}
-      - port: {{ default $config.port $config.exposedPort }}
-        name: {{ $name }}
-        targetPort: {{ $name | quote }}
-        protocol: {{ default "TCP" $config.protocol | quote }}
-        {{- if $config.nodePort }}
-        nodePort: {{ $config.nodePort }}
-        {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- if eq $type "LoadBalancer" }}
-      {{- with .Values.service.loadBalancerSourceRanges }}
-      loadBalancerSourceRanges:
-      {{- toYaml . | nindent 6 }}
-      {{- end -}}
-      {{- end -}}
-      {{- with .Values.service.externalIPs }}
-      externalIPs:
-      {{- toYaml . | nindent 6 }}
-      {{- end -}}
-{{- end }}
-
-{{- if  $udpPorts }}
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      name: {{ template "traefik.fullname" . }}-udp
-      labels:
-        app.kubernetes.io/name: {{ template "traefik.name" . }}
-        helm.sh/chart: {{ template "traefik.chart" . }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-      annotations:
-      {{- with .Values.service.annotations }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-    spec:
-      {{- $type := default "LoadBalancer" .Values.service.type }}
-      type: {{ $type }}
-      {{- with .Values.service.spec }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-      selector:
-        app.kubernetes.io/name: {{ template "traefik.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-      ports:
-      {{- range $name, $config := $udpPorts }}
-      {{- if $config.expose }}
-      - port: {{ default $config.port $config.exposedPort }}
-        name: {{ $name }}
-        targetPort: {{ $name | quote }}
-        protocol: {{ default "UDP" $config.protocol | quote }}
-        {{- if $config.nodePort }}
-        nodePort: {{ $config.nodePort }}
-        {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- if eq $type "LoadBalancer" }}
-      {{- with .Values.service.loadBalancerSourceRanges }}
-      loadBalancerSourceRanges:
-      {{- toYaml . | nindent 6 }}
-      {{- end -}}
-      {{- end -}}
-      {{- with .Values.service.externalIPs }}
-      externalIPs:
-      {{- toYaml . | nindent 6 }}
-      {{- end -}}
-{{- end }}
+kind: Service
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "traefik.name" . }}
+    helm.sh/chart: {{ template "traefik.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.service.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+  {{- with .Values.service.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $type := default "LoadBalancer" .Values.service.type }}
+  type: {{ $type }}
+  {{- with .Values.service.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "traefik.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+  {{- range $name, $config := .Values.ports }}
+  {{- if $config.expose }}
+  - port: {{ default $config.port $config.exposedPort }}
+    name: {{ $name }}
+    targetPort: {{ $name | quote }}
+    protocol: {{ default "TCP" $config.protocol | quote }}
+    {{- if $config.nodePort }}
+    nodePort: {{ $config.nodePort }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if eq $type "LoadBalancer" }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end -}}
+  {{- end -}}
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+  {{- toYaml . | nindent 2 }}
+  {{- end -}}
 {{- end -}}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -1,4 +1,116 @@
 {{- if .Values.service.enabled -}}
+
+{{- if semverCompare "< 1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+{{ $tcpPorts := dict }}
+{{ $udpPorts := dict }}
+{{- range $name, $config := .Values.ports }}
+  {{- if eq (toString $config.protocol) "UDP" }}
+    {{ $_ := set $udpPorts $name $config }}
+  {{- else }}
+    {{ $_ := set $tcpPorts $name $config }}
+  {{- end }}
+{{- end }}
+
+apiVersion: v1
+kind: List
+items:
+{{- if  $tcpPorts }}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ template "traefik.fullname" . }}
+      labels:
+        app.kubernetes.io/name: {{ template "traefik.name" . }}
+        helm.sh/chart: {{ template "traefik.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{- with .Values.service.annotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- $type := default "LoadBalancer" .Values.service.type }}
+      type: {{ $type }}
+      {{- with .Values.service.spec }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      selector:
+        app.kubernetes.io/name: {{ template "traefik.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+      {{- range $name, $config := $tcpPorts }}
+      {{- if $config.expose }}
+      - port: {{ default $config.port $config.exposedPort }}
+        name: {{ $name }}
+        targetPort: {{ $name | quote }}
+        protocol: {{ default "TCP" $config.protocol | quote }}
+        {{- if $config.nodePort }}
+        nodePort: {{ $config.nodePort }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if eq $type "LoadBalancer" }}
+      {{- with .Values.service.loadBalancerSourceRanges }}
+      loadBalancerSourceRanges:
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
+      {{- end -}}
+      {{- with .Values.service.externalIPs }}
+      externalIPs:
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
+{{- end }}
+
+{{- if  $udpPorts }}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ template "traefik.fullname" . }}-udp
+      labels:
+        app.kubernetes.io/name: {{ template "traefik.name" . }}
+        helm.sh/chart: {{ template "traefik.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+      {{- with .Values.service.annotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- $type := default "LoadBalancer" .Values.service.type }}
+      type: {{ $type }}
+      {{- with .Values.service.spec }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      selector:
+        app.kubernetes.io/name: {{ template "traefik.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+      {{- range $name, $config := $udpPorts }}
+      {{- if $config.expose }}
+      - port: {{ default $config.port $config.exposedPort }}
+        name: {{ $name }}
+        targetPort: {{ $name | quote }}
+        protocol: {{ default "UDP" $config.protocol | quote }}
+        {{- if $config.nodePort }}
+        nodePort: {{ $config.nodePort }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if eq $type "LoadBalancer" }}
+      {{- with .Values.service.loadBalancerSourceRanges }}
+      loadBalancerSourceRanges:
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
+      {{- end -}}
+      {{- with .Values.service.externalIPs }}
+      externalIPs:
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
+{{- end }}
+{{- else -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,4 +158,5 @@ spec:
   externalIPs:
   {{- toYaml . | nindent 2 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Commit 6d60914 acted as a work-around for LoadBalancers' single protocol requirement (see [bergmannf's comment](https://github.com/traefik/traefik-helm-chart/pull/145#issuecomment-610791540) on #145). Kubernetes now supports LoadBalancers with mixed protocols (kubernetes/kubernetes#94028).

This commit reverts the original work-around to reintroduce a single TCP/UDP LoadBalancer for Traefik, cutting LoadBalancer costs in half.

_Note: The mixed-protocol LoadBalancers are planned to be included in [Kubernetes milestone v1.20](https://github.com/kubernetes/kubernetes/milestone/48)._