### PR TITLE
Update default HPA API Version to `v2` and add support for behavior

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 11.1.1
+version: 12.0.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/hpa.yaml
+++ b/traefik/templates/hpa.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler" }}
 apiVersion: autoscaling/v2beta2
+{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta1/HorizontalPodAutoscaler" }}
+apiVersion: autoscaling/v2beta1
+{{- else }}
+{{- fail "\n\n ERROR: You must have at least autoscaling/v2beta1 to use HorizontalPodAutoscaler" }}
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "traefik.fullname" . }}

--- a/traefik/templates/hpa.yaml
+++ b/traefik/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "traefik.fullname" . }}
@@ -17,4 +17,8 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
 {{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- if .Values.autoscaling.behavior }}
+  behaviour: 
+{{ toYaml .Values.autoscaling.behavior | indent 4 }}
+{{- end }}
 {{- end }}

--- a/traefik/templates/hpa.yaml
+++ b/traefik/templates/hpa.yaml
@@ -1,10 +1,17 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if .Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler" }}
+
+{{- if not .Values.autoscaling.maxReplicas }}
+  {{- fail "ERROR: maxReplicas is required on HPA" }}
+{{- end }}
+
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
 apiVersion: autoscaling/v2beta2
-{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta1/HorizontalPodAutoscaler" }}
+{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta1" }}
 apiVersion: autoscaling/v2beta1
 {{- else }}
-{{- fail "\n\n ERROR: You must have at least autoscaling/v2beta1 to use HorizontalPodAutoscaler" }}
+  {{- fail "ERROR: You must have at least autoscaling/v2beta1 to use HorizontalPodAutoscaler" }}
 {{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
@@ -19,10 +26,14 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "traefik.fullname" . }}
+{{- if .Values.autoscaling.minReplicas }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
+{{- end }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+{{- if .Values.autoscaling.metrics }}
   metrics:
 {{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}
 {{- if .Values.autoscaling.behavior }}
   behaviour: 
 {{ toYaml .Values.autoscaling.behavior | indent 4 }}

--- a/traefik/tests/hpa-config_test.yaml
+++ b/traefik/tests/hpa-config_test.yaml
@@ -1,0 +1,77 @@
+suite: HPA configuration
+templates:
+  - hpa.yaml
+tests:
+  - it: should use autoscaling/v2 when available
+    capabilities:
+      apiVersions:
+        - autoscaling/v2
+    values:
+      - ./values/hpa.yaml
+    asserts:
+      - isAPIVersion:
+          of: autoscaling/v2
+  - it: should use autoscaling/v2beta2 otherwise
+    capabilities:
+      apiVersions:
+        - autoscaling/v2beta2
+    values:
+      - ./values/hpa.yaml
+    asserts:
+      - isAPIVersion:
+          of: autoscaling/v2beta2
+  - it: should use autoscaling/v2beta1 
+    capabilities:
+      apiVersions:
+        - autoscaling/v2beta1
+    values:
+      - ./values/hpa.yaml
+    asserts:
+      - isAPIVersion:
+          of: autoscaling/v2beta1
+  - it: should prefer to use autoscaling/v2 when available
+    capabilities:
+      apiVersions:
+        - autoscaling/v2beta2
+        - autoscaling/v2beta1
+        - autoscaling/v1
+        - autoscaling/v2
+    values:
+      - ./values/hpa.yaml
+    asserts:
+      - isAPIVersion:
+          of: autoscaling/v2
+  - it: should fail without maxReplicas
+    capabilities:
+      apiVersions:
+        - autoscaling/v2
+    set:
+      autoscaling:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "maxReplicas is required on HPA"
+  - it: should fail without autoscaling/v2 capabilities
+    capabilities:
+      apiVersions:
+        - autoscaling/v1
+    set:
+      autoscaling:
+        enabled: true
+        maxReplicas: 3
+    asserts:
+      - failedTemplate:
+          errorMessage: "You must have at least autoscaling/v2beta1 to use HorizontalPodAutoscaler"
+  - it: should not contains metrics nor behavior when they are not set
+    capabilities:
+      apiVersions:
+        - autoscaling/v2
+    set:
+      autoscaling:
+        enabled: true
+        maxReplicas: 3
+    asserts:
+      - isEmpty:
+          path: spec.metrics
+      - isEmpty:
+          path: spec.behavior

--- a/traefik/tests/values/hpa.yaml
+++ b/traefik/tests/values/hpa.yaml
@@ -1,0 +1,10 @@
+autoscaling: 
+  enabled: true
+  maxReplicas: 2
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -504,7 +504,7 @@ autoscaling:
 #       - type: Pods
 #         value: 1
 #         periodSeconds: 60
-  
+
 # Enable persistence using Persistent Volume Claims
 # ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 # After the pvc has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -493,7 +493,14 @@ autoscaling:
 #     resource:
 #       name: memory
 #       targetAverageUtilization: 60
-
+#   behavior:
+#     scaleDown:
+#       stabilizationWindowSeconds: 300
+#       policies:
+#       - type: Pods
+#         value: 1
+#         periodSeconds: 60
+  
 # Enable persistence using Persistent Volume Claims
 # ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 # After the pvc has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -488,11 +488,15 @@ autoscaling:
 #   - type: Resource
 #     resource:
 #       name: cpu
-#       targetAverageUtilization: 60
+#       target:
+#         type: Utilization
+#         averageUtilization: 60
 #   - type: Resource
 #     resource:
 #       name: memory
-#       targetAverageUtilization: 60
+#       target:
+#         type: Utilization
+#         averageUtilization: 60
 #   behavior:
 #     scaleDown:
 #       stabilizationWindowSeconds: 300


### PR DESCRIPTION
### What does this PR do?

This MR updates the API-Version of the hpa to autoscaling/v2beta2. Since k8s 1.18, this api-version adds support for custom scaling behavior. Therefore i added some example values and the corresponding property in hpa.yaml.

### Motivation
Requested by @Xyaren in #515

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

I wrapped the behavior property in the hpa in an additional if clause, because it is only supported in clusters >= 1.18, so it won't break things and needs to be enabled explicitly.
