### PR TITLE
Add support HTTPS scheme for healthcheks

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.29.0
+version: 10.30.0
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,13 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-<<<<<<< HEAD
 version: 10.30.0
 appVersion: 2.8.7
-=======
-version: 10.12.1
-appVersion: 2.6.0
->>>>>>> f90a1fe (update chart version)
 keywords:
   - traefik
   - ingress

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,13 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
+<<<<<<< HEAD
 version: 10.30.0
 appVersion: 2.8.7
+=======
+version: 10.12.1
+appVersion: 2.6.0
+>>>>>>> f90a1fe (update chart version)
 keywords:
   - traefik
   - ingress

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -49,11 +49,13 @@
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
+            scheme: {{ default "HTTP" .Values.ports.traefik.healthchecksScheme }}
           {{- toYaml .Values.readinessProbe | nindent 10 }}
         livenessProbe:
           httpGet:
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
+            scheme: {{ default "HTTP" .Values.ports.traefik.healthchecksScheme }}
           {{- toYaml .Values.livenessProbe | nindent 10 }}
         lifecycle:
           {{- with .Values.deployment.lifecycle }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -245,6 +245,9 @@ tests:
         - equal:
             path: spec.template.spec.containers[0].readinessProbe.httpGet.port
             content: 9001
+        - equal:
+            path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+            content: "HTTP"
         - contains:
             path: spec.template.spec.containers[0].args
             content: "--ping"

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -251,3 +251,30 @@ tests:
         - contains:
             path: spec.template.spec.containers[0].args
             content: "--ping.entrypoint=web"
+  - it: should set custom probe scheme
+    set:
+      additionalArguments:
+        - --ping
+        - --ping.entrypoint=websecure
+      ports:
+        traefik:
+          port: 9000
+          healthchecksPort: 8443
+          healthchecksScheme: HTTPS
+          exposedPort: 9000
+      asserts:
+        - equal:
+            path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+            content: 8443
+        - equal:
+            path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+            content: 8443
+        - equal:
+            path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+            content: "HTTPS"
+        - contains:
+            path: spec.template.spec.containers[0].args
+            content: "--ping"
+        - contains:
+            path: spec.template.spec.containers[0].args
+            content: "--ping.entrypoint=websecure"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -340,6 +340,10 @@ ports:
     # with an external Load Balancer that performs healthchecks.
     # healthchecksPort: 9000
 
+    # Override the liveness/readiness scheme. Useful for getting ping to
+    # respond on websecure entryPoint.
+    # healthchecksScheme: HTTPS
+
     # Defines whether the port is exposed if service.type is LoadBalancer or
     # NodePort.
     #


### PR DESCRIPTION
### What does this PR do?

Enables us to use HTTPS for /ping over websecure entrypoint.


### Motivation

We want our loadbalancer healthcheck to use HTTPS for /ping


### More

- [x] Yes, I updated the [chart version](https://github.com/AlexanderBrevig/traefik-helm-chart/blob/enhancement/add-healthcheks-scheme/traefik/Chart.yaml#L5)
- [x] Yes, I added a [unit test](https://github.com/AlexanderBrevig/traefik-helm-chart/blob/enhancement/add-healthcheks-scheme/traefik/tests/traefik-config_test.yaml#L239)
- [x] Yes, I added a comment to [values.yaml](https://github.com/AlexanderBrevig/traefik-helm-chart/blob/enhancement/add-healthcheks-scheme/traefik/values.yaml#L270)

