### PR TITLE
feat(labelSelector): option matching Ingresses based on labelSelectors

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.2
+version: 9.14.3
 appVersion: 2.4.2
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.3
+version: 9.14.4
 appVersion: 2.4.5
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.15.5
+version: 9.16.0
 appVersion: 2.4.6
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -113,6 +113,9 @@
           {{- if and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled }}
           - "--providers.kubernetesingress.ingressendpoint.publishedservice={{ template "providers.kubernetesIngress.publishedServicePath" . }}"
           {{- end }}
+          {{- if .Values.providers.kubernetesIngress.labelSelector }}
+          - "--providers.kubernetesingress.labelSelector={{ .Values.providers.kubernetesIngress.labelSelector }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.experimental.kubernetesGateway.enabled }}
           - "--providers.kubernetesgateway"

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -69,6 +69,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.ingressendpoint.publishedservice=foo/bar"
+  - it: should match ingresses based on input label
+    set:
+        providers:
+          kubernetesIngress:
+            labelSelector: environment=devel
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.labelSelector=environment=devel"
   - it: should have a plugin storage if the experimental feature is enabled
     set:
       experimental:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -103,6 +103,7 @@ providers:
       # - "default"
   kubernetesIngress:
     enabled: true
+    # labelSelector: environment=production,method=traefik
     namespaces: []
       # - "default"
     # IP used for Kubernetes Ingress endpoints


### PR DESCRIPTION
Fixes #264

traefik can pick Ingress objects based on a labelSelector.
This can be useful in larger clusters, when ingress are dedicated to an environment (prod, stage, ...), when SDN is broken into security zones with dedicated ingresses, ...