### PR TITLE
Add setting to enable Instana tracing

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.10.0
+version: 10.11.0
 appVersion: 2.6.0
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -131,6 +131,11 @@
           - "--metrics.statsd.address={{ .Values.metrics.statsd.address }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.tracing }}
+          {{- if .Values.tracing.instana }}
+          - "--tracing.instana=true"
+          {{- end }}
+          {{- end }}
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
           {{- if .Values.providers.kubernetesCRD.labelSelector }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -257,3 +257,13 @@ tests:
             prometheus.io/path: /metrics
             prometheus.io/port: "9100"
             prometheus.io/scrape: "true"
+  - it: should have instana tracing enabled
+    set:
+      tracing:
+        instana:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            "--tracing.instana=true"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -208,9 +208,9 @@ metrics:
   # statsd:
   #   address: localhost:8125
 
-# tracing:
-#   instana:
-#     enabled: true
+tracing: {}
+  # instana:
+  #   enabled: true
 
 globalArguments:
   - "--global.checknewversion"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -208,6 +208,10 @@ metrics:
   # statsd:
   #   address: localhost:8125
 
+# tracing:
+#   instana:
+#     enabled: true
+
 globalArguments:
   - "--global.checknewversion"
   - "--global.sendanonymoususage"


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces a helm chart setting to enable Instana tracing without the need of manually supplying arguments.


### Motivation

We want to make the Instana integration easier to use :)


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Enabling the Instana Tracing and Sensor integration is very straight forward now. Just use `--set tracing.instana=true` on the helm deployment and be done. The tracer will now seamlessly report to the Instana Agent.
