### PR TITLE
feat(gateway): introduces param / pick Namespace installing Gateway

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.0
+version: 10.0.1
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.1
+version: 10.0.2
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata: 
   name: traefik-gateway
-  namespace: default
+  namespace: {{ default .Release.Namespace .Values.experimental.kubernetesGateway.namespace }}
 spec: 
   gatewayClassName: traefik
   listeners: 

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -14,6 +14,9 @@ tests:
       - equal:
           path: spec.listeners[0].port
           value: 8000
+      - equal:
+          path: metadata.namespace
+          value: "NAMESPACE"
   - it: should have one gateway with the correct class and an http port as well as an https port
     set:
       experimental:
@@ -42,3 +45,13 @@ tests:
       - equal:
           path: spec.listeners[1].tls.certificateRef.kind
           value: "my-kind"
+  - it: should install gateway in custom namespace
+    set:
+      experimental:
+        kubernetesGateway:
+          enabled: true
+          namespace: "default"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "default"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -84,6 +84,9 @@ experimental:
     # - group: "core"
     #   kind: "Secret"
     #   name: "mysecret"
+    # By default, Gateway would be created to the Namespace you are deploying Traefik to.
+    # You may create that Gateway in another namespace, setting its name below:
+    # namespace: default
 
 # Create an IngressRoute for the dashboard
 ingressRoute:


### PR DESCRIPTION

### What does this PR do?

Allows to set a custom Namespace name creating Traefik initial Gateway


### Motivation

As reported by @ah-f3
Gateway is currently created into the default Namespace, regardless of where Traefik is being deployed to.
By default, we could want to install it alongside Traefik, into the same Namespace.
Though it could also make sense to put it somewhere else (default, kube-system, ...).
Could make sense to let end-user decide what's best for them..

Fixes https://github.com/traefik/traefik-helm-chart/issues/446


### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)


### Additional Notes

Maybe keep the default Gateway namespace to "default", preserving the current behavior?
Gateway being experimental and relatively recent, we could probably still change our mind on what the default should be.
Whichever. It's not too late to un-comment the `experimental.kubernetesGateway.namespace: default` from values. Let me know.