### PR TITLE
CRD: remove 'status:' key from generated configs

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.15.0
+version: 10.15.1
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/crds/ingressroute.yaml
+++ b/traefik/crds/ingressroute.yaml
@@ -188,9 +188,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/ingressroutetcp.yaml
+++ b/traefik/crds/ingressroutetcp.yaml
@@ -150,9 +150,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/ingressrouteudp.yaml
+++ b/traefik/crds/ingressrouteudp.yaml
@@ -74,9 +74,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/middlewares.yaml
+++ b/traefik/crds/middlewares.yaml
@@ -556,9 +556,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/middlewarestcp.yaml
+++ b/traefik/crds/middlewarestcp.yaml
@@ -56,9 +56,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/serverstransports.yaml
+++ b/traefik/crds/serverstransports.yaml
@@ -95,9 +95,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -82,9 +82,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/tlsstores.yaml
+++ b/traefik/crds/tlsstores.yaml
@@ -54,9 +54,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/traefik/crds/traefikservices.yaml
+++ b/traefik/crds/traefikservices.yaml
@@ -260,9 +260,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
The CRDs in this Helm chart all follow the form:

    kind: CustomResourceDefinition
    metadata:
      # ...
    spec:
      # ...
    status:
      acceptedNames:
        kind: ""
        plural: ""
      conditions: []
      storedVersions: []

The problem with the `status:` key is that it is usually
runtime-populated, for example by a controller.

In the case of a cluster managed by Anthos Config Management, it fails
to apply the Helm-generated Traefik configs with the error:

    KNV1045: Configs with "status" specified are not allowed.
    To fix, either remove the config or remove the "status" field in the config.
    For more information, see https://g.co/cloud/acm-errors#knv1045

If you remove the `status:` key from the CRDs, this now applies cleanly to an
Anthos-managed cluster.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

This does not really affect using `helm install`, but it does affect a situation where you `helm template` into a config-managed directory which is then pushed to the cluster using a separate mechanism (e.g. Anthos).