### PR TITLE
Support ingressClass option for KubernetesIngress provider

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.18.0
+version: 10.19.0
 appVersion: 2.6.2
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -178,6 +178,9 @@
           {{- if .Values.providers.kubernetesIngress.labelSelector }}
           - "--providers.kubernetesingress.labelSelector={{ .Values.providers.kubernetesIngress.labelSelector }}"
           {{- end }}
+          {{- if .Values.providers.kubernetesIngress.ingressClass }}
+          - "--providers.kubernetesingress.ingressClass={{ .Values.providers.kubernetesIngress.ingressClass }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.experimental.kubernetesGateway.enabled }}
           - "--providers.kubernetesgateway"

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -31,13 +31,13 @@ tests:
           enabled: true
           allowCrossNamespace: true
           namespaces:
-          - "foo"
-          - "bar"
+            - "foo"
+            - "bar"
         kubernetesIngress:
           enabled: true
           namespaces:
-          - "foo"
-          - "bar"
+            - "foo"
+            - "bar"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -54,8 +54,8 @@ tests:
         kubernetesCRD:
           enabled: false
           namespaces:
-          - "foo"
-          - "bar"
+            - "foo"
+            - "bar"
         kubernetesIngress:
           enabled: false
           namespaces:
@@ -82,10 +82,10 @@ tests:
           content: "--providers.kubernetesingress.ingressendpoint.publishedservice=NAMESPACE/RELEASE-NAME-traefik"
   - it: should have enable published Kubernetes service when specified in configuration
     set:
-        providers:
-          kubernetesIngress:
-            publishedService:
-              enabled: true
+      providers:
+        kubernetesIngress:
+          publishedService:
+            enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -104,20 +104,20 @@ tests:
 
   - it: should allow cross namespace services when specified in configuration
     set:
-        providers:
-          kubernetesCRD:
-            allowCrossNamespace: true
+      providers:
+        kubernetesCRD:
+          allowCrossNamespace: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.allowCrossNamespace=true"
   - it: should allow external name services when specified in configuration
     set:
-        providers:
-          kubernetesIngress:
-            allowExternalNameServices: true
-          kubernetesCRD:
-            allowExternalNameServices: true
+      providers:
+        kubernetesIngress:
+          allowExternalNameServices: true
+        kubernetesCRD:
+          allowExternalNameServices: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -127,20 +127,20 @@ tests:
           content: "--providers.kubernetesingress.allowExternalNameServices=true"
   - it: should allow empty services when specified in configuration
     set:
-        providers:
-          kubernetesIngress:
-            allowEmptyServices: true
+      providers:
+        kubernetesIngress:
+          allowEmptyServices: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.allowEmptyServices=true"
   - it: should match ingresses based on input label
     set:
-        providers:
-          kubernetesIngress:
-            labelSelector: environment=devel
-          kubernetesCRD:
-            labelSelector: environment=devel
+      providers:
+        kubernetesIngress:
+          labelSelector: environment=devel
+        kubernetesCRD:
+          labelSelector: environment=devel
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -151,12 +151,17 @@ tests:
   - it: should match ingresses based on ingressClass
     set:
       providers:
+        kubernetesIngress:
+          ingressClass: foo
         kubernetesCRD:
           ingressClass: foo
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.ingressClass=foo"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.ingressClass=foo"
 
   - it: should have a plugin storage if the experimental feature is enabled
     set:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -142,6 +142,7 @@ providers:
     enabled: true
     allowExternalNameServices: false
     allowEmptyServices: false
+    # ingressClass: traefik-internal
     # labelSelector: environment=production,method=traefik
     namespaces: []
       # - "default"


### PR DESCRIPTION
### What does this PR do?

This pull request adds the `ingressClass` option support for the `KubernetesIngress` provider.

### Motivation

Fixes #547
Supersedes #513

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Co-authored-by: faust64 <faust64@gmail.com>
