### PR TITLE
Bump traefik version to 2.5.6

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.9.0
-appVersion: 2.5.4
+version: 10.9.1
+appVersion: 2.5.6
 keywords:
   - traefik
   - ingress

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.5.4
+          value: traefik:2.5.6
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.5.4
+          value: traefik/traefik:2.5.6
 
   - it: should have no resource limit by default
     asserts:


### PR DESCRIPTION
### What does this PR do?

This PR updates the Traefik image version to [2.5.6](https://github.com/traefik/traefik/releases/tag/v2.5.6).


### Motivation

Be up-to-date.


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

This is my first PR here :)
