### PR TITLE
Add allowCrossNamespace option on kubernetesCRD provider

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.3.3
+version: 10.3.4
 appVersion: 2.5.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -134,6 +134,9 @@
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
           {{- end }}
+          {{- if .Values.providers.kubernetesCRD.allowCrossNamespace }}
+          - "--providers.kubernetescrd.allowCrossNamespace=true"
+          {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
           {{- if and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -133,9 +133,9 @@
           {{- end }}
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
-          {{- end }}
           {{- if .Values.providers.kubernetesCRD.allowCrossNamespace }}
           - "--providers.kubernetescrd.allowCrossNamespace=true"
+          {{- end }}
           {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -28,6 +28,7 @@ tests:
       providers:
         kubernetesCRD:
           enabled: true
+          allowCrossNamespace: true
           namespaces:
           - "foo"
           - "bar"
@@ -40,6 +41,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.namespaces=foo,bar"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.allowCrossNamespace=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.namespaces=foo,bar"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -108,6 +108,7 @@ rollingUpdate:
 providers:
   kubernetesCRD:
     enabled: true
+    allowCrossNamespace: false
     namespaces: []
       # - "default"
   kubernetesIngress:


### PR DESCRIPTION
### What does this PR do?

Add the flag that controls if cross namespace resources should be allowed. This is specially important since v2.4.10 as it fixes some bugs that allowed that unintentionally.

### Motivation

Replaces #491 to merge it as soon as possible


### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Co-authored-by: HaveFun83 <38665716+HaveFun83@users.noreply.github.com>