### PR TITLE
Allow setting TCP and UDP service annotations separately

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.2
+version: 10.2.0
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.7
+version: 10.2.0
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.2.0
+version: 10.1.7
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -29,7 +29,7 @@ items:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:
-      {{- with .Values.service.annotations }}
+      {{- with (merge .Values.service.annotationsTCP .Values.service.annotations) }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -76,7 +76,7 @@ items:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
-      {{- with .Values.service.annotations }}
+      {{- with (merge .Values.service.annotationsUDP .Values.service.annotations) }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -79,17 +79,61 @@ tests:
           protocol: UDP
     asserts:
       - equal:
-          path: items[0].metadata.annotations.azure-load-balancer-internal
-          value: true
+          path: items[0].metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: tcp.example.com
       - equal:
-          path: items[0].metadata.annotations.dns-hostname
-          value: tcp.example.com
+          path: items[1].metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: udp.example.com
+  - it: should merge protocol specific service annotations with annotationsTCP unspecified when specified via values
+    set:
+      service:
+        annotations:
+          azure-load-balancer-internal: true
+        annotationsUDP:
+          dns-hostname: udp.example.com 
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
       - equal:
-          path: items[1].metadata.annotations.dns-hostname
-          value: udp.example.com
+          path: items[0].metadata.annotations
+          value:
+            azure-load-balancer-internal: true
       - equal:
-          path: items[1].metadata.annotations.azure-load-balancer-internal
-          value: true
+          path: items[1].metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: udp.example.com
+  - it: should merge protocol specific service annotations with annotationsUDP unspecified when specified via values
+    set:
+      service:
+        annotations:
+          azure-load-balancer-internal: true
+        annotationsTCP:
+          dns-hostname: tcp.example.com 
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: tcp.example.com
+      - equal:
+          path: items[1].metadata.annotations
+          value:
+            azure-load-balancer-internal: true
   - it: should have customized labels when specified via values
     set:
       service:

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -28,6 +28,40 @@ tests:
       - equal:
           path: items[0].metadata.annotations.azure-load-balancer-internal
           value: true
+  - it: should have TCP only annotations when specified via values
+    set:
+      service:
+        annotationsTCP:
+          dns-hostname: tcp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].metadata.annotations.dns-hostname
+          value: tcp.example.com
+      - isNull:
+          path: items[1].metadata.annotations
+  - it: should have UDP only annotations when specified via values
+    set:
+      service:
+        annotationsUDP:
+          dns-hostname: udp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - isNull:
+          path: items[0].metadata.annotations
+      - equal:
+          path: items[1].metadata.annotations.dns-hostname
+          value: udp.example.com
   - it: should have customized labels when specified via values
     set:
       service:

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -62,6 +62,35 @@ tests:
       - equal:
           path: items[1].metadata.annotations.dns-hostname
           value: udp.example.com
+  - it: should merge protocol specific service annotations when specified via values
+    set:
+      service:
+        annotations:
+          azure-load-balancer-internal: true
+        annotationsTCP:
+          dns-hostname: tcp.example.com 
+        annotationsUDP:
+          dns-hostname: udp.example.com 
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].metadata.annotations.azure-load-balancer-internal
+          value: true
+      - equal:
+          path: items[0].metadata.annotations.dns-hostname
+          value: tcp.example.com
+      - equal:
+          path: items[1].metadata.annotations.dns-hostname
+          value: udp.example.com
+      - equal:
+          path: items[1].metadata.annotations.azure-load-balancer-internal
+          value: true
+
   - it: should have customized labels when specified via values
     set:
       service:

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -90,7 +90,6 @@ tests:
       - equal:
           path: items[1].metadata.annotations.azure-load-balancer-internal
           value: true
-
   - it: should have customized labels when specified via values
     set:
       service:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -328,8 +328,12 @@ tlsOptions: {}
 service:
   enabled: true
   type: LoadBalancer
-  # Additional annotations (e.g. for cloud provider specific config)
+  # Additional annotations applied to both TCP and UDP services (e.g. for cloud provider specific config)
   annotations: {}
+  # Additional annotations for TCP service only
+  annotationsTCP: {}
+  # Additional annotations for UDP service only
+  annotationsUDP: {}
   # Additional service labels (e.g. for filtering Service by custom labels)
   labels: {}
   # Additional entries here will be added to the service spec. Cannot contains


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Adds the following two options under `service`:
- `annotationsTCP: {}`
- `annotationsUDP: {}`

These annotations are applied to either the TCP or UDP service *only*. The option `service.annotations` remains and keeps the existing behavior of applying annotations to both services.

### Motivation

<!-- What inspired you to submit this pull request? -->
I am using [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns) to set DNS records for my traefik services. DNS records are specified by annotating the service. Traefik creates TCP and UDP LoadBalancer services and each is assigned a different IP address by [metallb](https://metallb.universe.tf/). I would like to set DNS records independently for the TCP service and UDP service, but this is not currently possible because `service.annotations` applies to *both* services.

There are likely other cases where you would want different annotations between the TCP and UDP services.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Open to design suggestions. I considered doing something like:
```yaml
service:
  annotations:
    tcp: {} # TCP-only annotations here
    udp: {} # UDP-only annotations here
```
This would break existing behavior. I think it is better to keep existing values working, so that is why I added `annotationsTCP` and `annotationsUDP` where I did.

<!-- Anything else we should know when reviewing? -->
