### PR TITLE
Chore: upgrade Traefik to 2.6.6

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.19.4
-appVersion: 2.6.3
+version: 10.19.5
+appVersion: 2.6.6
 keywords:
   - traefik
   - ingress

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.6.3
+          value: traefik:2.6.6
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.6.3
+          value: traefik/traefik:2.6.6
 
   - it: should have no resource limit by default
     asserts:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Upgrade Traefik to version 2.6.6


### Motivation

Traefik version in helm chart is still at 2.6.3


### More

- [x ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Signed-off-by: Pierre-Emmanuel Andre <pea@phenylethylamine.io>
