### PR TITLE
fix: missing service labels

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.2
+version: 10.0.3
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.5
+version: 10.1.6
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.0
+version: 10.0.1
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.3
+version: 10.1.4
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.4
+version: 10.1.5
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.1
+version: 10.0.2
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -75,6 +75,9 @@ items:
         helm.sh/chart: {{ template "traefik.chart" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
       {{- with .Values.service.annotations }}
       {{- toYaml . | nindent 8 }}


### PR DESCRIPTION

### What does this PR do?

Adds labels to the UDP service, according to values file.


### Motivation

Looking into something else, I realize that the labels we may configure in values file would only be added to the main TCP Service.
I would assume they should also be set on the UDP one.


### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)


### Additional Notes

N/A