### PR TITLE
Add metrics framework, and prom annotations

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.0.2
+version: 10.1.0
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -105,6 +105,25 @@
           {{- end }}
           - "--api.dashboard=true"
           - "--ping=true"
+          {{- if .Values.metrics }}
+          {{- if .Values.metrics.datadog }}
+          - "--metrics.datadog=true"
+          - "--metrics.datadog.address={{ .Values.metrics.datadog.address }}"
+          {{- end }}
+          {{- if .Values.metrics.influxdb }}
+          - "--metrics.influxdb=true"
+          - "--metrics.influxdb.address={{ .Values.metrics.influxdb.address }}"
+          - "--metrics.influxdb.protocol={{ .Values.metrics.influxdb.protocol }}"
+          {{- end }}
+          {{- if .Values.metrics.prometheus }}
+          - "--metrics.prometheus=true"
+          - "--metrics.prometheus.entrypoint={{ .Values.metrics.prometheus.entryPoint }}"
+          {{- end }}
+          {{- if .Values.metrics.statsd }}
+          - "--metrics.statsd=true"
+          - "--metrics.statsd.address={{ .Values.metrics.statsd.address }}"
+          {{- end }}
+          {{- end }}
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
           {{- end }}

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -27,6 +27,12 @@ metadata:
   {{- with .Values.deployment.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.metrics }}
+  {{- if .Values.metrics.prometheus }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
+  {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -30,6 +30,7 @@ metadata:
   {{- if .Values.metrics }}
   {{- if .Values.metrics.prometheus }}
     prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
     prometheus.io/port: {{ (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
   {{- end }}
   {{- end }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -29,6 +29,12 @@ metadata:
   {{- with .Values.deployment.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.metrics }}
+  {{- if .Values.metrics.prometheus }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
+  {{- end }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ default 1 .Values.deployment.replicas }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -32,6 +32,7 @@ metadata:
   {{- if .Values.metrics }}
   {{- if .Values.metrics.prometheus }}
     prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
     prometheus.io/port: {{ (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
   {{- end }}
   {{- end }}

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -50,5 +50,5 @@ tests:
           entryPoint: metrics
     asserts:
       - equal:
-          path: metadata.annotations.prometheus.io/port
+          path: metadata.annotations."[prometheus.io/port]"
           value: 9100

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -43,3 +43,12 @@ tests:
       - equal:
           path: spec.template.metadata.labels.traefik/powpow
           value: podLabels
+  - it: should have prometheus labels with specified values
+    set:
+      metrics:
+        prometheus:
+          entryPoint: metrics
+    asserts:
+      - equal:
+          path: metadata.annotations.prometheus.io/port
+          value: 9100

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -49,7 +49,9 @@ tests:
         prometheus:
           entryPoint: metrics
     asserts:
-      - contains:
+      - equals:
           path: metadata.annotations
           value:
+            prometheus.io/path: /metrics
             prometheus.io/port: 9100
+            prometheus.io/scrape: "true"

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -49,6 +49,7 @@ tests:
         prometheus:
           entryPoint: metrics
     asserts:
-      - equal:
-          path: metadata.annotations."[prometheus.io/port]"
-          value: 9100
+      - contains:
+          path: metadata.annotations
+          value:
+            prometheus.io/port: 9100

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -78,6 +78,7 @@ tests:
         prometheus:
           entryPoint: metrics
     asserts:
-      - equal:
-          path: metadata.annotations."[prometheus.io/port]"
-          value: 9100
+      - contains:
+          path: metadata.annotations
+          value:
+            prometheus.io/port: 9100

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -78,7 +78,9 @@ tests:
         prometheus:
           entryPoint: metrics
     asserts:
-      - contains:
+      - equals:
           path: metadata.annotations
           value:
+            prometheus.io/path: /metrics
             prometheus.io/port: 9100
+            prometheus.io/scrape: "true"

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -72,3 +72,12 @@ tests:
       - equal:
           path: spec.template.metadata.labels.traefik/powpow
           value: podLabels
+  - it: should have prometheus labels with specified values
+    set:
+      metrics:
+        prometheus:
+          entryPoint: metrics
+    asserts:
+      - equal:
+          path: metadata.annotations.prometheus.io/port
+          value: 9100

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -79,5 +79,5 @@ tests:
           entryPoint: metrics
     asserts:
       - equal:
-          path: metadata.annotations.prometheus.io/port
+          path: metadata.annotations."[prometheus.io/port]"
           value: 9100

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -186,6 +186,17 @@ logs:
           # Authorization: drop
           # Content-Type: keep
 
+metrics:
+  # datadog:
+  #   address: 127.0.0.1:8125
+  # influxdb:
+  #   address: localhost:8089
+  #   protocol: udp
+  prometheus:
+    entryPoint: metrics
+  # statsd:
+  #   address: localhost:8125
+
 globalArguments:
   - "--global.checknewversion"
   - "--global.sendanonymoususage"
@@ -284,6 +295,20 @@ ports:
       #   sans:
       #     - foo.example.com
       #     - bar.example.com
+  metrics:
+    port: 9100
+    # hostPort: 9100
+    # Defines whether the port is exposed if service.type is LoadBalancer or
+    # NodePort.
+    #
+    # You may not want to expose the metrics port on production deployments.
+    # If you want to access it from outside of your cluster,
+    # use `kubectl port-forward` or create a secure ingress
+    expose: false
+    # The exposed port for this service
+    exposedPort: 9100
+    # The port protocol (TCP/UDP)
+    protocol: TCP
 
 # TLS Options are created as TLSOption CRDs
 # https://doc.traefik.io/traefik/https/tls/#tls-options


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds a new entrypoint for metrics, and creates a base framework for metrics configuration

### Motivation

Simple prometheus implementation

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

This PR implements a port lookup based on the name of the port. This could also be used to enable metrics on the Traefik EP if users wanted to, similar to the old chart behavior.
