### PR TITLE
Revert CRD templating

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.20.0
+version: 9.19.2
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.19.2
+version: 9.20.1
 appVersion: 2.4.8
 keywords:
   - traefik

--- a/traefik/crds/ingressroute.yaml
+++ b/traefik/crds/ingressroute.yaml
@@ -1,29 +1,10 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutes.traefik.containo.us
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: IngressRoute
     plural: ingressroutes

--- a/traefik/crds/ingressroutetcp.yaml
+++ b/traefik/crds/ingressroutetcp.yaml
@@ -1,29 +1,10 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutetcps.traefik.containo.us
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: IngressRouteTCP
     plural: ingressroutetcps

--- a/traefik/crds/ingressrouteudp.yaml
+++ b/traefik/crds/ingressrouteudp.yaml
@@ -1,29 +1,11 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: ingressrouteudps.traefik.containo.us
+
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: IngressRouteUDP
     plural: ingressrouteudps

--- a/traefik/crds/middlewares.yaml
+++ b/traefik/crds/middlewares.yaml
@@ -1,29 +1,10 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: middlewares.traefik.containo.us
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: Middleware
     plural: middlewares

--- a/traefik/crds/serverstransports.yaml
+++ b/traefik/crds/serverstransports.yaml
@@ -1,29 +1,10 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: serverstransports.traefik.containo.us
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: ServersTransport
     plural: serverstransports

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -1,29 +1,10 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: tlsoptions.traefik.containo.us
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: TLSOption
     plural: tlsoptions

--- a/traefik/crds/tlsstores.yaml
+++ b/traefik/crds/tlsstores.yaml
@@ -1,29 +1,11 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: tlsstores.traefik.containo.us
+
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: TLSStore
     plural: tlsstores

--- a/traefik/crds/traefikservices.yaml
+++ b/traefik/crds/traefikservices.yaml
@@ -1,29 +1,10 @@
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-apiVersion: apiextensions.k8s.io/v1
-{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: traefikservices.traefik.containo.us
 spec:
   group: traefik.containo.us
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" }}
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
-{{- else }}
   version: v1alpha1
-{{- end }}
   names:
     kind: TraefikService
     plural: traefikservices


### PR DESCRIPTION
This PR reverts the templating added to the CRDs in 9.20.0.

Although Helm v2 supports templating in CRDs, Helm v3 does not.