### PR TITLE
fix(crd): TLSOption clientAuth RequireAnyCert (#503)

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.3.5
+version: 10.3.6
 appVersion: 2.5.3
 keywords:
   - traefik

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -54,6 +54,7 @@ spec:
                     - RequestClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
                     type: string
                   secretNames:
                     description: SecretName is the name of the referenced Kubernetes


### PR DESCRIPTION

### What does this PR do?

Fix TLSOption CRD, which does not allow usage of the RequireAnyClientCert clientAuthType


### Motivation

Issue #503 filed by @Aetf

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

N/A