### PR TITLE
CVE 2022 23632 mitigation

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.14.1
+version: 10.14.2
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 10.14.1
-appVersion: 2.6.0
+appVersion: 2.6.1
 keywords:
   - traefik
   - ingress


### PR DESCRIPTION
### What does this PR do?

Update to Traefik Version v2.6.1


### Motivation

This will mitigate the security issue described in [CVE-2022-23632] https://nvd.nist.gov/vuln/detail/CVE-2022-23632

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
