### PR TITLE
Add name-metadata for service "List" object

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.19.1
+version: 9.19.2
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -12,6 +12,8 @@
 
 apiVersion: v1
 kind: List
+metadata:
+  name: {{ template "traefik.fullname" . }}
 items:
 {{- if  $tcpPorts }}
   - apiVersion: v1


### PR DESCRIPTION
This is necessary for traefik to pass validation from `https://www.kubeval.com/` (https://www.kubeval.com/), which currently complains that this object has no name.

Steps:
1. helm template the traefik chart, saving to a file
2. run `kubeval` with `--skip-kinds "CustomResourceDefinition,IngressRoute,List,Middleware,Config"`, `----kubernetes-version 1.19`, and `--schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/`, and providing your helm-templated output file as an input.
3. Without this change, you should see the following error:

`ERR  - ly-traefik-aws/charts/traefik/templates/service.yaml: Missing 'metadata' key`