### PR TITLE
Allow setting revisionHistoryLimit for Deployment and DaemonSet

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.21.1
+version: 10.22.0
 appVersion: 2.7.1
 keywords:
   - traefik

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -37,5 +37,8 @@ spec:
     rollingUpdate:
       maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
+  {{- if .Values.deployment.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+  {{- end }}
   template: {{ template "traefik.podTemplate" . }}
 {{- end -}}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ default 1 .Values.deployment.replicas }}
   {{- end }}
+  {{- if .Values.deployment.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "traefik.name" . }}

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -52,3 +52,12 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 30
+  - it: should have revisionHistoryLimit with specified value
+    set:
+      deployment:
+        kind: DaemonSet
+        revisionHistoryLimit: 1
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 1

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -15,6 +15,14 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
+  - it: should have revisionHistoryLimit with specified value
+    set:
+      deployment:
+        revisionHistoryLimit: 1
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 1
   - it: should have a rollingUpdate strategy with default values
     asserts:
       - equal:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -14,8 +14,8 @@ deployment:
   kind: Deployment
   # Number of pods of the deployment (only applies when kind == Deployment)
   replicas: 1
-  # how many old ReplicaSets for this Deployment you want to retain (only applies when kind == Deployment)
-  # revisionHistoryLimit: 10
+  # Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+  # revisionHistoryLimit: 1
   # Amount of time (in seconds) before Kubernetes will send the SIGKILL signal if Traefik does not shut down
   terminationGracePeriodSeconds: 60
   # The minimum number of seconds Traefik needs to be up and running before the DaemonSet/Deployment controller considers it available

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -14,6 +14,8 @@ deployment:
   kind: Deployment
   # Number of pods of the deployment (only applies when kind == Deployment)
   replicas: 1
+  # how many old ReplicaSets for this Deployment you want to retain (only applies when kind == Deployment)
+  # revisionHistoryLimit: 10
   # Amount of time (in seconds) before Kubernetes will send the SIGKILL signal if Traefik does not shut down
   terminationGracePeriodSeconds: 60
   # The minimum number of seconds Traefik needs to be up and running before the DaemonSet/Deployment controller considers it available


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces a helm chart setting to enable the revision history limit.

### Motivation

I want limit the number of replica sets.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Co-authored-by: Julien Aubert <julien.aubert@malt.com>
