### PR TITLE
Add metrics.prometheus.addRoutersLabels option

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.14.2
+version: 10.15.0
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -128,6 +128,9 @@
           {{- if .Values.metrics.prometheus }}
           - "--metrics.prometheus=true"
           - "--metrics.prometheus.entrypoint={{ .Values.metrics.prometheus.entryPoint }}"
+          {{- if .Values.metrics.prometheus.addrouterslabels }}
+          - "--metrics.prometheus.addrouterslabels={{ .Values.metrics.prometheus.addrouterslabels }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.metrics.statsd }}
           - "--metrics.statsd=true"

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -128,8 +128,10 @@
           {{- if .Values.metrics.prometheus }}
           - "--metrics.prometheus=true"
           - "--metrics.prometheus.entrypoint={{ .Values.metrics.prometheus.entryPoint }}"
+          {{- if semverCompare ">=2.5.0" (default $.Chart.AppVersion $.Values.image.tag)}}
           {{- if .Values.metrics.prometheus.addrouterslabels }}
-          - "--metrics.prometheus.addrouterslabels={{ .Values.metrics.prometheus.addrouterslabels }}"
+          - "--metrics.prometheus.addrouterslabels=true"
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.metrics.statsd }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -128,10 +128,8 @@
           {{- if .Values.metrics.prometheus }}
           - "--metrics.prometheus=true"
           - "--metrics.prometheus.entrypoint={{ .Values.metrics.prometheus.entryPoint }}"
-          {{- if semverCompare ">=2.5.0" (default $.Chart.AppVersion $.Values.image.tag)}}
-          {{- if .Values.metrics.prometheus.addrouterslabels }}
-          - "--metrics.prometheus.addrouterslabels=true"
-          {{- end }}
+          {{- if .Values.metrics.prometheus.addRoutersLabels }}
+          - "--metrics.prometheus.addRoutersLabels=true"
           {{- end }}
           {{- end }}
           {{- if .Values.metrics.statsd }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -260,15 +260,15 @@ tests:
             prometheus.io/path: /metrics
             prometheus.io/port: "9100"
             prometheus.io/scrape: "true"
-  - it: should have prometheus addrouterslabels enabled
+  - it: should have prometheus addRoutersLabels enabled
     set:
       metrics:
         prometheus:
-          addrouterslabels: true
+          addRoutersLabels: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--metrics.prometheus.addrouterslabels=true"
+          content: "--metrics.prometheus.addRoutersLabels=true"
   - it: should have instana tracing enabled
     set:
       tracing:

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -260,6 +260,15 @@ tests:
             prometheus.io/path: /metrics
             prometheus.io/port: "9100"
             prometheus.io/scrape: "true"
+  - it: should have prometheus addrouterslabels enabled
+    set:
+      metrics:
+        prometheus:
+          addrouterslabels: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics.prometheus.addrouterslabels=true"
   - it: should have instana tracing enabled
     set:
       tracing:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -209,7 +209,7 @@ metrics:
   #   protocol: udp
   prometheus:
     entryPoint: metrics
-    # addrouterslabels: true
+  #  addRoutersLabels: true
   # statsd:
   #   address: localhost:8125
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -209,6 +209,7 @@ metrics:
   #   protocol: udp
   prometheus:
     entryPoint: metrics
+    # addrouterslabels: true
   # statsd:
   #   address: localhost:8125
 


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds the option `metrics.prometheus.addrouterslabels`to the values file.
Then the routers metrics can be set using the values.

### Motivation

<!-- What inspired you to submit this pull request? -->
Set easily the routers metrics when we install Traefik using the Helm Chart.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)