### PR TITLE
chore: update chart-testing dependency to 3.5.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install
         run: |
           curl -L https://git.io/get_helm.sh | bash -s -- -v v3.1.2
-          curl -sSL -o /tmp/ct.tgz https://github.com/helm/chart-testing/releases/download/v3.0.0-beta.2/chart-testing_3.0.0-beta.2_linux_amd64.tar.gz
+          curl -sSL -o /tmp/ct.tgz https://github.com/helm/chart-testing/releases/download/v3.5.0/chart-testing_3.5.0_linux_amd64.tar.gz
           tar xzf /tmp/ct.tgz -C /tmp && sudo cp /tmp/ct /usr/local/bin/ct && command -v ct
 
       - name: Make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install
         run: |
           curl -L https://git.io/get_helm.sh | bash -s -- -v v3.1.2
-          curl -sSL -o /tmp/ct.tgz https://github.com/helm/chart-testing/releases/download/v3.0.0-beta.2/chart-testing_3.0.0-beta.2_linux_amd64.tar.gz
+          curl -sSL -o /tmp/ct.tgz https://github.com/helm/chart-testing/releases/download/v3.5.0/chart-testing_3.5.0_linux_amd64.tar.gz
           tar xzf /tmp/ct.tgz -C /tmp && sudo cp /tmp/ct /usr/local/bin/ct && command -v ct
 
       - name: Make

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint: lint-requirements
 	@git remote add traefik https://github.com/traefik/traefik-helm-chart >/dev/null 2>&1 || true
 	@git fetch traefik master >/dev/null 2>&1 || true
 ifeq ($(LINT_USE_DOCKER),true)
-	@docker run --rm -t -v $(CURDIR):/charts -w /charts quay.io/helmpack/chart-testing:v3.0.0-beta.2 $(LINT_CMD)
+	@docker run --rm -t -v $(CURDIR):/charts -w /charts quay.io/helmpack/chart-testing:v3.5.0 $(LINT_CMD)
 else
 	cd $(CHART_DIR)/tests && $(LINT_CMD)
 endif


### PR DESCRIPTION
### What does this PR do?

This pull request updates the `chart-testing` dependency version to `v3.5.0` in order to be able to invoke the `lint` target on Apple silicon (arm64 builds are available since `v3.5.0`).  

https://github.com/helm/chart-testing/compare/v3.0.0-beta.2...v3.5.0

**Note:** version `v3.6.0` is not working with the CI because of the following error `Error: Error linting charts: Error identifying charts to process: Must be in a git repository`

### Motivation

To be able to invoke the `lint` target on Apple silicon.

### More

- [ ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)