### PR TITLE
Make it possible to configure a host based config

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.9.1
+version: 10.9.2
 appVersion: 2.5.6
 keywords:
   - traefik

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -20,7 +20,7 @@ spec:
   entryPoints:
     - traefik
   routes:
-  - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+  - match: {{- if .Values.ingressRoute.dashboard.host -}} Host(`{{.Values.ingressRoute.dashboard.host}}`) && {{- end -}} (PathPrefix(`/dashboard`) || PathPrefix(`/api`)) 
     kind: Rule
     services:
     - name: api@internal


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Make it possible to provide a host-based ingress-route


### Motivation

I was adding multiple configured Traefik 2 instances in my cluster. To activate the dashboard I needed to define different templates (To support host based filtering). But filtering those templates (Based on their value file) was not easy and I ended up in adding  a lot "if dashboard.<name>.enabled" statements. I thought it would be an easier solution to just add an optional host to the ingress route config 


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
