### PR TITLE
Add missing Gateway API resources to ClusterRole

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.6.0
+version: 10.6.1
 appVersion: 2.5.3
 keywords:
   - traefik

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -67,49 +67,23 @@ rules:
       - networking.x-k8s.io
     resources:
       - gatewayclasses
-      - gatewayclasses/status
       - gateways
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.x-k8s.io
-    resources:
-      - gatewayclasses/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - networking.x-k8s.io
-    resources:
-      - gateways/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - networking.x-k8s.io
-    resources:
       - httproutes
       - tcproutes
       - tlsroutes
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - networking.x-k8s.io
     resources:
+      - gatewayclasses/status
+      - gateways/status
       - httproutes/status
+      - tcproutes/status
+      - tlsroutes/status
     verbs:
-      - get
-      - patch
       - update
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -93,6 +93,8 @@ rules:
       - networking.x-k8s.io
     resources:
       - httproutes
+      - tcproutes
+      - tlsroutes
     verbs:
       - create
       - delete


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
I've added access to two Gateway API resources (TCPRoutes and TLSRoutes) to ClusterRole.


### Motivation

<!-- What inspired you to submit this pull request? -->
This PR will fix `Failed to watch *v1alpha1.TCPRoute: failed to list *v1alpha1.TCPRoute: tcproutes.networking.x-k8s.io is forbidden: User "system:serviceaccount:traefik:traefik" cannot list resource "tcproutes" in API group "networking.x-k8s.io" at the cluster scope"` error, which occurs after enabling `experimental.kubernetesGateway.enabled` chart option.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
