### PR TITLE
Add support for ipFamilyPolicy

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.6.2
+version: 10.7.0
 appVersion: 2.5.4
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -63,6 +63,9 @@ items:
       externalIPs:
       {{- toYaml . | nindent 6 }}
       {{- end -}}
+      {{- if .Values.service.ipFamilyPolicy -}}
+      ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+      {{- end -}}
 {{- end }}
 
 {{- if  $udpPorts }}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -63,9 +63,9 @@ items:
       externalIPs:
       {{- toYaml . | nindent 6 }}
       {{- end -}}
-      {{- if .Values.service.ipFamilyPolicy -}}
+      {{- if .Values.service.ipFamilyPolicy }}
       ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
-      {{- end -}}
+      {{- end }}
 {{- end }}
 
 {{- if  $udpPorts }}
@@ -116,5 +116,8 @@ items:
       externalIPs:
       {{- toYaml . | nindent 6 }}
       {{- end -}}
+      {{- if .Values.service.ipFamilyPolicy }}
+      ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+      {{- end }}
 {{- end }}
 {{- end -}}

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -181,7 +181,7 @@ tests:
       - equal:
           path: items[0].spec.externalIPs[0]
           value: "1.2.3.4"
-  - it: should have custom spec elements when specified via values for UPD ports
+  - it: should have custom spec elements when specified via values for UDP ports
     set:
       ports:
         udp:
@@ -196,18 +196,29 @@ tests:
       - equal:
           path: items[1].spec.ports[0].protocol
           value: UDP
-  - it: should not set ipFamilyPolicy if it is null
+  - it: should not have ipFamilyPolicy when not specified
     set:
-      service:
-        ipFamilyPolicy: null
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
     asserts:
       - isEmpty:
           path: items[0].spec.ipFamilyPolicy
-  - it: should set ipFamilyPolicy if it is not null
+      - isEmpty:
+          path: items[1].spec.ipFamilyPolicy
+  - it: should have custom ipFamilyPolicy when specified via values
     set:
       service:
         ipFamilyPolicy: PreferDualStack
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
     asserts:
       - equal:
           path: items[0].spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: items[1].spec.ipFamilyPolicy
           value: PreferDualStack

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -68,9 +68,9 @@ tests:
         annotations:
           azure-load-balancer-internal: true
         annotationsTCP:
-          dns-hostname: tcp.example.com 
+          dns-hostname: tcp.example.com
         annotationsUDP:
-          dns-hostname: udp.example.com 
+          dns-hostname: udp.example.com
       ports:
         udp:
           port: 3000
@@ -94,7 +94,7 @@ tests:
         annotations:
           azure-load-balancer-internal: true
         annotationsUDP:
-          dns-hostname: udp.example.com 
+          dns-hostname: udp.example.com
       ports:
         udp:
           port: 3000
@@ -117,7 +117,7 @@ tests:
         annotations:
           azure-load-balancer-internal: true
         annotationsTCP:
-          dns-hostname: tcp.example.com 
+          dns-hostname: tcp.example.com
       ports:
         udp:
           port: 3000
@@ -196,3 +196,18 @@ tests:
       - equal:
           path: items[1].spec.ports[0].protocol
           value: UDP
+  - it: should not set ipFamilyPolicy if it is null
+    set:
+      service:
+        ipFamilyPolicy: null
+    asserts:
+      - isEmpty:
+          path: items[0].spec.ipFamilyPolicy
+  - it: should set ipFamilyPolicy if it is not null
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+    asserts:
+      - equal:
+          path: items[0].spec.ipFamilyPolicy
+          value: PreferDualStack

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -354,6 +354,8 @@ service:
     # - 172.16.0.0/16
   externalIPs: []
     # - 1.2.3.4
+  # null or one of 'SingleStack', 'PreferDualStack', or 'RequireDualStack'
+  ipFamilyPolicy: null
 
 ## Create HorizontalPodAutoscaler object.
 ##

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -343,8 +343,8 @@ service:
   annotationsUDP: {}
   # Additional service labels (e.g. for filtering Service by custom labels)
   labels: {}
-  # Additional entries here will be added to the service spec. Cannot contains
-  # type, selector or ports entries.
+  # Additional entries here will be added to the service spec.
+  # Cannot contain type, selector or ports entries.
   spec: {}
     # externalTrafficPolicy: Cluster
     # loadBalancerIP: "1.2.3.4"
@@ -354,8 +354,8 @@ service:
     # - 172.16.0.0/16
   externalIPs: []
     # - 1.2.3.4
-  # null or one of 'SingleStack', 'PreferDualStack', or 'RequireDualStack'
-  ipFamilyPolicy: null
+  # One of SingleStack, PreferDualStack, or RequireDualStack.
+  # ipFamilyPolicy: SingleStack
 
 ## Create HorizontalPodAutoscaler object.
 ##


### PR DESCRIPTION
Closes #453

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Allows setting the service's `.spec.ipFamilyPolicy` as documented in <https://kubernetes.io/docs/concepts/services-networking/dual-stack/>

### Motivation

#453 

<!-- What inspired you to submit this pull request? -->


### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
