### PR TITLE
Fix IngressClass api version

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.18.2
+version: 9.18.3
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.18.3
+version: 9.19.0
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,8 +1,10 @@
 {{- if and .Values.ingressClass.enabled (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass" }}
 apiVersion: networking.k8s.io/v1beta1
+  {{- else if or (eq .Values.ingressClass.fallbackApiVersion "v1beta1") (eq .Values.ingressClass.fallbackApiVersion "v1") }}
+apiVersion: {{ printf "networking.k8s.io/%s" .Values.ingressClass.fallbackApiVersion }}
   {{- else }}
   {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}
   {{- end }}

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.ingressClass.enabled (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass" }}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
   {{- else }}
-    {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}
+  {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}
   {{- end }}
 kind: IngressClass
 metadata:

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -6,7 +6,7 @@ apiVersion: networking.k8s.io/v1beta1
   {{- else if or (eq .Values.ingressClass.fallbackApiVersion "v1beta1") (eq .Values.ingressClass.fallbackApiVersion "v1") }}
 apiVersion: {{ printf "networking.k8s.io/%s" .Values.ingressClass.fallbackApiVersion }}
   {{- else }}
-  {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}
+    {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}
   {{- end }}
 kind: IngressClass
 metadata:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -63,6 +63,8 @@ ingressClass:
   # true is not unit-testable yet, pending https://github.com/rancher/helm-unittest/pull/12
   enabled: false
   isDefaultClass: false
+  # Use to force a networking.k8s.io API Version for certain CI/CD applications. E.g. "v1beta1"
+  fallbackApiVersion:
 
 # Activate Pilot integration
 pilot:


### PR DESCRIPTION
Many automation systems do not template out every sub-api-capability. being v1beta1/v1 should be sufficient to validate usability. To not break functionality and only enhance ability, this PR adds the option of a fallback apiVersion to allow user defined **api version only** of networking.k8s.io

argo-cd templated example (formatted and annotated for readability: 
```
rpc error: code = Unknown desc = Manifest generation error (cached): 
helm template . 
    --name-template traefik-home 
    --namespace ingress 
    --values values.yaml 
    --values values-home.yaml 
    --values /tmp/values-811050304.yaml 
    --api-versions v1 
    --api-versions apiregistration.k8s.io/v1 
    --api-versions apiregistration.k8s.io/v1beta1 
    --api-versions apps/v1 
    --api-versions events.k8s.io/v1 
    --api-versions events.k8s.io/v1beta1 
    --api-versions authentication.k8s.io/v1 
    --api-versions authentication.k8s.io/v1beta1 
    --api-versions authorization.k8s.io/v1 
    --api-versions authorization.k8s.io/v1beta1 
    --api-versions autoscaling/v1 
    --api-versions autoscaling/v2beta1 
    --api-versions autoscaling/v2beta2 
    --api-versions batch/v1 
    --api-versions batch/v1beta1 
    --api-versions certificates.k8s.io/v1 
    --api-versions certificates.k8s.io/v1beta1 
    --api-versions networking.k8s.io/v1         # < has ingressClass
    --api-versions networking.k8s.io/v1beta1    # < has ingressClass
    --api-versions extensions/v1beta1 
    --api-versions policy/v1beta1 
    --api-versions rbac.authorization.k8s.io/v1 
    --api-versions rbac.authorization.k8s.io/v1beta1 
    --api-versions storage.k8s.io/v1 
    --api-versions storage.k8s.io/v1beta1 
    --api-versions admissionregistration.k8s.io/v1 
    --api-versions admissionregistration.k8s.io/v1beta1 
    --api-versions apiextensions.k8s.io/v1 
    --api-versions apiextensions.k8s.io/v1beta1 
    --api-versions scheduling.k8s.io/v1 
    --api-versions scheduling.k8s.io/v1beta1 
    --api-versions coordination.k8s.io/v1 
    --api-versions coordination.k8s.io/v1beta1 
    --api-versions node.k8s.io/v1 
    --api-versions node.k8s.io/v1beta1 
    --api-versions discovery.k8s.io/v1beta1 
    --api-versions flowcontrol.apiserver.k8s.io/v1beta1 
    --api-versions mutators.kubedb.com/v1alpha1 
    --api-versions validators.kubedb.com/v1alpha1 
    --api-versions acme.cert-manager.io/v1 
    --api-versions acme.cert-manager.io/v1beta1 
    --api-versions acme.cert-manager.io/v1alpha3 
    --api-versions acme.cert-manager.io/v1alpha2 
    --api-versions ceph.rook.io/v1 
    --api-versions cert-manager.io/v1 
    --api-versions cert-manager.io/v1beta1 
    --api-versions cert-manager.io/v1alpha3 
    --api-versions cert-manager.io/v1alpha2 
    --api-versions crd.projectcalico.org/v1 
    --api-versions kubernetes-client.io/v1 
    --api-versions monitoring.coreos.com/v1 
    --api-versions monitoring.coreos.com/v1alpha1 
    --api-versions nvidia.com/v1 
    --api-versions appcatalog.appscode.com/v1alpha1 
    --api-versions argoproj.io/v1alpha1 
    --api-versions autoscaling.kubedb.com/v1alpha1 
    --api-versions catalog.kubedb.com/v1alpha1 
    --api-versions externaldns.k8s.io/v1alpha1 
    --api-versions objectbucket.io/v1alpha1 
    --api-versions ops.kubedb.com/v1alpha1 
    --api-versions traefik.containo.us/v1alpha1 
    --api-versions kubedb.com/v1alpha2 
    --api-versions rook.io/v1alpha2 
    --api-versions metrics.k8s.io/v1beta1 
    --include-crds`
failed exit status 1: Error: 
    template: traefik/charts/traefik/templates/ingressclass.yaml:7:8:
        executing "traefik/charts/traefik/templates/ingressclass.yaml" at
            <fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass">:
                error calling fail: ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass
                    Use --debug flag to render out invalid YAML
```