### PR TITLE
fix(ingressclass): fallbackApiVersion default shouldn't be `nil`

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.2
+version: 10.1.3
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.3
+version: 10.1.4
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -6,7 +6,7 @@ apiVersion: networking.k8s.io/v1beta1
   {{- else if or (eq .Values.ingressClass.fallbackApiVersion "v1beta1") (eq .Values.ingressClass.fallbackApiVersion "v1") }}
 apiVersion: {{ printf "networking.k8s.io/%s" .Values.ingressClass.fallbackApiVersion }}
   {{- else }}
-    {{- fail "\n\n ERROR: You must have atleast networking.k8s.io/v1beta1 to use ingressClass" }}
+    {{- fail "\n\n ERROR: You must have at least networking.k8s.io/v1beta1 to use ingressClass" }}
   {{- end }}
 kind: IngressClass
 metadata:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -64,7 +64,7 @@ ingressClass:
   enabled: false
   isDefaultClass: false
   # Use to force a networking.k8s.io API Version for certain CI/CD applications. E.g. "v1beta1"
-  fallbackApiVersion:
+  fallbackApiVersion: ""
 
 # Activate Pilot integration
 pilot:


### PR DESCRIPTION
### What does this PR do?

Fixes some default, preventing the actual error message from being shown.
And a typo in that error message...

### Motivation

As reported by @mylesagray , see traefik/traefik-helm-chart#473

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

N/A