### PR TITLE
wip / shouldn't we set ingressclass for kubernetes ingresses as well?!

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 10.9.1
-appVersion: 2.5.6
+appVersion: 2.5.7
 keywords:
   - traefik
   - ingress

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.9.1
-appVersion: 2.5.7
+version: 10.9.2
+appVersion: 2.5.6
 keywords:
   - traefik
   - ingress

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.6.0
+version: 10.6.1
 appVersion: 2.5.3
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.7.1
+version: 10.7.2
 appVersion: 2.5.4
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -154,6 +154,9 @@
           {{- if .Values.providers.kubernetesIngress.labelSelector }}
           - "--providers.kubernetesingress.labelSelector={{ .Values.providers.kubernetesIngress.labelSelector }}"
           {{- end }}
+          {{- if .Values.providers.kubernetesIngressClass.ingressClass }}
+          - "--providers.kubernetesingress.ingressClass={{ .Values.providers.kubernetesCRD.ingressClass }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.experimental.kubernetesGateway.enabled }}
           - "--providers.kubernetesgateway"

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -154,8 +154,8 @@
           {{- if .Values.providers.kubernetesIngress.labelSelector }}
           - "--providers.kubernetesingress.labelSelector={{ .Values.providers.kubernetesIngress.labelSelector }}"
           {{- end }}
-          {{- if .Values.providers.kubernetesIngressClass.ingressClass }}
-          - "--providers.kubernetesingress.ingressClass={{ .Values.providers.kubernetesCRD.ingressClass }}"
+          {{- if .Values.providers.kubernetesIngress.ingressClass }}
+          - "--providers.kubernetesingress.ingressClass={{ .Values.providers.kubernetesIngress.ingressClass }}"
           {{- end }}
           {{- end }}
           {{- if .Values.experimental.kubernetesGateway.enabled }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -122,6 +122,7 @@ providers:
     # labelSelector: environment=production,method=traefik
     namespaces: []
       # - "default"
+    # ingressClass: traefik-internal
     # IP used for Kubernetes Ingress endpoints
     publishedService:
       enabled: false


### PR DESCRIPTION

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Reading a question on SO, I  realize we may be missing something ... (question about nginx ... I've lost my focus ..)
An option that is documented, in Traefik docs, seems to be missing from our _podTemplate

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

don't merge yet

would there be any rational for using separate IGC, dealing with Ingresses and traefik-specific objects?
maybe move providers.xxx.ingressClass to providers.ingressClass?

then: add tests

