### PR TITLE
added providers.kubernetesCRD.allowCrossNamespace

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.3.2
+version: 10.3.3
 appVersion: 2.5.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -134,6 +134,9 @@
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
           {{- end }}
+          {{- if .Values.providers.kubernetesCRD.allowCrossNamespace }}
+          - "--providers.kubernetescrd.allowCrossNamespace=true"
+          {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
           {{- if and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -28,6 +28,7 @@ tests:
       providers:
         kubernetesCRD:
           enabled: true
+          allowCrossNamespace: true
           namespaces:
           - "foo"
           - "bar"
@@ -40,6 +41,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.namespaces=foo,bar"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.allowCrossNamespace=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.namespaces=foo,bar"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -108,6 +108,7 @@ rollingUpdate:
 providers:
   kubernetesCRD:
     enabled: true
+    allowCrossNamespace: false
     namespaces: []
       # - "default"
   kubernetesIngress:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR allow the configuration of  `providers.kubernetesCRD.allowCrossNamespace` via values.yaml.
Default is this value set to false so no container argument will be set.  As the default behaviour within the traefik container image changed from `true` to `false` since version v2.4.11 [providers/kubernetes-crd.md#allowcrossnamespace]( https://github.com/traefik/traefik/blob/master/docs/content/providers/kubernetes-crd.md#allowcrossnamespace
)
### Motivation

<!-- What inspired you to submit this pull request? -->
This PR fix the workaround in.
https://github.com/traefik/traefik-helm-chart/issues/489

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
