### PR TITLE
Add readinessGates and lifecycle properties

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.14.1
-appVersion: 2.6.0
+version: 10.14.2
+appVersion: 2.6.1
 keywords:
   - traefik
   - ingress

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.14.2
+version: 10.14.3
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -30,6 +30,10 @@
       {{- with .Values.deployment.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
+      {{- with .Values.deployment.readinessGates }}
+      readinessGates:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.deployment.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
@@ -63,6 +67,10 @@
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
+        lifecycle:
+          {{- with .Values.deployment.lifecycle }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.6.0
+          value: traefik:2.6.1
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.6.0
+          value: traefik/traefik:2.6.1
 
   - it: should have no resource limit by default
     asserts:

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -52,3 +52,49 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 30
+  - it: should have a preStop hook with specified values
+    set:
+      deployment:
+        kind: DaemonSet
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 40"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 40"]
+  - it: should have a postStart hook with specified values
+    set:
+      deployment:
+        kind: DaemonSet
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /ping
+              port: 9000
+              host: localhost
+              scheme: HTTP
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.host
+          value: localhost
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.scheme
+          value: HTTP
+  - it: should have readinessGates with specified values
+    set:
+      deployment:
+        kind: DaemonSet
+        readinessGates:
+          - conditionType: target-health.alb.ingress.k8s.aws/traefik-ingress_traefik-service_9000
+    asserts:
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.alb.ingress.k8s.aws/traefik-ingress_traefik-service_9000

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -80,3 +80,46 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 30
+  - it: should have a preStop hook with specified values
+    set:
+      deployment:
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 40"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 40"]
+  - it: should have a postStart hook with specified values
+    set:
+      deployment:
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /ping
+              port: 9000
+              host: localhost
+              scheme: HTTP
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.host
+          value: localhost
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.scheme
+          value: HTTP
+  - it: should have readinessGates with specified values
+    set:
+      deployment:
+        readinessGates:
+          - conditionType: target-health.alb.ingress.k8s.aws/traefik-ingress_traefik-service_9000
+    asserts:
+      - equal:
+          path: spec.template.spec.readinessGates[0].conditionType
+          value: target-health.alb.ingress.k8s.aws/traefik-ingress_traefik-service_9000

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -57,10 +57,21 @@ deployment:
   # Additional imagePullSecrets
   imagePullSecrets: []
     # - name: myRegistryKeySecretName
-  # Use readiness gates
+  # Use readiness gates (e.g to specify a list of additional conditions for pod readiness)
   readinessGates: []
+    # Example with AWS LB Controller to set pod healthiness based on its registration state on a given Application Load Balancer
+    # - conditionType: target-health.alb.ingress.k8s.aws/traefik-ingress_traefik-service_9000
   # Pod lifecycle actions
   lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "sleep 40"]
+    # postStart:
+    #   httpGet:
+    #     path: /ping
+    #     port: 9000
+    #     host: localhost
+    #     scheme: HTTP
 
 # Pod disruption budget
 podDisruptionBudget:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -57,6 +57,10 @@ deployment:
   # Additional imagePullSecrets
   imagePullSecrets: []
     # - name: myRegistryKeySecretName
+  # Use readiness gates
+  readinessGates: []
+  # Pod lifecycle actions
+  lifecycle: {}
 
 # Pod disruption budget
 podDisruptionBudget:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Add the `readinessGates` and `lifecycle` properties to the pod template

### Motivation

<!-- What inspired you to submit this pull request? -->

In order to use the AWS LB Controller in conjunction with Traefik with minimal downtime, we need to setup a readinessGate as well as a preStop command (cf. [this article](https://easoncao.com/zero-downtime-deployment-when-using-alb-ingress-controller-on-amazon-eks-and-prevent-502-error/))

```
        lifecycle:
          preStop:
            exec:
              command:
              - /bin/sh
              - -c
              - sleep 40
      readinessGates:
      - conditionType: target-health.alb.ingress.k8s.aws/<ingress_name>_<service_name>_<service_port>
```

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
