### PR TITLE
Support liveness and readyness probes customization

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.17.0
+version: 10.18.0
 appVersion: 2.6.2
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -49,20 +49,14 @@
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
-          failureThreshold: 1
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- toYaml .Values.readiness.probe | trim | nindent 10 }}
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
-          failureThreshold: 3
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- toYaml .Values.liveness.probe | trim | nindent 10 }}
+          {{- end }}
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -49,14 +49,12 @@
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
-          {{- toYaml .Values.readiness.probe | trim | nindent 10 }}
-          {{- end }}
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
         livenessProbe:
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
-          {{- toYaml .Values.liveness.probe | trim | nindent 10 }}
-          {{- end }}
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -110,6 +110,20 @@ rollingUpdate:
   maxUnavailable: 1
   maxSurge: 1
 
+# Customize liveness and readiness probe values.
+readinessProbe:
+  failureThreshold: 1
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+
+livenessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
 
 #
 # Configure providers
@@ -384,23 +398,6 @@ service:
   # ipFamilies:
   #   - IPv4
   #   - IPv6
-
-## Customize liveness and readiness probes
-readiness:
-  probe:
-    failureThreshold: 1
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 2
-
-liveness:
-  probe:
-    failureThreshold: 3
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 2
 
 ## Create HorizontalPodAutoscaler object.
 ##

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -385,6 +385,23 @@ service:
   #   - IPv4
   #   - IPv6
 
+## Customize liveness and readiness probes
+readiness:
+  probe:
+    failureThreshold: 1
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
+
+liveness:
+  probe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
+
 ## Create HorizontalPodAutoscaler object.
 ##
 autoscaling:


### PR DESCRIPTION
### What does this PR do?

`Liveness` and `readiness` probes cannot be changes. So this PR will add ability customize params of probes and we are able to  disable probes.

### Motivation

I have specific case, i need to disable `liveness` probe and do more aggressive readiness probe. Now, i can't customize these probes.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes
