### PR TITLE
Create CRDs only if kubernetesCRD provider is enabled

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.7.1
+version: 10.7.2
 appVersion: 2.5.4
 keywords:
   - traefik

--- a/traefik/templates/crds/ingressroute.yaml
+++ b/traefik/templates/crds/ingressroute.yaml
@@ -1,23 +1,25 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: ingressroutetcps.traefik.containo.us
+  name: ingressroutes.traefik.containo.us
 spec:
   group: traefik.containo.us
   names:
-    kind: IngressRouteTCP
-    listKind: IngressRouteTCPList
-    plural: ingressroutetcps
-    singular: ingressroutetcp
+    kind: IngressRoute
+    listKind: IngressRouteList
+    plural: ingressroutes
+    singular: ingressroute
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IngressRouteTCP is an Ingress CRD specification.
+        description: IngressRoute is an Ingress CRD specification.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: IngressRouteTCPSpec is a specification for a IngressRouteTCPSpec
+            description: IngressRouteSpec is a specification for a IngressRouteSpec
               resource.
             properties:
               entryPoints:
@@ -41,16 +43,17 @@ spec:
                 type: array
               routes:
                 items:
-                  description: RouteTCP contains the set of routes.
+                  description: Route contains the set of routes.
                   properties:
+                    kind:
+                      enum:
+                      - Rule
+                      type: string
                     match:
                       type: string
                     middlewares:
-                      description: Middlewares contains references to MiddlewareTCP
-                        resources.
                       items:
-                        description: ObjectReference is a generic reference to a Traefik
-                          resource.
+                        description: MiddlewareRef is a ref to the Middleware resources.
                         properties:
                           name:
                             type: string
@@ -60,42 +63,81 @@ spec:
                         - name
                         type: object
                       type: array
+                    priority:
+                      type: integer
                     services:
                       items:
-                        description: ServiceTCP defines an upstream to proxy traffic.
+                        description: Service defines an upstream to proxy traffic.
                         properties:
+                          kind:
+                            enum:
+                            - Service
+                            - TraefikService
+                            type: string
                           name:
+                            description: Name is a reference to a Kubernetes Service
+                              object (for a load-balancer of servers), or to a TraefikService
+                              object (service load-balancer, mirroring, etc). The
+                              differentiation between the two is specified in the
+                              Kind field.
                             type: string
                           namespace:
                             type: string
+                          passHostHeader:
+                            type: boolean
                           port:
                             anyOf:
                             - type: integer
                             - type: string
                             x-kubernetes-int-or-string: true
-                          proxyProtocol:
-                            description: ProxyProtocol holds the ProxyProtocol configuration.
+                          responseForwarding:
+                            description: ResponseForwarding holds configuration for
+                              the forward of the response.
                             properties:
-                              version:
-                                type: integer
+                              flushInterval:
+                                type: string
                             type: object
-                          terminationDelay:
-                            type: integer
+                          scheme:
+                            type: string
+                          serversTransport:
+                            type: string
+                          sticky:
+                            description: Sticky holds the sticky configuration.
+                            properties:
+                              cookie:
+                                description: Cookie holds the sticky configuration
+                                  based on cookie.
+                                properties:
+                                  httpOnly:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  sameSite:
+                                    type: string
+                                  secure:
+                                    type: boolean
+                                type: object
+                            type: object
+                          strategy:
+                            type: string
                           weight:
+                            description: Weight should only be specified when Name
+                              references a TraefikService object (and to be precise,
+                              one that embeds a Weighted Round Robin).
                             type: integer
                         required:
                         - name
-                        - port
                         type: object
                       type: array
                   required:
+                  - kind
                   - match
                   type: object
                 type: array
               tls:
-                description: "TLSTCP contains the TLS certificates configuration of
-                  the routes. To enable Let's Encrypt, use an empty TLS struct, e.g.
-                  in YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
+                description: "TLS contains the TLS certificates configuration of the
+                  routes. To enable Let's Encrypt, use an empty TLS struct, e.g. in
+                  YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
                   # block format"
                 properties:
                   certResolver:
@@ -123,8 +165,6 @@ spec:
                     required:
                     - name
                     type: object
-                  passthrough:
-                    type: boolean
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
@@ -156,3 +196,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/ingressroutetcp.yaml
+++ b/traefik/templates/crds/ingressroutetcp.yaml
@@ -1,23 +1,25 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: ingressroutes.traefik.containo.us
+  name: ingressroutetcps.traefik.containo.us
 spec:
   group: traefik.containo.us
   names:
-    kind: IngressRoute
-    listKind: IngressRouteList
-    plural: ingressroutes
-    singular: ingressroute
+    kind: IngressRouteTCP
+    listKind: IngressRouteTCPList
+    plural: ingressroutetcps
+    singular: ingressroutetcp
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IngressRoute is an Ingress CRD specification.
+        description: IngressRouteTCP is an Ingress CRD specification.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: IngressRouteSpec is a specification for a IngressRouteSpec
+            description: IngressRouteTCPSpec is a specification for a IngressRouteTCPSpec
               resource.
             properties:
               entryPoints:
@@ -41,17 +43,16 @@ spec:
                 type: array
               routes:
                 items:
-                  description: Route contains the set of routes.
+                  description: RouteTCP contains the set of routes.
                   properties:
-                    kind:
-                      enum:
-                      - Rule
-                      type: string
                     match:
                       type: string
                     middlewares:
+                      description: Middlewares contains references to MiddlewareTCP
+                        resources.
                       items:
-                        description: MiddlewareRef is a ref to the Middleware resources.
+                        description: ObjectReference is a generic reference to a Traefik
+                          resource.
                         properties:
                           name:
                             type: string
@@ -61,81 +62,42 @@ spec:
                         - name
                         type: object
                       type: array
-                    priority:
-                      type: integer
                     services:
                       items:
-                        description: Service defines an upstream to proxy traffic.
+                        description: ServiceTCP defines an upstream to proxy traffic.
                         properties:
-                          kind:
-                            enum:
-                            - Service
-                            - TraefikService
-                            type: string
                           name:
-                            description: Name is a reference to a Kubernetes Service
-                              object (for a load-balancer of servers), or to a TraefikService
-                              object (service load-balancer, mirroring, etc). The
-                              differentiation between the two is specified in the
-                              Kind field.
                             type: string
                           namespace:
                             type: string
-                          passHostHeader:
-                            type: boolean
                           port:
                             anyOf:
                             - type: integer
                             - type: string
                             x-kubernetes-int-or-string: true
-                          responseForwarding:
-                            description: ResponseForwarding holds configuration for
-                              the forward of the response.
+                          proxyProtocol:
+                            description: ProxyProtocol holds the ProxyProtocol configuration.
                             properties:
-                              flushInterval:
-                                type: string
+                              version:
+                                type: integer
                             type: object
-                          scheme:
-                            type: string
-                          serversTransport:
-                            type: string
-                          sticky:
-                            description: Sticky holds the sticky configuration.
-                            properties:
-                              cookie:
-                                description: Cookie holds the sticky configuration
-                                  based on cookie.
-                                properties:
-                                  httpOnly:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  sameSite:
-                                    type: string
-                                  secure:
-                                    type: boolean
-                                type: object
-                            type: object
-                          strategy:
-                            type: string
+                          terminationDelay:
+                            type: integer
                           weight:
-                            description: Weight should only be specified when Name
-                              references a TraefikService object (and to be precise,
-                              one that embeds a Weighted Round Robin).
                             type: integer
                         required:
                         - name
+                        - port
                         type: object
                       type: array
                   required:
-                  - kind
                   - match
                   type: object
                 type: array
               tls:
-                description: "TLS contains the TLS certificates configuration of the
-                  routes. To enable Let's Encrypt, use an empty TLS struct, e.g. in
-                  YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
+                description: "TLSTCP contains the TLS certificates configuration of
+                  the routes. To enable Let's Encrypt, use an empty TLS struct, e.g.
+                  in YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
                   # block format"
                 properties:
                   certResolver:
@@ -163,6 +125,8 @@ spec:
                     required:
                     - name
                     type: object
+                  passthrough:
+                    type: boolean
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
@@ -194,3 +158,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/ingressrouteudp.yaml
+++ b/traefik/templates/crds/ingressrouteudp.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -80,3 +82,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/middlewares.yaml
+++ b/traefik/templates/crds/middlewares.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -562,3 +564,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/middlewarestcp.yaml
+++ b/traefik/templates/crds/middlewarestcp.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -55,3 +57,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/serverstransports.yaml
+++ b/traefik/templates/crds/serverstransports.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -101,3 +103,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/tlsoptions.yaml
+++ b/traefik/templates/crds/tlsoptions.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -88,3 +90,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/tlsstores.yaml
+++ b/traefik/templates/crds/tlsstores.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -60,3 +62,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}

--- a/traefik/templates/crds/traefikservices.yaml
+++ b/traefik/templates/crds/traefikservices.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.providers.kubernetesCRD.enabled }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -266,3 +268,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end -}}


### PR DESCRIPTION
### What does this PR do?
Afaiu CRDs can be only used when `kubernetesCRD` provider is enabled so this PR will add check which skips creating those in case it is not which is nice for those of use who prefer to use `kubernetesIngress` instead.

### Motivation
I'm running multi-tenant Kubernetes setup on way that there is multiple [vcluster](https://www.vcluster.com/)s running on top of prefer to keep those without CRDs so they are easier to understand by users.

### More
- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes
Currently I have done only very light testing for this one but I assume that there is nice CI here which should tell about if this change breaks something or not.
