### PR TITLE
Prefix cluster resources to allow multiple cluster level installs

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.12.0
+version: 10.12.1
 appVersion: 2.6.0
 keywords:
   - traefik

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Create a default fully qualified cluster name. This allows multiple traefik inst
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "traefik.rbac.clusterFullname" -}}
-{{- $trimmedClusterName := .Values.rbac.clusterFullName | trunc 63 | trimSuffix "-" -}}
+{{- $trimmedClusterName := .Values.rbac.prefix | trunc 63 | trimSuffix "-" -}}
 {{- if $trimmedClusterName -}}
 {{- $trimmedClusterName = printf "%s-" $trimmedClusterName -}}
 {{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -37,12 +37,12 @@ Create a default fully qualified cluster name. This allows multiple traefik inst
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "traefik.rbac.clusterFullname" -}}
-{{- $trimmedClusterName := .Values.rbac.clusterFullName | trimSuffix "-" -}}
+{{- $trimmedClusterName := .Values.rbac.clusterFullName | trunc 63 | trimSuffix "-" -}}
 {{- if $trimmedClusterName -}}
 {{- $trimmedClusterName = printf "%s-" $trimmedClusterName -}}
 {{- end -}}
 {{- $clusterFullName := printf "%s%s" $trimmedClusterName (include "traefik.fullname" .) -}}
-{{- default $clusterFullName | trunc 63 -}}
+{{- $clusterFullName | trunc 63 -}}
 {{- end -}}
 
 {{/*

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -33,6 +33,19 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a default fully qualified cluster name. This allows multiple traefik installs per cluster.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "traefik.rbac.clusterFullname" -}}
+{{- $trimmedClusterName := .Values.rbac.clusterFullName | trimSuffix "-" -}}
+{{- if $trimmedClusterName -}}
+{{- $trimmedClusterName = printf "%s-" $trimmedClusterName -}}
+{{- end -}}
+{{- $clusterFullName := printf "%s%s" $trimmedClusterName (include "traefik.fullname" .) -}}
+{{- default $clusterFullName | trunc 63 -}}
+{{- end -}}
+
+{{/*
 The name of the service account to use
 */}}
 {{- define "traefik.serviceAccountName" -}}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.rbac.clusterFullname" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}
@@ -56,7 +56,7 @@ rules:
   - apiGroups:
       - policy
     resourceNames:
-      - {{ template "traefik.fullname" . }}
+      - {{ template "traefik.rbac.clusterFullname" . }}
     resources:
       - podsecuritypolicies
     verbs:

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.rbac.clusterFullname" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -79,3 +79,25 @@ tests:
           path: subjects[0].name
           value: foobar
         template: rbac/clusterrolebinding.yaml
+  - it: should prefix cluster resources with provided value
+    set:
+      rbac:
+        clusterFullName: prefix-
+    asserts:
+      - equal:
+          path: metadata.name
+          value: prefix-RELEASE-NAME-traefik
+        template: rbac/clusterrolebinding.yaml
+      - equal:
+          path: metadata.name
+          value: prefix-RELEASE-NAME-traefik
+        template: rbac/clusterrole.yaml
+  - it: should add dash to cluster full name
+    set:
+      rbac:
+        clusterFullName: prefix
+    asserts:
+      - equal:
+          path: metadata.name
+          value: prefix-RELEASE-NAME-traefik
+        template: rbac/clusterrolebinding.yaml

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -82,7 +82,7 @@ tests:
   - it: should prefix cluster resources with provided value
     set:
       rbac:
-        clusterFullName: prefix-
+        prefix: prefix-
     asserts:
       - equal:
           path: metadata.name
@@ -95,7 +95,7 @@ tests:
   - it: should add dash to cluster full name
     set:
       rbac:
-        clusterFullName: prefix
+        prefix: prefix
     asserts:
       - equal:
           path: metadata.name

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -409,6 +409,11 @@ rbac:
   # If set to true, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
   namespaced: false
 
+  # Prefix for cluster resources to enable multiple installs per cluster.
+  # This creates unique cluster roles and cluster role binding names
+  # Only works if namespace is set to false and enables is set to true
+  clusterFullName: ""
+
 # Enable to create a PodSecurityPolicy and assign it to the Service Account via RoleBinding or ClusterRoleBinding
 podSecurityPolicy:
   enabled: false

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -417,7 +417,7 @@ rbac:
   # Prefix for cluster resources to enable multiple installs per cluster.
   # This creates unique cluster roles and cluster role binding names
   # Only works if namespace is set to false and enables is set to true
-  clusterFullName: ""
+  prefix: ""
 
 # Enable to create a PodSecurityPolicy and assign it to the Service Account via RoleBinding or ClusterRoleBinding
 podSecurityPolicy:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Adds a new value under rbac called prefix. This allows multiple versions of traefik to be installed on each cluster without conflicts.


### Motivation
As part of our deployment, we tend to need multiple instances of traefik running in our clusters. We could set ```rbac.namespaced=true``` but then we are limited to having 1 instance of traefik per namespace. What we are actually looking for is to allow N number of traefik instances to work with M namespaces. 
Essentially this adds a third option to the configuration.
1) 1 traefik instance per cluster
2) 1 traefik instance per namespace
3) (New) N traefik instances per cluster


### More

- [x ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Right now the main issue with deploying multiple instances of traefik with this configuration is because of the cluster role and cluster role binding templates. So we added ```rbac.prefix``` as a value. Though would like some feedback on if this should actually be a root value since the goal is to allow any cluster level resources to be prefixed.
