### PR TITLE
Add helm resource-policy annotation on PVC

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.17.3
+version: 9.17.4
 appVersion: 2.4.7
 keywords:
   - traefik

--- a/traefik/templates/pvc.yaml
+++ b/traefik/templates/pvc.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- with .Values.persistence.annotations  }}
   {{ toYaml . | indent 4 }}
   {{- end }}
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}


### PR DESCRIPTION
Following up on #385 

We could argue it is expected of Helm to purge objects based on a change of values, we could ensure that a PersistentVolumeClaim would never be removed automatically.