### PR TITLE
fix: prometheus annotations

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.2
+version: 10.1.3
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.1
+version: 10.1.2
 appVersion: 2.4.9
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -4,6 +4,13 @@
       {{- with .Values.deployment.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.metrics }}
+      {{- if .Values.metrics.prometheus }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ quote (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
+      {{- end }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ template "traefik.name" . }}
         helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -27,13 +27,6 @@ metadata:
   {{- with .Values.deployment.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.metrics }}
-  {{- if .Values.metrics.prometheus }}
-    prometheus.io/scrape: "true"
-    prometheus.io/path: "/metrics"
-    prometheus.io/port: {{ quote (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
-  {{- end }}
-  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -29,13 +29,6 @@ metadata:
   {{- with .Values.deployment.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.metrics }}
-  {{- if .Values.metrics.prometheus }}
-    prometheus.io/scrape: "true"
-    prometheus.io/path: "/metrics"
-    prometheus.io/port: {{ quote (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
-  {{- end }}
-  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ default 1 .Values.deployment.replicas }}

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -43,17 +43,3 @@ tests:
       - equal:
           path: spec.template.metadata.labels.traefik/powpow
           value: podLabels
-  - it: should have prometheus labels with specified values
-    set:
-      deployment:
-        kind: DaemonSet 
-      metrics:
-        prometheus:
-          entryPoint: metrics
-    asserts:
-      - equal:
-          path: metadata.annotations
-          value:
-            prometheus.io/path: /metrics
-            prometheus.io/port: "9100"
-            prometheus.io/scrape: "true"

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -72,15 +72,3 @@ tests:
       - equal:
           path: spec.template.metadata.labels.traefik/powpow
           value: podLabels
-  - it: should have prometheus labels with specified values
-    set:
-      metrics:
-        prometheus:
-          entryPoint: metrics
-    asserts:
-      - equal:
-          path: metadata.annotations
-          value:
-            prometheus.io/path: /metrics
-            prometheus.io/port: "9100"
-            prometheus.io/scrape: "true"

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -234,3 +234,18 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             "--pilot.dashboard=false"
+  - it: should have prometheus labels with specified values
+    set:
+      metrics:
+        prometheus:
+          entryPoint: metrics
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.prometheus\.io/path
+          value: /metrics
+      - equal:
+          path: spec.template.metadata.annotations.prometheus\.io/port
+          value: "9100"
+      - equal:
+          path: spec.template.metadata.annotations.prometheus\.io/scrape
+          value: "true"


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Moves prometheus annotation to pods instead of deployment/daemonset


### Motivation
Prometheus cannot scrape from deployment/daemonset, only from pods or services


### More

- [ x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

This should fix #460 
