### PR TITLE
Support allowEmptyServices config for KubernetesCRD 

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.20.1
+version: 10.21.0
 appVersion: 2.7.0
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -163,6 +163,9 @@
           {{- if .Values.providers.kubernetesCRD.allowExternalNameServices }}
           - "--providers.kubernetescrd.allowExternalNameServices=true"
           {{- end }}
+          {{- if .Values.providers.kubernetesCRD.allowEmptyServices }}
+          - "--providers.kubernetescrd.allowEmptyServices=true"
+          {{- end }}
           {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -138,7 +138,7 @@ tests:
           content: "--providers.kubernetesingress.allowEmptyServices=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--providers.kubernetesCRD.allowEmptyServices=true"
+          content: "--providers.kubernetescrd.allowEmptyServices=true"
   - it: should match ingresses based on input label
     set:
       providers:

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -130,10 +130,15 @@ tests:
       providers:
         kubernetesIngress:
           allowEmptyServices: true
+        kubernetesCRD:
+          allowEmptyServices: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.allowEmptyServices=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesCRD.allowEmptyServices=true"
   - it: should match ingresses based on input label
     set:
       providers:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -133,6 +133,7 @@ providers:
     enabled: true
     allowCrossNamespace: false
     allowExternalNameServices: false
+    allowEmptyServices: false
     # ingressClass: traefik-internal
     # labelSelector: environment=production,method=traefik
     namespaces: []


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
- Adds config option `allowEmptyServices` for Kubernetes CRD

### Motivation
- I came across this option in the [official docs](https://doc.traefik.io/traefik/providers/kubernetes-crd/#allowemptyservices), but struggled to get it to work with the official chart, thought I would open a PR to make it easier :)


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

