### PR TITLE
Revert Traefik version to 2.6.2

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.19.1
-appVersion: 2.6.3
+version: 10.19.2
+appVersion: 2.6.2
 keywords:
   - traefik
   - ingress

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.6.3
+          value: traefik:2.6.2
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.6.3
+          value: traefik/traefik:2.6.2
 
   - it: should have no resource limit by default
     asserts:


### PR DESCRIPTION
### What does this PR do?

This pull request reverts the Traefik version to `v2.6.2` as the official Docker image is not yet available for the amd64 architecture (due to Docker build delay, see https://doi-janky.infosiftr.net/job/multiarch/view/images/view/traefik/).

### Motivation

Reverts #579

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)