### PR TITLE
Fix pod disruption when using percentages

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.7.0
+version: 10.7.1
 appVersion: 2.5.4
 keywords:
   - traefik

--- a/traefik/templates/poddisruptionbudget.yaml
+++ b/traefik/templates/poddisruptionbudget.yaml
@@ -14,9 +14,9 @@ spec:
       app.kubernetes.io/name: {{ template "traefik.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | int }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- if .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | int }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}

--- a/traefik/tests/poddisruptionbudget-config_test.yaml
+++ b/traefik/tests/poddisruptionbudget-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should have minAvailable set
+  - it: should have minAvailable set as int
     set:
       podDisruptionBudget:
         enabled: true
@@ -17,7 +17,7 @@ tests:
           value: 2
       - isEmpty:
           path: spec.maxUnavailable
-  - it: should have maxUnavailable set
+  - it: should have maxUnavailable set as int
     set:
       podDisruptionBudget:
         enabled: true
@@ -26,5 +26,27 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 1
+      - isEmpty:
+          path: spec.minAvailable
+  - it: should have minAvailable set as percentage
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 25%
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 25%
+      - isEmpty:
+          path: spec.maxUnavailable
+  - it: should have maxUnavailable set as percentage
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 33%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 33%
       - isEmpty:
           path: spec.minAvailable

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -52,13 +52,15 @@ deployment:
   # dnsPolicy: ClusterFirstWithHostNet
   # Additional imagePullSecrets
   imagePullSecrets: []
-   # - name: myRegistryKeySecretName
+    # - name: myRegistryKeySecretName
 
 # Pod disruption budget
 podDisruptionBudget:
   enabled: false
   # maxUnavailable: 1
+  # maxUnavailable: 33%
   # minAvailable: 0
+  # minAvailable: 25%
 
 # Use ingressClass. Ignored if Traefik version < 2.3 / kubernetes < 1.18.x
 ingressClass:


### PR DESCRIPTION
### What does this PR do?

It fixes the issue where setting `podDisruptionBudget.minAvailable` or `podDisruptionBudget.maxUnavailable` as percentage will be convert to `0` value


### Motivation

Having an issue in production while setting a `podDisruptionBudget.minAvailable` to `50%` shows us that it was converted to value `0`.
Which leads to no disruption budget and a downtime on traefik service.


### More

- [X] Yes, I updated the [chart version](https://github.com/LudovicTOURMAN/traefik-helm-chart/blob/8297d33e0564ebff58f10953ebaa3efa4db97a7f/traefik/Chart.yaml#L5)

### Additional Notes

This fix relates to the current opened issue: https://github.com/traefik/traefik-helm-chart/issues/258
It follows Kubernetes specification: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget

> .spec.minAvailable which is a description of the number of pods from that set that must still be available after the eviction,
> even in the absence of the evicted pod. minAvailable can be either an absolute number or a percentage.