### PR TITLE
fix(crd): missing alpnProtocols in TLSOption

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.3.2
+version: 10.3.3
 appVersion: 2.5.1
 keywords:
   - traefik

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -34,6 +34,10 @@ spec:
           spec:
             description: TLSOptionSpec configures TLS for an entry point.
             properties:
+              alpnProtocols:
+                items:
+                  type: string
+                type: array
               cipherSuites:
                 items:
                   type: string


### PR DESCRIPTION
### What does this PR do?

Fixes TLSOption CRD, introducing alpnProtocols option

### Motivation

Issue reported by @sdwire

Fixes #495

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

N/A