### PR TITLE
Support allowEmptyServices for KubernetesIngress provider

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.15.1
+version: 10.16.0
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.15.0
+version: 10.15.1
 appVersion: 2.6.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -162,6 +162,9 @@
           {{- if .Values.providers.kubernetesIngress.allowExternalNameServices }}
           - "--providers.kubernetesingress.allowExternalNameServices=true"
           {{- end }}
+          {{- if .Values.providers.kubernetesIngress.allowEmptyServices }}
+          - "--providers.kubernetesingress.allowEmptyServices=true"
+          {{- end }}
           {{- if and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled }}
           - "--providers.kubernetesingress.ingressendpoint.publishedservice={{ template "providers.kubernetesIngress.publishedServicePath" . }}"
           {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -125,6 +125,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.allowExternalNameServices=true"
+  - it: should allow empty services when specified in configuration
+    set:
+        providers:
+          kubernetesIngress:
+            allowEmptyServices: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.allowEmptyServices=true"
   - it: should match ingresses based on input label
     set:
         providers:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -127,6 +127,7 @@ providers:
   kubernetesIngress:
     enabled: true
     allowExternalNameServices: false
+    # allowEmptyServices: false
     # labelSelector: environment=production,method=traefik
     namespaces: []
       # - "default"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -127,7 +127,7 @@ providers:
   kubernetesIngress:
     enabled: true
     allowExternalNameServices: false
-    # allowEmptyServices: false
+    allowEmptyServices: false
     # labelSelector: environment=production,method=traefik
     namespaces: []
       # - "default"


### PR DESCRIPTION
### What does this PR do?

Add option [`allowEmptyServices`](https://doc.traefik.io/traefik/providers/kubernetes-ingress/#allowemptyservices) to allow creating empty services within Kubernetes + Traefik.

The configuration was comment out in `values.yaml` as non-critical feature.

### Motivation

I have a usecase in my cluster to create a service which is mostly empty.
To enable traefik to create a router I need to enable this feature.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
