### PR TITLE
Do not disable Traefik Pilot in the dashboard by default

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.18.0
+version: 9.18.1
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -191,9 +191,9 @@
           {{- end }}
           {{- if .Values.pilot.enabled }}
           - "--pilot.token={{ .Values.pilot.token }}"
+          {{- if hasKey .Values.pilot "dashboard" }}
+          - "--pilot.dashboard={{ .Values.pilot.dashboard }}"
           {{- end }}
-          {{- if not .Values.pilot.dashboard}}
-          - "--pilot.dashboard=false"
           {{- end }}
           {{- with .Values.additionalArguments }}
           {{- range . }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -219,10 +219,20 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             "--providers.kubernetesgateway"
+  - it: should have the pilot dashboard enabled
+    set:
+      pilot:
+        enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content:
+            "--pilot.dashboard=false"
   - it: should have the pilot dashboard disabled
     set:
       pilot:
-          dashboard: false
+        enabled: true
+        dashboard: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args


### PR DESCRIPTION
This PR fixes the behaviour of the option introduced in #398.
By default, Traefik Pilot must be enabled in the dashboard as it's implemented in Traefik.