### PR TITLE
Add missing inFlightConn TCP middleware CRD

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.14.0
+version: 10.14.1
 appVersion: 2.6.0
 keywords:
   - traefik

--- a/traefik/crds/middlewarestcp.yaml
+++ b/traefik/crds/middlewarestcp.yaml
@@ -34,6 +34,13 @@ spec:
           spec:
             description: MiddlewareTCPSpec holds the MiddlewareTCP configuration.
             properties:
+              inFlightConn:
+                description: TCPInFlightConn holds the TCP in flight connection configuration.
+                properties:
+                  amount:
+                    format: int64
+                    type: integer
+                type: object
               ipWhiteList:
                 description: TCPIPWhiteList holds the TCP ip white list configuration.
                 properties:


### PR DESCRIPTION
### What does this PR do?

This PR updates the `middlewaretcp` CRD to have access to missing `inFlightConn` middleware.

### Motivation

Have the possibility to use more TCP middleware

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)