### PR TITLE
Update PodDisruptionBudget apiVersion to policy/v1

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.24.0
+version: 10.24.1
 appVersion: 2.8.0
 keywords:
   - traefik

--- a/traefik/templates/poddisruptionbudget.yaml
+++ b/traefik/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "traefik.fullname" . }}


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Update `apiVersion` on `PodDisruptionBudget` to `policy/v1`, available in Kubernetes 1.21+.


### Motivation

The current version,  `policy/v1beta1`, has been deprecated and will be removed in Kubernetes 1.25.


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

Fixes issue #458
