### PR TITLE
Update Traefik to v2.6

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.9.1
+version: 10.10.0
 appVersion: 2.6.0
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 10.9.1
-appVersion: 2.5.6
+appVersion: 2.6.0
 keywords:
   - traefik
   - ingress

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -1,33 +1,25 @@
 {{- if .Values.experimental.kubernetesGateway.enabled }}
---- 
-apiVersion: networking.x-k8s.io/v1alpha1
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
-metadata: 
+metadata:
   name: traefik-gateway
   namespace: {{ default .Release.Namespace .Values.experimental.kubernetesGateway.namespace }}
-spec: 
+spec:
   gatewayClassName: traefik
-  listeners: 
-    - port: {{ .Values.ports.web.port }}
+  listeners:
+    - name: web
+      port: {{ .Values.ports.web.port }}
       protocol: HTTP
-      routes: 
-        kind: HTTPRoute
-        selector: 
-          matchLabels: 
-            app: {{ .Values.experimental.kubernetesGateway.appLabelSelector }}
 
-    {{- range $index, $cert:= .Values.experimental.kubernetesGateway.certificates }}
-    - port: {{ $.Values.ports.websecure.port }}
+    {{- if .Values.experimental.kubernetesGateway.certificate }}
+    - name: websecure
+      port: {{ $.Values.ports.websecure.port }}
       protocol: HTTPS
       tls:
-        certificateRef:
-          name: {{ $cert.name }}
-          group: {{ $cert.group }}
-          kind: {{ $cert.kind }}
-      routes: 
-        kind: HTTPRoute
-        selector: 
-          matchLabels: 
-            app: {{ $.Values.experimental.kubernetesGateway.appLabelSelector }}
+        certificateRefs:
+          - name: {{ .Values.experimental.kubernetesGateway.certificate.name }}
+            group: {{ .Values.experimental.kubernetesGateway.certificate.group }}
+            kind: {{ .Values.experimental.kubernetesGateway.certificate.kind }}
     {{- end }}
 {{- end }}

--- a/traefik/templates/gatewayclass.yaml
+++ b/traefik/templates/gatewayclass.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.experimental.kubernetesGateway.enabled }}
 ---
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
-apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: traefik
 spec:
-  controller: traefik.io/gateway-controller
+  controllerName: traefik.io/gateway-controller
 {{- end }}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -64,7 +64,14 @@ rules:
 {{- end -}}
 {{- if .Values.experimental.kubernetesGateway.enabled }}
   - apiGroups:
-      - networking.x-k8s.io
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
     resources:
       - gatewayclasses
       - gateways
@@ -76,7 +83,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
       - gatewayclasses/status
       - gateways/status

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.5.6
+          value: traefik:2.6.0
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.5.6
+          value: traefik/traefik:2.6.0
 
   - it: should have no resource limit by default
     asserts:

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -1,8 +1,9 @@
 suite: Gateway configuration
 templates:
   - gateway.yaml
+
 tests:
-  - it: should have one gateway with the correct class and an http port
+  - it: should have one Gateway with the correct class and an http port
     set:
       experimental:
         kubernetesGateway:
@@ -17,15 +18,15 @@ tests:
       - equal:
           path: metadata.namespace
           value: "NAMESPACE"
-  - it: should have one gateway with the correct class and an http port as well as an https port
+  - it: should have one Gateway with the correct class and an http port as well as an https port
     set:
       experimental:
         kubernetesGateway:
           enabled: true
-          certificates:
-            - name: "my-name"
-              group: "my-group"
-              kind: "my-kind"
+          certificate:
+            name: "my-name"
+            group: "my-group"
+            kind: "my-kind"
     asserts:
       - equal:
           path: spec.gatewayClassName
@@ -34,18 +35,21 @@ tests:
           path: spec.listeners[0].port
           value: 8000
       - equal:
+          path: spec.listeners[1].name
+          value: websecure
+      - equal:
           path: spec.listeners[1].port
           value: 8443
       - equal:
-          path: spec.listeners[1].tls.certificateRef.name
+          path: spec.listeners[1].tls.certificateRefs[0].name
           value: "my-name"
       - equal:
-          path: spec.listeners[1].tls.certificateRef.group
+          path: spec.listeners[1].tls.certificateRefs[0].group
           value: "my-group"
       - equal:
-          path: spec.listeners[1].tls.certificateRef.kind
+          path: spec.listeners[1].tls.certificateRefs[0].kind
           value: "my-kind"
-  - it: should install gateway in custom namespace
+  - it: should install Gateway in custom namespace
     set:
       experimental:
         kubernetesGateway:

--- a/traefik/tests/gatewayclass-config_test.yaml
+++ b/traefik/tests/gatewayclass-config_test.yaml
@@ -1,13 +1,14 @@
-suite: Gatewayclass configuration
+suite: GatewayClass configuration
 templates:
   - gatewayclass.yaml
+
 tests:
-  - it: should have one gatewayclass with controller value traefik.io/gateway-controller
+  - it: should have one GatewayClass with contollerName value traefik.io/gateway-controller
     set:
       experimental:
         kubernetesGateway:
           enabled: true
     asserts:
       - equal:
-          path: spec.controller
+          path: spec.controllerName
           value: traefik.io/gateway-controller

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -85,9 +85,8 @@ experimental:
     enabled: false
   kubernetesGateway:
     enabled: false
-    appLabelSelector: "traefik"
-    certificates: []
-    # - group: "core"
+    # certificate:
+    #   group: "core"
     #   kind: "Secret"
     #   name: "mysecret"
     # By default, Gateway would be created to the Namespace you are deploying Traefik to.


### PR DESCRIPTION
### What does this PR do?

This pull request updates the Traefik version to [`v2.6`](https://github.com/traefik/traefik/releases/tag/v2.6.0). As Traefik `v2.6` only supports Gateway API [`v1alpha2`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/) the corresponding resources have been updated accordingly.

### Motivation

Fixes #550 #549

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)
