### PR TITLE
Add ingressclasses to traefik role

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.25.0
+version: 10.25.1
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -24,6 +24,7 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
     verbs:
       - get
       - list


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Add ingressclasses to traefik role



### Motivation
This PR solves the issue when Traefik is being deployed with `.Values.rbac.namespaced`
```
User system:serviceaccount:sc-services:traefik cannot list resource ingressclasses in API group networking.k8s.io at the cluster scope
```


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
