### PR TITLE
✨ add optional ServiceMonitor & PrometheusRule CRDs

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,73 @@
 # Change Log
 
+## 16.1.0 
+
+**Release date:** 2022-10-19
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* ✨ add optional ServiceMonitor & PrometheusRule CRDs
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 7e335b5..9b5afc4 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -237,8 +237,46 @@ metrics:
+   prometheus:
+     entryPoint: metrics
+   #  addRoutersLabels: true
+-  # statsd:
+-  #   address: localhost:8125
++  #  statsd:
++  #    address: localhost:8125
++##
++##  enable optional CRDs for Prometheus Operator
++##
++  #  serviceMonitor:
++  #    additionalLabels:
++  #      foo: bar
++  #    namespace: "another-namespace"
++  #    namespaceSelector: {}
++  #    metricRelabelings: []
++  #      - sourceLabels: [__name__]
++  #        separator: ;
++  #        regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
++  #        replacement: $1
++  #        action: drop
++  #    relabelings: []
++  #      - sourceLabels: [__meta_kubernetes_pod_node_name]
++  #        separator: ;
++  #        regex: ^(.*)$
++  #        targetLabel: nodename
++  #        replacement: $1
++  #        action: replace
++  #    jobLabel: traefik
++  #    scrapeInterval: 30s
++  #    scrapeTimeout: 5s
++  #    honorLabels: true
++  #  prometheusRule:
++  #    additionalLabels: {}
++  #    namespace: "another-namespace"
++  #    rules:
++  #      - alert: TraefikDown
++  #        expr: up{job="traefik"} == 0
++  #        for: 5m
++  #        labels:
++  #          context: traefik
++  #          severity: warning
++  #        annotations:
++  #          summary: "Traefik Down"
++  #          description: "{{ $labels.pod }} on {{ $labels.nodename }} is down"
+ 
+ tracing: {}
+   # instana:
+```
+
 ## 16.0.0 
 
 **Release date:** 2022-10-19
@@ -8,7 +76,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* :fire: Remove `Pilot` and `fallbackApiVersion` 
+* :fire: Remove `Pilot` and `fallbackApiVersion` (#665) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 16.0.0
+version: 16.1.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/prometheusrules.yaml
+++ b/traefik/templates/prometheusrules.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.metrics.prometheus.prometheusRule.enabled }}
+{{- if .Values.metrics.prometheus }}
+{{- if .Values.metrics.prometheus.prometheusRule }}
+{{- if (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) }}
+  {{- fail "ERROR: You have to deploy monitoring.coreos.com/v1 first" }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -7,18 +11,18 @@ metadata:
   namespace: {{ .Values.metrics.prometheus.prometheusRule.namespace }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ template "traefik.name" . }}
-    helm.sh/chart: {{ template "traefik.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "traefik.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheus.prometheusRule.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .Values.metrics.prometheus.prometheusRule.rules }}
+  {{- if .Values.metrics.prometheus.prometheusRule.rules }}
   groups:
-  - name: {{ template "traefik.name" . }}
+  - name: {{ template "traefik.name" $ }}
     rules:
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.metrics.prometheus.prometheusRule.rules }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/traefik/templates/prometheusrules.yaml
+++ b/traefik/templates/prometheusrules.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.metrics.prometheus.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  {{- if .Values.metrics.prometheus.prometheusRule.namespace }}
+  namespace: {{ .Values.metrics.prometheus.prometheusRule.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "traefik.name" . }}
+    helm.sh/chart: {{ template "traefik.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.metrics.prometheus.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.metrics.prometheus.prometheusRule.rules }}
+  groups:
+  - name: {{ template "traefik.name" . }}
+    rules:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.metrics.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  {{- with .Values.metrics.prometheus.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "traefik.name" . }}
+    helm.sh/chart: {{ template "traefik.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.metrics.prometheus.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ .Values.metrics.prometheus.serviceMonitor.jobLabel | default .Release.Name }}
+  endpoints:
+    - port: metrics
+      path: /{{ .Values.metrics.prometheus.entryPoint }}
+      {{- with .Values.metrics.prometheus.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.prometheus.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- if .Values.metrics.prometheus.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ tpl (toYaml .Values.metrics.prometheus.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.metrics.prometheus.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.metrics.prometheus.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
+  {{- if .Values.metrics.prometheus.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{ toYaml .Values.metrics.prometheus.serviceMonitor.namespaceSelector | indent 4 -}}
+  {{ else }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "traefik.name" . }}
+{{- end }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.metrics.prometheus.serviceMonitor.enabled }}
+{{- if .Values.metrics.prometheus }}
+{{- if .Values.metrics.prometheus.serviceMonitor }}
+{{- if (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) }}
+  {{- fail "ERROR: You have to deploy monitoring.coreos.com/v1 first" }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -7,10 +11,7 @@ metadata:
   namespace: {{ . }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ template "traefik.name" . }}
-    helm.sh/chart: {{ template "traefik.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "traefik.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheus.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -44,4 +45,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "traefik.name" . }}
+{{- end }}
 {{- end }}

--- a/traefik/tests/prometheusrules-config_test.yaml
+++ b/traefik/tests/prometheusrules-config_test.yaml
@@ -1,0 +1,43 @@
+suite: PrometheusRules configuration
+templates:
+  - prometheusrules.yaml
+tests:
+  - it: should not provide PrometheusRules by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should fail to provide PrometheusRules without the API
+    values:
+      - ./values/prometheusrules.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "You have to deploy monitoring.coreos.com/v1 first"
+  - it: should successfully provide PrometheusRules with the API and example values
+    values:
+      - ./values/prometheusrules.yaml
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: another-namespace
+      - equal:
+          path: metadata.labels.foo
+          value: bar
+      - contains:
+          path: spec.groups
+          content:
+            name: traefik
+            rules:
+              - alert: TraefikDown
+                annotations:      
+                  description: '{{ $labels.pod }} on {{ $labels.nodename }} is down'
+                  summary: Traefik Down
+                expr: up{job="traefik"} == 0
+                for: 5m
+                labels:
+                  context: traefik
+                  severity: warning

--- a/traefik/tests/servicemonitor-config_test.yaml
+++ b/traefik/tests/servicemonitor-config_test.yaml
@@ -1,0 +1,53 @@
+suite: ServiceMonitor configuration
+templates:
+  - servicemonitor.yaml
+tests:
+  - it: should not provide ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should fail to provide ServiceMonitor without the API
+    values:
+      - ./values/servicemonitor.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "You have to deploy monitoring.coreos.com/v1 first"
+  - it: should successfully provide ServiceMonitor with example values
+    values:
+      - ./values/servicemonitor.yaml
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.jobLabel
+          value: another-label
+      - contains:
+          path: spec.endpoints
+          content:
+            port: metrics
+            path: /metrics
+            scrapeTimeout: 5s
+            metricRelabelings:
+            - action: drop
+              regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
+              replacement: $1
+              separator: ;
+              sourceLabels:
+              - __name__
+            relabelings:
+            - action: replace
+              regex: ^(.*)$
+              replacement: $1
+              separator: ;
+              sourceLabels:
+              - __meta_kubernetes_pod_node_name
+              targetLabel: nodename
+      - equal:
+          path: spec.namespaceSelector.any
+          value: true
+      - equal:
+          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          value: traefik

--- a/traefik/tests/values/prometheusrules.yaml
+++ b/traefik/tests/values/prometheusrules.yaml
@@ -1,0 +1,17 @@
+metrics:
+  prometheus:
+    prometheusRule:
+      enabled: true
+      additionalLabels:
+        foo: bar
+      namespace: another-namespace
+      rules:
+        - alert: TraefikDown
+          expr: up{job="traefik"} == 0
+          for: 5m
+          labels:
+            context: traefik
+            severity: warning
+          annotations:
+            summary: "Traefik Down"
+            description: "{{ $labels.pod }} on {{ $labels.nodename }} is down"

--- a/traefik/tests/values/servicemonitor.yaml
+++ b/traefik/tests/values/servicemonitor.yaml
@@ -1,0 +1,27 @@
+metrics:
+  prometheus:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: traefik-release
+      namespace: another-namespace
+      namespaceSelector:
+        any: true
+      metricRelabelings:
+       - sourceLabels: [__name__]
+         separator: ;
+         regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
+         replacement: $1
+         action: drop
+      relabelings:
+       - sourceLabels: [__meta_kubernetes_pod_node_name]
+         separator: ;
+         regex: ^(.*)$
+         targetLabel: nodename
+         replacement: $1
+         action: replace
+      jobLabel: another-label
+      scrapeInterval: 30s
+      scrapeTimeout: 5s
+      honorLabels: true
+

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -229,7 +229,6 @@ logs:
           # Content-Type: keep
 
 metrics:
-  enabled: true
   # datadog:
   #   address: 127.0.0.1:8125
   # influxdb:
@@ -238,51 +237,46 @@ metrics:
   prometheus:
     entryPoint: metrics
   #  addRoutersLabels: true
-    serviceMonitor:
-      enabled: false
-      additionalLabels:
-        release: kube-prometheus-stack
-      namespace: ""
-      namespaceSelector: {}
-      ## metric relabel configs to apply to samples before ingestion.
-      ##
-      metricRelabelings: []
-      # - sourceLabels: [__name__]
-      #   separator: ;
-      #   regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
-      #   replacement: $1
-      #   action: drop
-      ## relabel configs to apply to samples after ingestion.
-      ##
-      relabelings: []
-      # - sourceLabels: [__meta_kubernetes_pod_node_name]
-      #   separator: ;
-      #   regex: ^(.*)$
-      #   targetLabel: nodename
-      #   replacement: $1
-      #   action: replace
-      ## Additional serviceMonitor config
-      ##
-      # jobLabel: traefik
-      # scrapeInterval: 30s
-      # scrapeTimeout: 5s
-      # honorLabels: true
-    prometheusRule:
-      enabled: false
-      additionalLabels: {}
-      namespace: ""
-      rules: []
-      # - alert: TraefikDown
-      #   expr: up{job="traefik"} == 0
-      #   for: 5m
-      #   labels:
-      #     context: traefik
-      #     severity: warning
-      #   annotations:
-      #     summary: "Traefik Down"
-      #     description: "{{ $labels.pod }} on {{ $labels.nodename }} is down"
-  # statsd:
-  #   address: localhost:8125
+  #  statsd:
+  #    address: localhost:8125
+##
+##  enable optional CRDs for Prometheus Operator
+##
+  #  serviceMonitor:
+  #    additionalLabels:
+  #      foo: bar
+  #    namespace: "another-namespace"
+  #    namespaceSelector: {}
+  #    metricRelabelings: []
+  #      - sourceLabels: [__name__]
+  #        separator: ;
+  #        regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
+  #        replacement: $1
+  #        action: drop
+  #    relabelings: []
+  #      - sourceLabels: [__meta_kubernetes_pod_node_name]
+  #        separator: ;
+  #        regex: ^(.*)$
+  #        targetLabel: nodename
+  #        replacement: $1
+  #        action: replace
+  #    jobLabel: traefik
+  #    scrapeInterval: 30s
+  #    scrapeTimeout: 5s
+  #    honorLabels: true
+  #  prometheusRule:
+  #    additionalLabels: {}
+  #    namespace: "another-namespace"
+  #    rules:
+  #      - alert: TraefikDown
+  #        expr: up{job="traefik"} == 0
+  #        for: 5m
+  #        labels:
+  #          context: traefik
+  #          severity: warning
+  #        annotations:
+  #          summary: "Traefik Down"
+  #          description: "{{ $labels.pod }} on {{ $labels.nodename }} is down"
 
 tracing: {}
   # instana:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -229,6 +229,7 @@ logs:
           # Content-Type: keep
 
 metrics:
+  enabled: true
   # datadog:
   #   address: 127.0.0.1:8125
   # influxdb:
@@ -237,6 +238,49 @@ metrics:
   prometheus:
     entryPoint: metrics
   #  addRoutersLabels: true
+    serviceMonitor:
+      enabled: false
+      additionalLabels:
+        release: kube-prometheus-stack
+      namespace: ""
+      namespaceSelector: {}
+      ## metric relabel configs to apply to samples before ingestion.
+      ##
+      metricRelabelings: []
+      # - sourceLabels: [__name__]
+      #   separator: ;
+      #   regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
+      #   replacement: $1
+      #   action: drop
+      ## relabel configs to apply to samples after ingestion.
+      ##
+      relabelings: []
+      # - sourceLabels: [__meta_kubernetes_pod_node_name]
+      #   separator: ;
+      #   regex: ^(.*)$
+      #   targetLabel: nodename
+      #   replacement: $1
+      #   action: replace
+      ## Additional serviceMonitor config
+      ##
+      # jobLabel: traefik
+      # scrapeInterval: 30s
+      # scrapeTimeout: 5s
+      # honorLabels: true
+    prometheusRule:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+      rules: []
+      # - alert: TraefikDown
+      #   expr: up{job="traefik"} == 0
+      #   for: 5m
+      #   labels:
+      #     context: traefik
+      #     severity: warning
+      #   annotations:
+      #     summary: "Traefik Down"
+      #     description: "{{ $labels.pod }} on {{ $labels.nodename }} is down"
   # statsd:
   #   address: localhost:8125
 


### PR DESCRIPTION
* Add serviceMonitor to select ingress objects
* Add prometheusRules section

Closes: https://github.com/traefik/traefik-helm-chart/issues/156

Signed-off-by: Diogo Guerra <diogo.filipe.tomas.guerra@cern.ch>