### PR TITLE
Add lifecycle values property

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.6.1
+version: 10.7.0
 appVersion: 2.5.3
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -37,6 +37,9 @@
       containers:
       - image: "{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.deployment.lifecycle }}
+        lifecycle: {{ . | toYaml | nindent 10 }}
+        {{- end }}
         name: {{ template "traefik.fullname" . }}
         resources:
           {{- with .Values.resources }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -16,6 +16,8 @@ deployment:
   replicas: 1
   # Amount of time (in seconds) before Kubernetes will send the SIGKILL signal if Traefik does not shut down
   terminationGracePeriodSeconds: 60
+  # Container Lifecycle Hook configuration (e.g. for PreStop hooks for delayed pod termination)
+  lifecycle: {}
   # Additional deployment annotations (e.g. for jaeger-operator sidecar injection)
   annotations: {}
   # Additional deployment labels (e.g. for filtering deployment by custom labels)


### PR DESCRIPTION
### What does this PR do?

This PR adds the capability to add a `deployment.lifecycle` value property to the traefik podTemplate. This allows setting Kubernetes Lifecycle Hooks for traefik containers.

### Motivation

Running traefik as ingress controller behind an AWS pod-ip-based Network Load Balancer (NLB), the update of a TargetGroupBinding is propagated by the AWS Load Balancer Controller relatively quickly to the NLB target-group. 
Terminating a traefik Pod (due to rebalancing or HPA scale-down) however still creates a time frame in which the traefik container in the pod has received SIGTERM and stops serving requests while the NLB Target Group drains connections from pod that is to be terminated.

This causes single requests running into timeouts - especially on longer living connections that are not always terminated instantly (http with keepalive or ssh).

A common solution to get this deployment interruption free is to delay the SIGTERM to traefik via preStop Container Lifecycle Hook (simple sleep command) for a time frame that allows the TargetGroup to gracefully drain and deregister the Pod as target.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

