### PR TITLE
Adds support for namespace overrides when Traefik is extended as a sub-chart

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.14.3
+version: 9.14.4
 appVersion: 2.4.5
 keywords:
   - traefik

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -33,6 +33,19 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Construct the namespace for all namespaced resources
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Preserve the default behavior of the Release namespace if no override is provided
+*/}}
+{{- define "traefik.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 The name of the service account to use
 */}}
 {{- define "traefik.serviceAccountName" -}}

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -12,6 +12,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -3,6 +3,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
+  namespace: {{ template "traefik.namespace" . }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     {{- with .Values.ingressRoute.dashboard.annotations }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -14,6 +14,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/hpa.yaml
+++ b/traefik/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/poddisruptionbudget.yaml
+++ b/traefik/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/pvc.yaml
+++ b/traefik/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   annotations:
   {{- with .Values.persistence.annotations  }}
   {{ toYaml . | indent 4 }}

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -18,6 +18,7 @@ items:
     kind: Service
     metadata:
       name: {{ template "traefik.fullname" . }}
+      namespace: {{ template "traefik.namespace" . }}
       labels:
         app.kubernetes.io/name: {{ template "traefik.name" . }}
         helm.sh/chart: {{ template "traefik.chart" . }}
@@ -68,6 +69,7 @@ items:
     kind: Service
     metadata:
       name: {{ template "traefik.fullname" . }}-udp
+      namespace: {{ template "traefik.namespace" . }}
       labels:
         app.kubernetes.io/name: {{ template "traefik.name" . }}
         helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/tlsoption.yaml
+++ b/traefik/templates/tlsoption.yaml
@@ -3,6 +3,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: TLSOption
 metadata:
   name: {{ $name }}
+  namespace: {{ template "traefik.namespace" $ }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" $ }}
     helm.sh/chart: {{ template "traefik.chart" $ }}

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -28,3 +28,20 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.traefik/powpow
           value: podAnnotations
+  - it: should use helm managed namespace as default behavior
+    set:
+      deployment:
+        kind: DaemonSet
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+  - it: should accept overridden namespace
+    set:
+      namespaceOverride: "traefik-ns-override"
+      deployment:
+        kind: DaemonSet
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "traefik-ns-override"

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -58,3 +58,15 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.traefik/powpow
           value: podAnnotations
+  - it: should use helm managed namespace as default behavior
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+  - it: should accept overridden namespace
+    set:
+      namespaceOverride: "traefik-ns-override"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "traefik-ns-override"

--- a/traefik/tests/poddisruptionbudget-config_test.yaml
+++ b/traefik/tests/poddisruptionbudget-config_test.yaml
@@ -28,3 +28,20 @@ tests:
           value: 1
       - isEmpty:
           path: spec.minAvailable
+  - it: should use helm managed namespace as default behavior
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+  - it: should accept overridden namespace
+    set:
+      namespaceOverride: "traefik-ns-override"
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "traefik-ns-override"

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -79,3 +79,22 @@ tests:
           path: subjects[0].name
           value: foobar
         template: rbac/clusterrolebinding.yaml
+  - it: should use helm managed namespace as default behavior
+    set:
+      rbac:
+        namespaced: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+        template: rbac/role.yaml 
+  - it: should accept overridden namespace
+    set:
+      namespaceOverride: "traefik-ns-override"
+      rbac:
+        namespaced: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "traefik-ns-override"
+        template: rbac/role.yaml 

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -90,3 +90,34 @@ tests:
       - equal:
           path: items[1].spec.ports[0].protocol
           value: UDP
+  - it: should use helm managed namespace as default behavior
+    set:
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: items[1].metadata.namespace
+          value: NAMESPACE
+  - it: should accept overridden namespace
+    set:
+      namespaceOverride: "traefik-ns-override"
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].metadata.namespace
+          value: "traefik-ns-override"
+      - equal:
+          path: items[1].metadata.namespace
+          value: "traefik-ns-override"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -401,3 +401,5 @@ securityContext:
 
 podSecurityContext:
   fsGroup: 65532
+
+# namespaceOverride: traefik


### PR DESCRIPTION
### What problem does this solve?

This pull request improves the experience for cluster and namespace admins who may be extending this Helm chart via use as a sub-chart, which is an encouraged approach in the Traefik philosophy. 

An example use case is that as a cluster admin, I want to create an umbrella chart which bootstraps a bare cluster with all the infrastructure necessary to support application deployments; e.g. ingress (Traefik), service mesh, admission control, monitoring, configs for all of it, and some of our own tooling. 

The desired behavior for this use case is that all manifests provided directly by the umbrella chart (all my tools and configs) are installed to the Helm release namespace, and each dependency of that chart is installed to a separate dedicated namespace. 

The current situation is that the Traefik Helm chart assumes that the Helm release namespace is where it should deploy manifests and provides no way to opt-out of that behavior. This limits the ability to compose Traefik with other dependencies as in the use case above. 

### Solution Approach

This pull request provides an optional feature called `namespaceOverride`. As a non-critical optional feature, it has been added to `values.yaml` disabled by comment. 

If a value is not provided for `namespaceOverride`, the default behavior of using the Helm release namespace is preserved. 

Use cases as described above must be responsible for ensuring the target namespace exists and overriding the value. 

### Open Question

The experimental Gateway manifest ignores the existing behavior of the other namespaced resources in this chart and instead has a hard coded `default` as the namespace. Is this desired behavior? 