### PR TITLE
feat(healthchecksPort): Support for overriding the liveness/readiness probes port

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,13 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
+<<<<<<< HEAD
 version: 9.17.1
 appVersion: 2.4.7
+=======
+version: 9.14.4
+appVersion: 2.4.5
+>>>>>>> fix(version)
 keywords:
   - traefik
   - ingress

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,12 +3,17 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 <<<<<<< HEAD
+<<<<<<< HEAD
 version: 9.17.1
 appVersion: 2.4.7
 =======
 version: 9.14.4
 appVersion: 2.4.5
 >>>>>>> fix(version)
+=======
+version: 9.15.6
+appVersion: 2.4.6
+>>>>>>> fix(version): 9.15.6
 keywords:
   - traefik
   - ingress

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,21 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-<<<<<<< HEAD
-<<<<<<< HEAD
 version: 9.17.1
 appVersion: 2.4.7
-=======
-version: 9.14.4
-appVersion: 2.4.5
->>>>>>> fix(version)
-=======
-version: 9.15.6
-appVersion: 2.4.6
->>>>>>> fix(version): 9.15.6
-keywords:
-  - traefik
-  - ingress
 home: https://traefik.io/
 sources:
   - https://github.com/traefik/traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.16.2
+version: 9.17.1
 appVersion: 2.4.7
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -38,7 +38,7 @@
         readinessProbe:
           httpGet:
             path: /ping
-            port: {{ .Values.ports.traefik.port }}
+            port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -47,7 +47,7 @@
         livenessProbe:
           httpGet:
             path: /ping
-            port: {{ .Values.ports.traefik.port }}
+            port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -126,3 +126,26 @@ tests:
         - equal:
             path: spec.template.spec.containers[0].volumeMounts[3].mountPath
             value: /var/log/traefik
+  - it: should set custom probe port
+    set:
+      additionalArguments:
+        - --ping
+        - --ping.entrypoint=web
+      ports:
+        traefik:
+          port: 9000
+          healthchecksPort: 9001
+          exposedPort: 9000
+      asserts:
+        - equal:
+            path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+            content: 9001
+        - equal:
+            path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+            content: 9001
+        - contains:
+            path: spec.template.spec.containers[0].args
+            content: "--ping"
+        - contains:
+            path: spec.template.spec.containers[0].args
+            content: "--ping.entrypoint=web"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -120,6 +120,8 @@ providers:
 # After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg:
 # additionalArguments:
 # - "--providers.file.filename=/config/dynamic.toml"
+# - "--ping"
+# - "--ping.entrypoint=web"
 volumes: []
 # - name: public-cert
 #   mountPath: "/certs"
@@ -224,6 +226,10 @@ ports:
     # to set this value if you need traefik to listen on specific interface
     # only.
     # hostIP: 192.168.100.10
+
+    # Override the liveness/readiness port. This is useful to integrate traefik
+    # with an external Load Balancer that performs healthchecks.
+    # healthchecksPort: 9000
 
     # Defines whether the port is exposed if service.type is LoadBalancer or
     # NodePort.


### PR DESCRIPTION
Allows to change liveness & readiness probes port, facilitating integration with GKE.

Fixes #339