### PR TITLE
Added the ability to use tlsStore in helm chart to set default certificate in traefik

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.19.1
+version: 9.19.2
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/templates/tlsstore.yaml
+++ b/traefik/templates/tlsstore.yaml
@@ -1,0 +1,14 @@
+{{- range $name, $config := .Values.tlsStore }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: TLSStore
+metadata:
+  name: {{ $name }}
+  labels:
+    app.kubernetes.io/name: {{ template "traefik.name" $ }}
+    helm.sh/chart: {{ template "traefik.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  {{- toYaml $config | nindent 2 }}
+---
+{{- end -}}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -299,6 +299,7 @@ tlsOptions: {}
 # https://doc.traefik.io/traefik/https/tls/#default-certificate
 # Example:
 # tlsStore:
+#   default:
     # defaultCertificate:
     #   secretName: tls-cert
 tlsStore: {}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -295,6 +295,14 @@ ports:
 #       - CurveP384
 tlsOptions: {}
 
+# TLS Store are created as TLSStore CRDs. This is useful if you want to set a default certificate
+# https://doc.traefik.io/traefik/https/tls/#default-certificate
+# Example:
+# tlsStore:
+    # defaultCertificate:
+    #   secretName: tls-cert
+tlsStore: {}
+
 # Options for the main traefik service, where the entrypoints traffic comes
 # from.
 service:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -300,8 +300,8 @@ tlsOptions: {}
 # Example:
 # tlsStore:
 #   default:
-    # defaultCertificate:
-    #   secretName: tls-cert
+#     defaultCertificate:
+#       secretName: tls-cert
 tlsStore: {}
 
 # Options for the main traefik service, where the entrypoints traffic comes


### PR DESCRIPTION
This change allows creating an object of type tlsStore from the values.yaml, this is useful to configure default certificates in Traefik

This change it also solves the issue [https://github.com/traefik/traefik-helm-chart/issues/187](https://github.com/traefik/traefik-helm-chart/issues/187)