### PR TITLE
Enable router metrics by default

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.15.0
+version: 10.15.1
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -209,7 +209,7 @@ metrics:
   #   protocol: udp
   prometheus:
     entryPoint: metrics
-  #  addRoutersLabels: true
+    addRoutersLabels: true
   # statsd:
   #   address: localhost:8125
 


### PR DESCRIPTION
### What does this PR do?

Enables that router metrics are available by default

### Motivation

My default installation was only having service and no router metrics


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes