### PR TITLE
Add semVer validation check flag

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.19.1
+version: 9.19.2
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.ingressClass.enabled (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}
+{{- if .Values.ingressClass.enabled  -}}
+  {{- if eq .Values.image.disableSemVerValidation false -}}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
   {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass" }}

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.ingressClass.enabled  -}}
-  {{- if eq .Values.image.disableSemVerValidation false -}}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
+  # If semVerValidation is defined and not disabled, check
+  {{- if .Values.image.disableSemVerValidation -}}{{- if eq .Values.image.disableSemVerValidation false -}}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
+  # Otherwise check
+  {{- else }}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
   {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass" }}

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressClass.enabled  -}}
   # If semVerValidation is defined and not disabled, check
-  {{- if .Values.image.disableSemVerValidation -}}{{- if eq .Values.image.disableSemVerValidation false -}}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
+  {{- if .Values.image.semVerValidation -}}{{- if eq .Values.image.semVerValidation true -}}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
   # Otherwise check
   {{- else }}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
   {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingressClass.enabled  -}}
-  # If semVerValidation is defined and not disabled, check
+  # If semVerValidation is defined and true, check
   {{- if .Values.image.semVerValidation -}}{{- if eq .Values.image.semVerValidation true -}}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
-  # Otherwise check
+  # Otherwise if undefined, check
   {{- else }}{{- (semverCompare ">=2.3.0" (default .Chart.AppVersion .Values.image.tag)) -}}{{- end }}
   {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -4,7 +4,7 @@ image:
   # defaults to appVersion
   tag: ""
   pullPolicy: IfNotPresent
-  # disableSemVerValidation: false
+  # semVerValidation: true
 
 #
 # Configure the deployment

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -4,7 +4,7 @@ image:
   # defaults to appVersion
   tag: ""
   pullPolicy: IfNotPresent
-  disableSemVerValidation: false
+  # disableSemVerValidation: false
 
 #
 # Configure the deployment

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -4,6 +4,7 @@ image:
   # defaults to appVersion
   tag: ""
   pullPolicy: IfNotPresent
+  disableSemVerValidation: false
 
 #
 # Configure the deployment
@@ -64,7 +65,7 @@ ingressClass:
   enabled: false
   isDefaultClass: false
   # Use to force a networking.k8s.io API Version for certain CI/CD applications. E.g. "v1beta1"
-  fallbackApiVersion:
+  fallbackApiVersion: "v1beta1"
 
 # Activate Pilot integration
 pilot:


### PR DESCRIPTION
This PR:

- Adds an optional field to disable the semVer check required for ingressClass.
- Adds a missing default field for fallbackApiVersion
- Bumps the chart minor version

This allows IngressClass to be used with a non-semVer image tag for testing if required.