### PR TITLE
Add shareProcessNamespace option to podtemplate

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.11.1
+version: 10.12.0
 appVersion: 2.6.0
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -34,6 +34,9 @@
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.deployment.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       containers:
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -149,6 +149,14 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[1].name
           value: myOtherRegistryKeySecretName
+  - it: should have shareProcessNamespace enabled
+    set:
+      deployment:
+        shareProcessNamespace: true
+    asserts:
+      - equal:
+          path: spec.template.spec.shareProcessNamespace
+          value: true
   - it: should have customized labels when specified via values
     set:
       deployment:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -55,6 +55,8 @@ deployment:
   # Additional imagePullSecrets
   imagePullSecrets: []
     # - name: myRegistryKeySecretName
+  # Use process namespace sharing
+  shareProcessNamespace: false
 
 # Pod disruption budget
 podDisruptionBudget:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -50,13 +50,13 @@ deployment:
     #   volumeMounts:
     #     - name: data
     #       mountPath: /data
+  # Use process namespace sharing
+  shareProcessNamespace: false
   # Custom pod DNS policy. Apply if `hostNetwork: true`
   # dnsPolicy: ClusterFirstWithHostNet
   # Additional imagePullSecrets
   imagePullSecrets: []
     # - name: myRegistryKeySecretName
-  # Use process namespace sharing
-  shareProcessNamespace: false
 
 # Pod disruption budget
 podDisruptionBudget:


### PR DESCRIPTION
This change relates to https://github.com/traefik/traefik/issues/3489. Currently if you're using Kubernetes with a sidecar to ship logs there is no way to rotate logs and signal Traefik to [close/re-open](https://doc.traefik.io/traefik/observability/logs/#log-rotation) its log files.

The addition of the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) pod spec flag with a logrotate sidecar including the `SYS_PTRACE` securityContext.capabilities  allows one to send the `USR1` signal to the traefik process and trigger it to close/re-open its logs

There are a number of ways the same result could be achieved, so I would be open to alternatives if one is suggested. 