### PR TITLE
Add http3 support

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.9.1
+version: 10.9.2
 appVersion: 2.5.6
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -162,6 +162,9 @@
           - "--providers.kubernetesgateway"
           - "--experimental.kubernetesgateway"
           {{- end }}
+          {{- if .Values.experimental.http3.enabled }}
+          - "--experimental.http3=true"
+          {{- end }}
           {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" . }}"
@@ -193,6 +196,16 @@
           {{- if $domain.sans }}
           - "--entrypoints.{{ $entrypoint }}.http.tls.domains[{{ $index }}].sans={{ join "," $domain.sans }}"
           {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if hasKey $config "http3" }}
+          {{- if semverCompare ">=2.6.0" (default $.Chart.AppVersion $.Values.image.tag)}}
+          - "--entrypoints.{{ $entrypoint }}.http3"
+          {{ else }}
+          - "--entrypoints.{{ $entrypoint }}.enabledHTTP3=true"
+          {{ end }}
+          {{- if and $config.http3.advertisedPort (semverCompare ">=2.6.0" (default $.Chart.AppVersion $.Values.image.tag)) }}
+          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.advertisedPort }}"
           {{- end }}
           {{- end }}
           {{- end }}

--- a/traefik/tests/http3-config_test.yaml
+++ b/traefik/tests/http3-config_test.yaml
@@ -1,0 +1,78 @@
+suite: Http3 configuration
+templates:
+  - deployment.yaml
+tests:
+  - it: should inject the experimental flag if sepcified
+    set:
+      experimental:
+        http3:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.http3=true"
+
+  - it: should not have any http3 config by default
+    set:
+      ports:
+        websecure:
+          tls:
+            enabled: true
+    asserts:
+      # >=2.6.0
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.enabledHTTP3=true"
+      # <2.6.0
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http3"
+
+  - it: should have no http3 arguments when tls is disabled
+    set:
+      ports:
+        websecure:
+          http3: {}
+          tls:
+            enabled: false
+    asserts:
+      # >=2.6.0
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.enabledHTTP3=true"
+      # <2.6.0
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http3"
+
+  - it: should use enabledHTTP3 when the the version <2.6.0
+    set:
+      image:
+        tag: 2.5.6
+      ports:
+        websecure:
+          http3: {}
+          tls:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.enabledHTTP3=true"
+
+  - it: should specify advertisedPort when the the version >=2.6.0
+    set:
+      image:
+        tag: 2.6.0
+      ports:
+        websecure:
+          http3:
+            advertisedPort: 443
+          tls:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http3"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http3.advertisedPort=443"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -81,6 +81,8 @@ pilot:
 
 # Enable experimental features
 experimental:
+  http3:
+    enabled: false
   plugins:
     enabled: false
   kubernetesGateway:
@@ -295,6 +297,9 @@ ports:
     # The port protocol (TCP/UDP)
     protocol: TCP
     # nodePort: 32443
+    # Enable http3, requires explicit enabled in experimental section and tls
+    # http3:
+    #   advertisedPort: 443
     # Set TLS at the entrypoint
     # https://doc.traefik.io/traefik/routing/entrypoints/#tls
     tls:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
https://github.com/traefik/traefik-helm-chart/issues/537

Add http3 support for the helm chart


### Motivation

I want to enable http3 on my small k3s cluster because it sounds cool and I am a bit frustrated this can't be done in a "preferential kind of way". In the linked issue I discuss how to do it before this patch but it is very hacky in my opinion and ver fragile since it depends on you typing the entrypoint names correctly. This should improve things


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

I took care of the config changes between 2.5 and 2.6 version so everything should be working when we decide to upgrade the app version. It is also tested but I am open to add more if is is necessary.
