### PR TITLE
feat: add allowExternalNameServices to KubernetesIngress provider

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.8.0
+version: 10.9.0
 appVersion: 2.5.4
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -148,6 +148,9 @@
           {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
+          {{- if .Values.providers.kubernetesIngress.allowExternalNameServices }}
+          - "--providers.kubernetesingress.allowExternalNameServices=true"
+          {{- end }}
           {{- if and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled }}
           - "--providers.kubernetesingress.ingressendpoint.publishedservice={{ template "providers.kubernetesIngress.publishedServicePath" . }}"
           {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -124,6 +124,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.allowExternalNameServices=true"
+  - it: should allow external name services when specified in configuration
+    set:
+        providers:
+          kubernetesIngress:
+            allowExternalNameServices: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.allowExternalNameServices=true"
   - it: should match ingresses based on input label
     set:
         providers:

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -118,18 +118,14 @@ tests:
   - it: should allow external name services when specified in configuration
     set:
         providers:
+          kubernetesIngress:
+            allowExternalNameServices: true
           kubernetesCRD:
             allowExternalNameServices: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.allowExternalNameServices=true"
-  - it: should allow external name services when specified in configuration
-    set:
-        providers:
-          kubernetesIngress:
-            allowExternalNameServices: true
-    asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.allowExternalNameServices=true"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -123,6 +123,7 @@ providers:
 
   kubernetesIngress:
     enabled: true
+    allowExternalNameServices: false
     # labelSelector: environment=production,method=traefik
     namespaces: []
       # - "default"


### PR DESCRIPTION
### What does this PR do?

Adds a missing option (providers.kubernetesingress.allowExternalNameServices)

### Motivation

Supersedes #529 
Fixes #521

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Co-authored-by: Samuel MARTIN MORO <faust64@gmail.com>
