### PR TITLE
Releasing Traefik 2.5.0

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.2.0
-appVersion: 2.4.13
+version: 10.3.0
+appVersion: 2.5.0
 keywords:
   - traefik
   - ingress

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.4.13
+          value: traefik:2.5.0
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.4.13
+          value: traefik/traefik:2.5.0
 
   - it: should have no resource limit by default
     asserts:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR releases the latest Traefik version 2.5.0. 


### Motivation

Traefik 2.5.0 has been just released which includes a few great features, such as:
- Kubernetes 1.22 API support
- Consul Connect integration
- HTTP3 (experimental feature)
- TCP middlewares
- Advanced load balancing with nested healthchecks

and more. 


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
