### PR TITLE
Fix missing RequireAnyClientCert value to TLSOption CRD 

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.3.5
+version: 10.3.6
 appVersion: 2.5.3
 keywords:
   - traefik

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - NoClientCert
                     - RequestClientCert
+                    - RequireAnyClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
                     type: string


### PR DESCRIPTION
### What does this PR do?

This PR updates the `TLSOption`CRD to add the missing `RequireAnyClientCert` value.

### Motivation

Fixes #503 

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

The CRD generation has been fixed on the Traefik side by https://github.com/traefik/traefik/pull/8464
