### PR TITLE
Add support for ipFamilies

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.12.0
+version: 10.13.0
 appVersion: 2.6.0
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -15,7 +15,7 @@ kind: List
 metadata:
   name: {{ template "traefik.fullname" . }}
 items:
-{{- if  $tcpPorts }}
+{{- if $tcpPorts }}
   - apiVersion: v1
     kind: Service
     metadata:
@@ -66,9 +66,13 @@ items:
       {{- if .Values.service.ipFamilyPolicy }}
       ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
       {{- end }}
+      {{- with .Values.service.ipFamilies }}
+      ipFamilies: 
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
 {{- end }}
 
-{{- if  $udpPorts }}
+{{- if $udpPorts }}
   - apiVersion: v1
     kind: Service
     metadata:
@@ -119,5 +123,9 @@ items:
       {{- if .Values.service.ipFamilyPolicy }}
       ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
       {{- end }}
+      {{- with .Values.service.ipFamilies }}
+      ipFamilies: 
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
 {{- end }}
 {{- end -}}

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -222,3 +222,32 @@ tests:
       - equal:
           path: items[1].spec.ipFamilyPolicy
           value: PreferDualStack
+  - it: should not have ipFamilies when not specified
+    set:
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
+    asserts:
+      - isEmpty:
+          path: items[0].spec.ipFamilies
+      - isEmpty:
+          path: items[1].spec.ipFamilies
+  - it: should have custom ipFamilies when specified via values
+    set:
+      service:
+        ipFamilies:
+        - IPv6
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
+    asserts:
+      - equal:
+          path: items[0].spec.ipFamilies
+          value: 
+          - IPv6
+      - equal:
+          path: items[1].spec.ipFamilies
+          value: 
+          - IPv6

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -237,7 +237,7 @@ tests:
     set:
       service:
         ipFamilies:
-        - IPv6
+          - IPv6
       ports:
         udp:
           port: 3000
@@ -246,8 +246,8 @@ tests:
       - equal:
           path: items[0].spec.ipFamilies
           value: 
-          - IPv6
+            - IPv6
       - equal:
           path: items[1].spec.ipFamilies
           value: 
-          - IPv6
+            - IPv6

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -366,10 +366,11 @@ service:
     # - 1.2.3.4
   # One of SingleStack, PreferDualStack, or RequireDualStack.
   # ipFamilyPolicy: SingleStack
-  # Can set to IPv4 or/and IPv6 
+  # List of IP families (e.g. IPv4 and/or IPv6).
   # ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
   # ipFamilies:
-  # - IPv6
+  #   - IPv4
+  #   - IPv6
 
 ## Create HorizontalPodAutoscaler object.
 ##

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -366,6 +366,10 @@ service:
     # - 1.2.3.4
   # One of SingleStack, PreferDualStack, or RequireDualStack.
   # ipFamilyPolicy: SingleStack
+  # Can set to IPv4 or/and IPv6 
+  # ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
+  # ipFamilies:
+  # - IPv6
 
 ## Create HorizontalPodAutoscaler object.
 ##


### PR DESCRIPTION
Signed-off-by: peterfromthehill <peter@1qay.net>

### What does this PR do?

Allows setting the service's .spec.ipFamilies as documented in https://kubernetes.io/docs/concepts/services-networking/dual-stack/


### Motivation

#453 is not enough to provide in an dualstack cluster a IPv6 only LoadBalancer object.

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes
