### PR TITLE
Disallow only ACME with TLS or HTTP challenge

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.3
+version: 9.15.0
 appVersion: 2.4.5
 keywords:
   - traefik

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.deployment.enabled (eq .Values.deployment.kind "DaemonSet") -}}
   {{- with .Values.additionalArguments -}}
     {{- range . -}}
-      {{- if contains ".acme." . -}}
-        {{- fail (printf "ACME functionality is not supported when running Traefik as a DaemonSet") -}}
+      {{- if (or (contains ".acme.tlschallenge" .) (contains ".acme.httpchallenge" .) ) -}}
+        {{- fail (printf "ACME with TLS or HTTP challenge is not supported when running Traefik as a DaemonSet") -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -2,8 +2,8 @@
   {{- if gt (int .Values.deployment.replicas) 1 -}}
     {{- with .Values.additionalArguments -}}
       {{- range . -}}
-        {{- if contains ".acme." . -}}
-          {{- fail (printf "You can not enabled acme if you set more than one traefik replica") -}}
+        {{- if (or (contains ".acme.tlschallenge" .) (contains ".acme.httpchallenge" .) ) -}}
+          {{- fail (printf "You can not enable ACME using TLS or HTTP challenge if you set more than one traefik replica") -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
We know exactly which challenges require special care. So why not
restrict only those, and let people that use the other (read: DNS)
challenge enjoy the Helm chart?

Fixes: https://github.com/traefik/traefik-helm-chart/issues/335