### PR TITLE
feat(internal-service): adds an optional "internal" service

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.0
+version: 10.0.1
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/templates/service-internal.yaml
+++ b/traefik/templates/service-internal.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.service.enabled -}}
+{{- if .Values.service.internal.enabled -}}
 
 {{ $tcpPorts := dict }}
 {{ $udpPorts := dict }}
 {{- range $name, $config := .Values.ports }}
-  {{- if $config.expose }}
+  {{- if $config.exposeInternal }}
     {{- if eq (toString $config.protocol) "UDP" }}
       {{ $_ := set $udpPorts $name $config }}
     {{- else }}
@@ -16,29 +16,32 @@
 apiVersion: v1
 kind: List
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.fullname" . }}-internal
 items:
 {{- if $tcpPorts }}
   - apiVersion: v1
     kind: Service
     metadata:
-      name: {{ template "traefik.fullname" . }}
+      name: {{ template "traefik.fullname" . }}-internal
       labels:
         app.kubernetes.io/name: {{ template "traefik.name" . }}
         helm.sh/chart: {{ template "traefik.chart" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-      {{- with .Values.service.labels }}
+      {{- $svclabels := default .Values.service.labels .Values.service.internal.labels }}
+      {{- with $svclabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:
-      {{- with .Values.service.annotations }}
+      {{- $svcannotations := default .Values.service.annotations .Values.service.internal.annotations }}
+      {{- with $svcannotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       {{- $type := default "LoadBalancer" .Values.service.type }}
-      type: {{ $type }}
-      {{- with .Values.service.spec }}
+      {{- $typeint := default $type .Values.service.internal.type }}
+      type: {{ $typeint }}
+      {{- with .Values.service.internal.spec }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       selector:
@@ -54,36 +57,42 @@ items:
         nodePort: {{ $config.nodePort }}
         {{- end }}
       {{- end }}
-      {{- if eq $type "LoadBalancer" }}
-      {{- with .Values.service.loadBalancerSourceRanges }}
+      {{- if eq $typeint "LoadBalancer" }}
+      {{- with .Values.service.internal.loadBalancerSourceRanges }}
       loadBalancerSourceRanges:
       {{- toYaml . | nindent 6 }}
       {{- end -}}
       {{- end -}}
-      {{- with .Values.service.externalIPs }}
+      {{- with .Values.service.internal.externalIPs }}
       externalIPs:
       {{- toYaml . | nindent 6 }}
       {{- end -}}
 {{- end }}
 
-{{- if  $udpPorts }}
+{{- if $udpPorts }}
   - apiVersion: v1
     kind: Service
     metadata:
-      name: {{ template "traefik.fullname" . }}-udp
+      name: {{ template "traefik.fullname" . }}-internal-udp
       labels:
         app.kubernetes.io/name: {{ template "traefik.name" . }}
         helm.sh/chart: {{ template "traefik.chart" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- $svclabels := default .Values.service.labels .Values.service.internal.labels }}
+      {{- with $svclabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
-      {{- with .Values.service.annotations }}
+      {{- $svcannotations := default .Values.service.annotations .Values.service.internal.annotations }}
+      {{- with $svcannotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       {{- $type := default "LoadBalancer" .Values.service.type }}
-      type: {{ $type }}
-      {{- with .Values.service.spec }}
+      {{- $typeint := default $type .Values.service.internal.type }}
+      type: {{ $typeint }}
+      {{- with .Values.service.internal.spec }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       selector:
@@ -99,13 +108,13 @@ items:
         nodePort: {{ $config.nodePort }}
         {{- end }}
       {{- end }}
-      {{- if eq $type "LoadBalancer" }}
-      {{- with .Values.service.loadBalancerSourceRanges }}
+      {{- if eq $typeint "LoadBalancer" }}
+      {{- with .Values.service.internal.loadBalancerSourceRanges }}
       loadBalancerSourceRanges:
       {{- toYaml . | nindent 6 }}
       {{- end -}}
       {{- end -}}
-      {{- with .Values.service.externalIPs }}
+      {{- with .Values.service.internal.externalIPs }}
       externalIPs:
       {{- toYaml . | nindent 6 }}
       {{- end -}}

--- a/traefik/tests/service-internal-config_test.yaml
+++ b/traefik/tests/service-internal-config_test.yaml
@@ -1,0 +1,143 @@
+suite: Internal Service configuration
+templates:
+  - service-internal.yaml
+tests:
+  - it: should be a type LoadBalancer by default
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        internal:
+          enabled: true
+    asserts:
+      - equal:
+          path: items[0].spec.type
+          value: LoadBalancer
+  - it: should be a custom type when specified via values
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        internal:
+          enabled: true
+        type: NodePort
+    asserts:
+      - equal:
+          path: items[0].spec.type
+          value: NodePort
+  - it: should have no annotations by default
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        internal:
+          enabled: true
+    asserts:
+      - isNull:
+          path: items[0].metadata.annotations
+  - it: should have internal customized annotations when specified via values
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        internal:
+          enabled: true
+          annotations:
+            azure-load-balancer-internal: true
+    asserts:
+      - equal:
+          path: items[0].metadata.annotations.azure-load-balancer-internal
+          value: true
+  - it: should inherit from main customized annotations when specified via values
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        annotations:
+          azure-load-balancer-internal: true
+        internal:
+          enabled: true
+    asserts:
+      - equal:
+          path: items[0].metadata.annotations.azure-load-balancer-internal
+          value: true
+  - it: should have customized labels when specified via values
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        internal:
+          enabled: true
+          labels:
+            custom-label: custom-value
+    asserts:
+      - equal:
+          path: items[0].metadata.labels.custom-label
+          value: custom-value
+
+  - it: should have custom spec elements when specified via values
+    set:
+      ports:
+        traefik:
+          exposeInternal: true
+      service:
+        internal:
+          enabled: true
+          spec:
+            externalTrafficPolicy: Cluster
+            loadBalancerIP: "1.2.3.4"
+            clusterIP: "2.3.4.5"
+            loadBalancerSourceRanges:
+              - 192.168.0.1/32
+              - 172.16.0.0/16
+            externalIPs:
+              - "1.2.3.4"
+    asserts:
+      - equal:
+          path: items[0].spec.ports[0].name
+          value: traefik
+      - equal:
+          path: items[0].spec.ports[0].protocol
+          value: TCP
+      - equal:
+          path: items[0].spec.externalTrafficPolicy
+          value: Cluster
+      - equal:
+          path: items[0].spec.loadBalancerIP
+          value: "1.2.3.4"
+      - equal:
+          path: items[0].spec.clusterIP
+          value: "2.3.4.5"
+      - equal:
+          path: items[0].spec.loadBalancerSourceRanges[0]
+          value: 192.168.0.1/32
+      - equal:
+          path: items[0].spec.loadBalancerSourceRanges[1]
+          value: 172.16.0.0/16
+      - equal:
+          path: items[0].spec.externalIPs[0]
+          value: "1.2.3.4"
+  - it: should have custom spec elements when specified via values for UPD ports
+    set:
+      service:
+        internal:
+          enabled: true
+      ports:
+        udp:
+          port: 3000
+          exposedPort: 80
+          exposeInternal: true
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].spec.ports[0].name
+          value: udp
+      - equal:
+          path: items[0].spec.ports[0].protocol
+          value: UDP

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -243,6 +243,9 @@ ports:
     # If you want to access it from outside of your cluster,
     # use `kubectl port-forward` or create a secure ingress
     expose: false
+    # However you could expose the traefik port via an internal service
+    # Requires service.internal.enabled to be True
+    # exposeInternal: false
     # The exposed port for this service
     exposedPort: 9000
     # The port protocol (TCP/UDP)
@@ -252,10 +255,12 @@ ports:
     # hostPort: 8000
     expose: true
     exposedPort: 80
+    # exposeInternal: false
     # The port protocol (TCP/UDP)
     protocol: TCP
     # Use nodeport if set. This is useful if you have configured Traefik in a
-    # LoadBalancer
+    # LoadBalancer. Do not set, if both expose & exposeInternal are true while
+    # service.internal.type & service.type are either NodePort or LoadBalancer
     # nodePort: 32080
     # Port Redirections
     # Added in 2.2, you can make permanent redirects via entrypoints.
@@ -266,6 +271,7 @@ ports:
     # hostPort: 8443
     expose: true
     exposedPort: 443
+    # exposeInternal: false
     # The port protocol (TCP/UDP)
     protocol: TCP
     # nodePort: 32443
@@ -315,6 +321,18 @@ service:
     # - 172.16.0.0/16
   externalIPs: []
     # - 1.2.3.4
+  internal:
+    enabled: false
+    # Service type for internal Service, defaults to service.type
+    # type: ClusterIP
+    # Additional labels for internal Service, defaults to service.labels
+    # labels: {}
+    # Additional annotations for internal Service, defaults to service.annotations
+    # annotations: {}
+    # custom spec for internal Service, no defaults
+    spec: {}
+    loadBalancerSourceRanges: []
+    externalIPs: []
 
 ## Create HorizontalPodAutoscaler object.
 ##


### PR DESCRIPTION

### What does this PR do?

Introduces an optional internal Service, that could be used distinguishing "internal" accesses (eg: company LAN) from public accesses.


### Motivation

As suggested by @muffl0n
See https://github.com/traefik/traefik-helm-chart/issues/436


### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)


### Additional Notes

N/A