### PR TITLE
Customizable liveness/readiness probes

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.2
+version: 9.15.0
 appVersion: 2.4.2
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -36,23 +36,13 @@
           {{- toYaml . | nindent 10 }}
           {{- end }}
         readinessProbe:
-          httpGet:
-            path: /ping
-            port: {{ .Values.ports.traefik.port }}
-          failureThreshold: 1
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- with .Values.readinessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         livenessProbe:
-          httpGet:
-            path: /ping
-            port: {{ .Values.ports.traefik.port }}
-          failureThreshold: 3
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- with .Values.livenessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -58,3 +58,29 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.traefik/powpow
           value: podAnnotations
+  - it: should have a default readiness probe
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: 9000
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+  - it: should have a default liveness probe
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: 9000
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -71,6 +71,29 @@ tests:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
+  - it: should have a readiness probe with specified values
+    set:
+      readinessProbe:
+        httpGet:
+          path: /pingpong
+          port: 9001
+        failureThreshold: 12
+        initialDelaySeconds: 34
+        periodSeconds: 56
+        successThreshold: 78
+        timeoutSeconds: 90
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /pingpong
+              port: 9001
+            failureThreshold: 12
+            initialDelaySeconds: 34
+            periodSeconds: 56
+            successThreshold: 78
+            timeoutSeconds: 90
   - it: should have a default liveness probe
     asserts:
       - equal:
@@ -84,3 +107,26 @@ tests:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
+  - it: should have a liveness probe with specified values
+    set:
+      livenessProbe:
+        httpGet:
+          path: /pingpong
+          port: 9001
+        failureThreshold: 12
+        initialDelaySeconds: 34
+        periodSeconds: 56
+        successThreshold: 78
+        timeoutSeconds: 90
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /pingpong
+              port: 9001
+            failureThreshold: 12
+            initialDelaySeconds: 34
+            periodSeconds: 56
+            successThreshold: 78
+            timeoutSeconds: 90

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -401,3 +401,22 @@ securityContext:
 
 podSecurityContext:
   fsGroup: 65532
+
+readinessProbe:
+  httpGet:
+    path: /ping
+    port: 9000
+  failureThreshold: 1
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+livenessProbe:
+  httpGet:
+    path: /ping
+    port: 9000
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2


### PR DESCRIPTION
This addresses #339 but instead of customizing which of the named ports is used for the probes, the entire probes are exposed. While this is not as elegant, it looks to me like this is the standard way of doing this - albeit my experience here is surely limited.