### PR TITLE
allow `spec.strategy` to be `Recreate` in deployment

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.2
+version: 9.14.3
 appVersion: 2.4.2
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.3
+version: 9.14.4
 appVersion: 2.4.5
 keywords:
   - traefik

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -32,10 +32,12 @@ spec:
       app.kubernetes.io/name: {{ template "traefik.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   strategy:
-    type: RollingUpdate
+    type: {{ default "RollingUpdate" .Values.deployment.strategy }}
+    {{- if eq (default "RollingUpdate" .Values.deployment.strategy) "RollingUpdate" }}
     rollingUpdate:
       {{- with .Values.rollingUpdate }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- end }}
   template: {{ template "traefik.podTemplate" . }}
 {{- end -}}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -58,3 +58,11 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.traefik/powpow
           value: podAnnotations
+  - it: should have strategy with specified values
+    set:
+      deployment:
+        strategy: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -14,6 +14,8 @@ deployment:
   kind: Deployment
   # Number of pods of the deployment (only applies when kind == Deployment)
   replicas: 1
+  # Can be Recreate (when using PVC) or RollingUpdate (only applies when kind == Deployment)
+  strategy: RollingUpdate
   # Additional deployment annotations (e.g. for jaeger-operator sidecar injection)
   annotations: {}
   # Additional pod annotations (e.g. for mesh injection or prometheus scraping)


### PR DESCRIPTION
Allows to configure a deployment strategy from chart values.
Using LetsEncrypt integration with ReadWriteOnce PersistentVolumeClaims requires the deployment strategy to be Recreate, which is not doable with the current hard-coded RollingUpdate.


fixes #355