### PR TITLE
Support environment variable usage for Datadog

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.22.0
+version: 10.23.0
 appVersion: 2.7.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -110,7 +110,9 @@
           {{- if .Values.metrics }}
           {{- if .Values.metrics.datadog }}
           - "--metrics.datadog=true"
+          {{- if .Values.metrics.datadog.address }}
           - "--metrics.datadog.address={{ .Values.metrics.datadog.address }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.metrics.influxdb }}
           - "--metrics.influxdb=true"


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Updates the chart to only specify the Datadog metrics address when it's explicitly supplied. As part of https://github.com/traefik/traefik/pull/7721 it should allow using ENV vars to hit the host directly. The ENV vars are required for  accessing the host, other wise the metrics requests fail


### Motivation

I get around this now by using command line parameters directly. It would be nice to use the YAML definition.


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
