### PR TITLE
Allow changing the readiness/liveness probes

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.1.6
+version: 10.1.7
 appVersion: 2.4.13
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -43,6 +43,11 @@
           {{- toYaml . | nindent 10 }}
           {{- end }}
         readinessProbe:
+          {{- if .Values.ports.traefik.readinessProbe }}
+          {{- with .Values.ports.traefik.readinessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- else }}
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
@@ -51,7 +56,13 @@
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
+          {{- end }}
         livenessProbe:
+          {{- if .Values.ports.traefik.livenessProbe }}
+          {{- with .Values.ports.traefik.livenessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- else }}
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
@@ -60,6 +71,7 @@
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
+          {{- end }}
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -261,7 +261,7 @@ ports:
       # periodSeconds: 10
       # successThreshold: 1
       # timeoutSeconds: 2
-    
+
     # Override the livenessProbe. This is useful to use exec as health check instead of httpGet
     # The example shows the usage of wget inside exec, which will make the healthcheck run inside the container
     livenessProbe: {}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -246,6 +246,38 @@ ports:
     # only.
     # hostIP: 192.168.100.10
 
+    # Override the readinessProbe. This is useful to use exec as health check instead of httpGet.
+    # The example shows the usage of wget inside exec, which will make the healthcheck run inside the container
+    readinessProbe: {}
+      # exec:
+      #   command:
+      #     - "wget"
+      #     - "--no-verbose"
+      #     - "--tries=1"
+      #     - "--spider"
+      #     - "http://localhost:9000/ping"
+      # failureThreshold: 1
+      # initialDelaySeconds: 10
+      # periodSeconds: 10
+      # successThreshold: 1
+      # timeoutSeconds: 2
+    
+    # Override the livenessProbe. This is useful to use exec as health check instead of httpGet
+    # The example shows the usage of wget inside exec, which will make the healthcheck run inside the container
+    livenessProbe: {}
+      # exec:
+      #   command:
+      #     - "wget"
+      #     - "--no-verbose"
+      #     - "--tries=1"
+      #     - "--spider"
+      #     - "http://localhost:9000/ping"
+      # failureThreshold: 3
+      # initialDelaySeconds: 10
+      # periodSeconds: 10
+      # successThreshold: 1
+      # timeoutSeconds: 2
+
     # Override the liveness/readiness port. This is useful to integrate traefik
     # with an external Load Balancer that performs healthchecks.
     # healthchecksPort: 9000


### PR DESCRIPTION
### What does this PR do?
This will add the following two options under `ports>traefik`:
- `readinessProbe: {}`
- `livenessProbe: {}`

If any of these is set the default httpGet will be replace the corresponding pod probe.
The examples show how an exec with wget can be used instead.

### Motivation
Information about motivation can be found in the issue https://github.com/traefik/traefik-helm-chart/issues/479

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes
Please let me know if the solution is a bit too "open". I'd just like to switch the httpGet with exec, which can be done with less changes to values.

```yaml
readinessProbe: {}
  exec:
    command:
      - "wget"
      - "--no-verbose"
      - "--tries=1"
      - "--spider"
      - "http://localhost:9000/ping"
  failureThreshold: 1
  initialDelaySeconds: 10
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 2
```
