### PR TITLE
Configurable PVC name

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.4
+version: 9.15.1
 appVersion: 2.4.5
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -72,7 +72,7 @@
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
-          - name: data
+          - name: {{ .Values.persistence.name }}
             mountPath: {{ .Values.persistence.path }}
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
@@ -206,7 +206,7 @@
         {{- toYaml .Values.deployment.additionalContainers | nindent 6 }}
       {{- end }}
       volumes:
-        - name: data
+        - name: {{ .Values.persistence.name }}
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ default (include "traefik.fullname" .) .Values.persistence.existingClaim }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -51,6 +51,17 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: existing-pvc
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: data
+  - it: should have pvc with specified name
+    set:
+      persistence:
+        name: my-data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: my-data
   - it: should have initContainer with specified value
     set:
       deployment:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -327,6 +327,7 @@ autoscaling:
 # It will persist TLS certificates.
 persistence:
   enabled: false
+  name: data
 #  existingClaim: ""
   accessMode: ReadWriteOnce
   size: 128Mi


### PR DESCRIPTION
Currently the name of the [PVC for persistence][ref-pvc-pers] is “hardcoded“ to `data`. This could conflict when users add additional volumes and/or mounts that use the same name, resulting in “duplicate volume“ errors that are not as easy to debug and understand in the first place.
I ran into such a problem after trying to add an additional volume also named `data` and invested some hours trying to find the error within my own Kustomize + Flux setup while the actual root cause was not that obvious.

To prevent such situations, this PR adds a new `persistence.name` Helm values field, keeping `data` as default name, to allow users to change it when required.
I've added a new test and extended an existing one to also ensure that the default name still works fine. 

[ref-pvc-pers]: https://github.com/traefik/traefik-helm-chart/blob/6b4c3642/traefik/values.yaml#L328