### PR TITLE
Update Traefik version to v2.8.0

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.23.0
+version: 10.24.0
 appVersion: 2.8.0
 keywords:
   - traefik

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 10.23.0
-appVersion: 2.7.1
+appVersion: 2.8.0
 keywords:
   - traefik
   - ingress

--- a/traefik/crds/ingressroute.yaml
+++ b/traefik/crds/ingressroute.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,180 +16,250 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: IngressRoute is an Ingress CRD specification.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IngressRouteSpec is a specification for a IngressRouteSpec
-                resource.
-              properties:
-                entryPoints:
-                  items:
-                    type: string
-                  type: array
-                routes:
-                  items:
-                    description: Route contains the set of routes.
-                    properties:
-                      kind:
-                        enum:
-                          - Rule
-                        type: string
-                      match:
-                        type: string
-                      middlewares:
-                        items:
-                          description: MiddlewareRef is a ref to the Middleware resources.
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      priority:
-                        type: integer
-                      services:
-                        items:
-                          description: Service defines an upstream to proxy traffic.
-                          properties:
-                            kind:
-                              enum:
-                                - Service
-                                - TraefikService
-                              type: string
-                            name:
-                              description: Name is a reference to a Kubernetes Service
-                                object (for a load-balancer of servers), or to a TraefikService
-                                object (service load-balancer, mirroring, etc). The
-                                differentiation between the two is specified in the
-                                Kind field.
-                              type: string
-                            namespace:
-                              type: string
-                            passHostHeader:
-                              type: boolean
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                            responseForwarding:
-                              description: ResponseForwarding holds configuration for
-                                the forward of the response.
-                              properties:
-                                flushInterval:
-                                  type: string
-                              type: object
-                            scheme:
-                              type: string
-                            serversTransport:
-                              type: string
-                            sticky:
-                              description: Sticky holds the sticky configuration.
-                              properties:
-                                cookie:
-                                  description: Cookie holds the sticky configuration
-                                    based on cookie.
-                                  properties:
-                                    httpOnly:
-                                      type: boolean
-                                    name:
-                                      type: string
-                                    sameSite:
-                                      type: string
-                                    secure:
-                                      type: boolean
-                                  type: object
-                              type: object
-                            strategy:
-                              type: string
-                            weight:
-                              description: Weight should only be specified when Name
-                                references a TraefikService object (and to be precise,
-                                one that embeds a Weighted Round Robin).
-                              type: integer
-                          required:
-                            - name
-                          type: object
-                        type: array
-                    required:
-                      - kind
-                      - match
-                    type: object
-                  type: array
-                tls:
-                  description: "TLS contains the TLS certificates configuration of the
-                  routes. To enable Let's Encrypt, use an empty TLS struct, e.g. in
-                  YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
-                  # block format"
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressRouteSpec defines the desired state of IngressRoute.
+            properties:
+              entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
+                items:
+                  type: string
+                type: array
+              routes:
+                description: Routes defines the list of routes.
+                items:
+                  description: Route holds the HTTP route configuration.
                   properties:
-                    certResolver:
+                    kind:
+                      description: Kind defines the kind of the route. Rule is the
+                        only supported kind.
+                      enum:
+                      - Rule
                       type: string
-                    domains:
+                    match:
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#rule'
+                      type: string
+                    middlewares:
+                      description: 'Middlewares defines the list of references to
+                        Middleware resources. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-middleware'
                       items:
-                        description: Domain holds a domain name with SANs.
+                        description: MiddlewareRef is a reference to a Middleware
+                          resource.
                         properties:
-                          main:
+                          name:
+                            description: Name defines the name of the referenced Middleware
+                              resource.
                             type: string
-                          sans:
-                            items:
-                              type: string
-                            type: array
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Middleware resource.
+                            type: string
+                        required:
+                        - name
                         type: object
                       type: array
-                    options:
-                      description: Options is a reference to a TLSOption, that specifies
-                        the parameters of the TLS connection.
-                      properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      required:
+                    priority:
+                      description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.8/routing/routers/#priority'
+                      type: integer
+                    services:
+                      description: Services defines the list of Service. It can contain
+                        any combination of TraefikService and/or reference to a Kubernetes
+                        Service.
+                      items:
+                        description: Service defines an upstream HTTP service to proxy
+                          traffic to.
+                        properties:
+                          kind:
+                            description: Kind defines the kind of the Service.
+                            enum:
+                            - Service
+                            - TraefikService
+                            type: string
+                          name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service or TraefikService. The differentiation between
+                              the two is specified in the Kind field.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service or TraefikService.
+                            type: string
+                          passHostHeader:
+                            description: PassHostHeader defines whether the client
+                              Host header is forwarded to the upstream Kubernetes
+                              Service. By default, passHostHeader is true.
+                            type: boolean
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
+                            x-kubernetes-int-or-string: true
+                          responseForwarding:
+                            description: ResponseForwarding defines how Traefik forwards
+                              the response from the upstream Kubernetes Service to
+                              the client.
+                            properties:
+                              flushInterval:
+                                description: 'FlushInterval defines the interval,
+                                  in milliseconds, in between flushes to the client
+                                  while copying the response body. A negative value
+                                  means to flush immediately after each write to the
+                                  client. This configuration is ignored when ReverseProxy
+                                  recognizes a response as a streaming response; for
+                                  such responses, writes are flushed to the client
+                                  immediately. Default: 100ms'
+                                type: string
+                            type: object
+                          scheme:
+                            description: Scheme defines the scheme to use for the
+                              request to the upstream Kubernetes Service. It defaults
+                              to https when Kubernetes Service port is 443, http otherwise.
+                            type: string
+                          serversTransport:
+                            description: ServersTransport defines the name of ServersTransport
+                              resource to use. It allows to configure the transport
+                              between Traefik and your servers. Can only be used on
+                              a Kubernetes Service.
+                            type: string
+                          sticky:
+                            description: 'Sticky defines the sticky sessions configuration.
+                              More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                            properties:
+                              cookie:
+                                description: Cookie defines the sticky cookie configuration.
+                                properties:
+                                  httpOnly:
+                                    description: HTTPOnly defines whether the cookie
+                                      can be accessed by client-side APIs, such as
+                                      JavaScript.
+                                    type: boolean
+                                  name:
+                                    description: Name defines the Cookie name.
+                                    type: string
+                                  sameSite:
+                                    description: 'SameSite defines the same site policy.
+                                      More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                    type: string
+                                  secure:
+                                    description: Secure defines whether the cookie
+                                      can only be transmitted over an encrypted connection
+                                      (i.e. HTTPS).
+                                    type: boolean
+                                type: object
+                            type: object
+                          strategy:
+                            description: Strategy defines the load balancing strategy
+                              between the servers. RoundRobin is the only supported
+                              value at the moment.
+                            type: string
+                          weight:
+                            description: Weight defines the weight and should only
+                              be specified when Name references a TraefikService object
+                              (and to be precise, one that embeds a Weighted Round
+                              Robin).
+                            type: integer
+                        required:
                         - name
-                      type: object
-                    secretName:
-                      description: SecretName is the name of the referenced Kubernetes
-                        Secret to specify the certificate details.
-                      type: string
-                    store:
-                      description: Store is a reference to a TLSStore, that specifies
-                        the parameters of the TLS store.
-                      properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      required:
-                        - name
-                      type: object
+                        type: object
+                      type: array
+                  required:
+                  - kind
+                  - match
                   type: object
-              required:
-                - routes
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                type: array
+              tls:
+                description: 'TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#tls'
+                properties:
+                  certResolver:
+                    description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.8/https/acme/#certificate-resolvers'
+                    type: string
+                  domains:
+                    description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#domains'
+                    items:
+                      description: Domain holds a domain name with SANs.
+                      properties:
+                        main:
+                          description: Main defines the main domain name.
+                          type: string
+                        sans:
+                          description: SANs defines the subject alternative domain
+                            names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  options:
+                    description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
+                    properties:
+                      name:
+                        description: 'Name defines the name of the referenced TLSOption.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsoption'
+                        type: string
+                      namespace:
+                        description: 'Namespace defines the namespace of the referenced
+                          TLSOption. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsoption'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretName:
+                    description: SecretName is the name of the referenced Kubernetes
+                      Secret to specify the certificate details.
+                    type: string
+                  store:
+                    description: Store defines the reference to the TLSStore, that
+                      will be used to store certificates. Please note that only `default`
+                      TLSStore can be used.
+                    properties:
+                      name:
+                        description: 'Name defines the name of the referenced TLSStore.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsstore'
+                        type: string
+                      namespace:
+                        description: 'Namespace defines the namespace of the referenced
+                          TLSStore. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsstore'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+            required:
+            - routes
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/ingressroutetcp.yaml
+++ b/traefik/crds/ingressroutetcp.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,142 +16,193 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: IngressRouteTCP is an Ingress CRD specification.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IngressRouteTCPSpec is a specification for a IngressRouteTCPSpec
-                resource.
-              properties:
-                entryPoints:
-                  items:
-                    type: string
-                  type: array
-                routes:
-                  items:
-                    description: RouteTCP contains the set of routes.
-                    properties:
-                      match:
-                        type: string
-                      middlewares:
-                        description: Middlewares contains references to MiddlewareTCP
-                          resources.
-                        items:
-                          description: ObjectReference is a generic reference to a Traefik
-                            resource.
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      services:
-                        items:
-                          description: ServiceTCP defines an upstream to proxy traffic.
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                            proxyProtocol:
-                              description: ProxyProtocol holds the ProxyProtocol configuration.
-                              properties:
-                                version:
-                                  type: integer
-                              type: object
-                            terminationDelay:
-                              type: integer
-                            weight:
-                              type: integer
-                          required:
-                            - name
-                            - port
-                          type: object
-                        type: array
-                    required:
-                      - match
-                    type: object
-                  type: array
-                tls:
-                  description: "TLSTCP contains the TLS certificates configuration of
-                  the routes. To enable Let's Encrypt, use an empty TLS struct, e.g.
-                  in YAML: \n \t tls: {} # inline format \n \t tls: \t   secretName:
-                  # block format"
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressRouteTCPSpec defines the desired state of IngressRouteTCP.
+            properties:
+              entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
+                items:
+                  type: string
+                type: array
+              routes:
+                description: Routes defines the list of routes.
+                items:
+                  description: RouteTCP holds the TCP route configuration.
                   properties:
-                    certResolver:
+                    match:
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#rule_1'
                       type: string
-                    domains:
+                    middlewares:
+                      description: Middlewares defines the list of references to MiddlewareTCP
+                        resources.
                       items:
-                        description: Domain holds a domain name with SANs.
+                        description: ObjectReference is a generic reference to a Traefik
+                          resource.
                         properties:
-                          main:
+                          name:
+                            description: Name defines the name of the referenced Traefik
+                              resource.
                             type: string
-                          sans:
-                            items:
-                              type: string
-                            type: array
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Traefik resource.
+                            type: string
+                        required:
+                        - name
                         type: object
                       type: array
-                    options:
-                      description: Options is a reference to a TLSOption, that specifies
-                        the parameters of the TLS connection.
-                      properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      required:
+                    priority:
+                      description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.8/routing/routers/#priority_1'
+                      type: integer
+                    services:
+                      description: Services defines the list of TCP services.
+                      items:
+                        description: ServiceTCP defines an upstream TCP service to
+                          proxy traffic to.
+                        properties:
+                          name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
+                            x-kubernetes-int-or-string: true
+                          proxyProtocol:
+                            description: 'ProxyProtocol defines the PROXY protocol
+                              configuration. More info: https://doc.traefik.io/traefik/v2.8/routing/services/#proxy-protocol'
+                            properties:
+                              version:
+                                description: Version defines the PROXY Protocol version
+                                  to use.
+                                type: integer
+                            type: object
+                          terminationDelay:
+                            description: TerminationDelay defines the deadline that
+                              the proxy sets, after one of its connected peers indicates
+                              it has closed the writing capability of its connection,
+                              to close the reading capability as well, hence fully
+                              terminating the connection. It is a duration in milliseconds,
+                              defaulting to 100. A negative value means an infinite
+                              deadline (i.e. the reading capability is never closed).
+                            type: integer
+                          weight:
+                            description: Weight defines the weight used when balancing
+                              requests between multiple Kubernetes Service.
+                            type: integer
+                        required:
                         - name
-                      type: object
-                    passthrough:
-                      type: boolean
-                    secretName:
-                      description: SecretName is the name of the referenced Kubernetes
-                        Secret to specify the certificate details.
-                      type: string
-                    store:
-                      description: Store is a reference to a TLSStore, that specifies
-                        the parameters of the TLS store.
-                      properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      required:
-                        - name
-                      type: object
+                        - port
+                        type: object
+                      type: array
+                  required:
+                  - match
                   type: object
-              required:
-                - routes
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                type: array
+              tls:
+                description: 'TLS defines the TLS configuration on a layer 4 / TCP
+                  Route. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#tls_1'
+                properties:
+                  certResolver:
+                    description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.8/https/acme/#certificate-resolvers'
+                    type: string
+                  domains:
+                    description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#domains'
+                    items:
+                      description: Domain holds a domain name with SANs.
+                      properties:
+                        main:
+                          description: Main defines the main domain name.
+                          type: string
+                        sans:
+                          description: SANs defines the subject alternative domain
+                            names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  options:
+                    description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
+                    properties:
+                      name:
+                        description: Name defines the name of the referenced Traefik
+                          resource.
+                        type: string
+                      namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Traefik resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  passthrough:
+                    description: Passthrough defines whether a TLS router will terminate
+                      the TLS connection.
+                    type: boolean
+                  secretName:
+                    description: SecretName is the name of the referenced Kubernetes
+                      Secret to specify the certificate details.
+                    type: string
+                  store:
+                    description: Store defines the reference to the TLSStore, that
+                      will be used to store certificates. Please note that only `default`
+                      TLSStore can be used.
+                    properties:
+                      name:
+                        description: Name defines the name of the referenced Traefik
+                          resource.
+                        type: string
+                      namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Traefik resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+            required:
+            - routes
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/ingressrouteudp.yaml
+++ b/traefik/crds/ingressrouteudp.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,66 +16,80 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: IngressRouteUDP is an Ingress CRD specification.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: IngressRouteUDPSpec is a specification for a IngressRouteUDPSpec
-                resource.
-              properties:
-                entryPoints:
-                  items:
-                    type: string
-                  type: array
-                routes:
-                  items:
-                    description: RouteUDP contains the set of routes.
-                    properties:
-                      services:
-                        items:
-                          description: ServiceUDP defines an upstream to proxy traffic.
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                            weight:
-                              type: integer
-                          required:
-                            - name
-                            - port
-                          type: object
-                        type: array
-                    type: object
-                  type: array
-              required:
-                - routes
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressRouteUDPSpec defines the desired state of a IngressRouteUDP.
+            properties:
+              entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
+                items:
+                  type: string
+                type: array
+              routes:
+                description: Routes defines the list of routes.
+                items:
+                  description: RouteUDP holds the UDP route configuration.
+                  properties:
+                    services:
+                      description: Services defines the list of UDP services.
+                      items:
+                        description: ServiceUDP defines an upstream UDP service to
+                          proxy traffic to.
+                        properties:
+                          name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
+                            x-kubernetes-int-or-string: true
+                          weight:
+                            description: Weight defines the weight used when balancing
+                              requests between multiple Kubernetes Service.
+                            type: integer
+                        required:
+                        - name
+                        - port
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            required:
+            - routes
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/middlewares.yaml
+++ b/traefik/crds/middlewares.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,554 +16,899 @@ spec:
     singular: middleware
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Middleware is a specification for a Middleware resource.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'Middleware is the CRD implementation of a Traefik Middleware.
+          More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/overview/'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: MiddlewareSpec holds the Middleware configuration.
-              properties:
-                addPrefix:
-                  description: AddPrefix holds the AddPrefix configuration.
-                  properties:
-                    prefix:
-                      type: string
-                  type: object
-                basicAuth:
-                  description: BasicAuth holds the HTTP basic authentication configuration.
-                  properties:
-                    headerField:
-                      type: string
-                    realm:
-                      type: string
-                    removeHeader:
-                      type: boolean
-                    secret:
-                      type: string
-                  type: object
-                buffering:
-                  description: Buffering holds the request/response buffering configuration.
-                  properties:
-                    maxRequestBodyBytes:
-                      format: int64
-                      type: integer
-                    maxResponseBodyBytes:
-                      format: int64
-                      type: integer
-                    memRequestBodyBytes:
-                      format: int64
-                      type: integer
-                    memResponseBodyBytes:
-                      format: int64
-                      type: integer
-                    retryExpression:
-                      type: string
-                  type: object
-                chain:
-                  description: Chain holds a chain of middlewares.
-                  properties:
-                    middlewares:
-                      items:
-                        description: MiddlewareRef is a ref to the Middleware resources.
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                circuitBreaker:
-                  description: CircuitBreaker holds the circuit breaker configuration.
-                  properties:
-                    expression:
-                      type: string
-                  type: object
-                compress:
-                  description: Compress holds the compress configuration.
-                  properties:
-                    excludedContentTypes:
-                      items:
-                        type: string
-                      type: array
-                    minResponseBodyBytes:
-                      type: integer
-                  type: object
-                contentType:
-                  description: ContentType middleware - or rather its unique `autoDetect`
-                    option - specifies whether to let the `Content-Type` header, if
-                    it has not been set by the backend, be automatically set to a value
-                    derived from the contents of the response. As a proxy, the default
-                    behavior should be to leave the header alone, regardless of what
-                    the backend did with it. However, the historic default was to always
-                    auto-detect and set the header if it was nil, and it is going to
-                    be kept that way in order to support users currently relying on
-                    it. This middleware exists to enable the correct behavior until
-                    at least the default one can be changed in a future version.
-                  properties:
-                    autoDetect:
-                      type: boolean
-                  type: object
-                digestAuth:
-                  description: DigestAuth holds the Digest HTTP authentication configuration.
-                  properties:
-                    headerField:
-                      type: string
-                    realm:
-                      type: string
-                    removeHeader:
-                      type: boolean
-                    secret:
-                      type: string
-                  type: object
-                errors:
-                  description: ErrorPage holds the custom error page configuration.
-                  properties:
-                    query:
-                      type: string
-                    service:
-                      description: Service defines an upstream to proxy traffic.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MiddlewareSpec defines the desired state of a Middleware.
+            properties:
+              addPrefix:
+                description: 'AddPrefix holds the add prefix middleware configuration.
+                  This middleware updates the path of a request before forwarding
+                  it. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/addprefix/'
+                properties:
+                  prefix:
+                    description: Prefix is the string to add before the current path
+                      in the requested URL. It should include a leading slash (/).
+                    type: string
+                type: object
+              basicAuth:
+                description: 'BasicAuth holds the basic auth middleware configuration.
+                  This middleware restricts access to your services to known users.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/'
+                properties:
+                  headerField:
+                    description: 'HeaderField defines a header field to store the
+                      authenticated user. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/#headerfield'
+                    type: string
+                  realm:
+                    description: 'Realm allows the protected resources on a server
+                      to be partitioned into a set of protection spaces, each with
+                      its own authentication scheme. Default: traefik.'
+                    type: string
+                  removeHeader:
+                    description: 'RemoveHeader sets the removeHeader option to true
+                      to remove the authorization header before forwarding the request
+                      to your service. Default: false.'
+                    type: boolean
+                  secret:
+                    description: Secret is the name of the referenced Kubernetes Secret
+                      containing user credentials.
+                    type: string
+                type: object
+              buffering:
+                description: 'Buffering holds the buffering middleware configuration.
+                  This middleware retries or limits the size of requests that can
+                  be forwarded to backends. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/buffering/#maxrequestbodybytes'
+                properties:
+                  maxRequestBodyBytes:
+                    description: 'MaxRequestBodyBytes defines the maximum allowed
+                      body size for the request (in bytes). If the request exceeds
+                      the allowed size, it is not forwarded to the service, and the
+                      client gets a 413 (Request Entity Too Large) response. Default:
+                      0 (no maximum).'
+                    format: int64
+                    type: integer
+                  maxResponseBodyBytes:
+                    description: 'MaxResponseBodyBytes defines the maximum allowed
+                      response size from the service (in bytes). If the response exceeds
+                      the allowed size, it is not forwarded to the client. The client
+                      gets a 500 (Internal Server Error) response instead. Default:
+                      0 (no maximum).'
+                    format: int64
+                    type: integer
+                  memRequestBodyBytes:
+                    description: 'MemRequestBodyBytes defines the threshold (in bytes)
+                      from which the request will be buffered on disk instead of in
+                      memory. Default: 1048576 (1Mi).'
+                    format: int64
+                    type: integer
+                  memResponseBodyBytes:
+                    description: 'MemResponseBodyBytes defines the threshold (in bytes)
+                      from which the response will be buffered on disk instead of
+                      in memory. Default: 1048576 (1Mi).'
+                    format: int64
+                    type: integer
+                  retryExpression:
+                    description: 'RetryExpression defines the retry conditions. It
+                      is a logical combination of functions with operators AND (&&)
+                      and OR (||). More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/buffering/#retryexpression'
+                    type: string
+                type: object
+              chain:
+                description: 'Chain holds the configuration of the chain middleware.
+                  This middleware enables to define reusable combinations of other
+                  pieces of middleware. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/chain/'
+                properties:
+                  middlewares:
+                    description: Middlewares is the list of MiddlewareRef which composes
+                      the chain.
+                    items:
+                      description: MiddlewareRef is a reference to a Middleware resource.
                       properties:
-                        kind:
-                          enum:
-                            - Service
-                            - TraefikService
-                          type: string
                         name:
-                          description: Name is a reference to a Kubernetes Service object
-                            (for a load-balancer of servers), or to a TraefikService
-                            object (service load-balancer, mirroring, etc). The differentiation
-                            between the two is specified in the Kind field.
+                          description: Name defines the name of the referenced Middleware
+                            resource.
                           type: string
                         namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Middleware resource.
                           type: string
-                        passHostHeader:
-                          type: boolean
-                        port:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          x-kubernetes-int-or-string: true
-                        responseForwarding:
-                          description: ResponseForwarding holds configuration for the
-                            forward of the response.
-                          properties:
-                            flushInterval:
-                              type: string
-                          type: object
-                        scheme:
-                          type: string
-                        serversTransport:
-                          type: string
-                        sticky:
-                          description: Sticky holds the sticky configuration.
-                          properties:
-                            cookie:
-                              description: Cookie holds the sticky configuration based
-                                on cookie.
-                              properties:
-                                httpOnly:
-                                  type: boolean
-                                name:
-                                  type: string
-                                sameSite:
-                                  type: string
-                                secure:
-                                  type: boolean
-                              type: object
-                          type: object
-                        strategy:
-                          type: string
-                        weight:
-                          description: Weight should only be specified when Name references
-                            a TraefikService object (and to be precise, one that embeds
-                            a Weighted Round Robin).
-                          type: integer
                       required:
-                        - name
+                      - name
                       type: object
-                    status:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                forwardAuth:
-                  description: ForwardAuth holds the http forward authentication configuration.
-                  properties:
-                    address:
+                    type: array
+                type: object
+              circuitBreaker:
+                description: CircuitBreaker holds the circuit breaker configuration.
+                properties:
+                  checkPeriod:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CheckPeriod is the interval between successive checks
+                      of the circuit breaker condition (when in standby state).
+                    x-kubernetes-int-or-string: true
+                  expression:
+                    description: Expression is the condition that triggers the tripped
+                      state.
+                    type: string
+                  fallbackDuration:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: FallbackDuration is the duration for which the circuit
+                      breaker will wait before trying to recover (from a tripped state).
+                    x-kubernetes-int-or-string: true
+                  recoveryDuration:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: RecoveryDuration is the duration for which the circuit
+                      breaker will try to recover (as soon as it is in recovering
+                      state).
+                    x-kubernetes-int-or-string: true
+                type: object
+              compress:
+                description: 'Compress holds the compress middleware configuration.
+                  This middleware compresses responses before sending them to the
+                  client, using gzip compression. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/compress/'
+                properties:
+                  excludedContentTypes:
+                    description: ExcludedContentTypes defines the list of content
+                      types to compare the Content-Type header of the incoming requests
+                      and responses before compressing.
+                    items:
                       type: string
-                    authRequestHeaders:
-                      items:
+                    type: array
+                  minResponseBodyBytes:
+                    description: 'MinResponseBodyBytes defines the minimum amount
+                      of bytes a response body must have to be compressed. Default:
+                      1024.'
+                    type: integer
+                type: object
+              contentType:
+                description: ContentType holds the content-type middleware configuration.
+                  This middleware exists to enable the correct behavior until at least
+                  the default one can be changed in a future version.
+                properties:
+                  autoDetect:
+                    description: AutoDetect specifies whether to let the `Content-Type`
+                      header, if it has not been set by the backend, be automatically
+                      set to a value derived from the contents of the response. As
+                      a proxy, the default behavior should be to leave the header
+                      alone, regardless of what the backend did with it. However,
+                      the historic default was to always auto-detect and set the header
+                      if it was nil, and it is going to be kept that way in order
+                      to support users currently relying on it.
+                    type: boolean
+                type: object
+              digestAuth:
+                description: 'DigestAuth holds the digest auth middleware configuration.
+                  This middleware restricts access to your services to known users.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/digestauth/'
+                properties:
+                  headerField:
+                    description: 'HeaderField defines a header field to store the
+                      authenticated user. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/#headerfield'
+                    type: string
+                  realm:
+                    description: 'Realm allows the protected resources on a server
+                      to be partitioned into a set of protection spaces, each with
+                      its own authentication scheme. Default: traefik.'
+                    type: string
+                  removeHeader:
+                    description: RemoveHeader defines whether to remove the authorization
+                      header before forwarding the request to the backend.
+                    type: boolean
+                  secret:
+                    description: Secret is the name of the referenced Kubernetes Secret
+                      containing user credentials.
+                    type: string
+                type: object
+              errors:
+                description: 'ErrorPage holds the custom error middleware configuration.
+                  This middleware returns a custom page in lieu of the default, according
+                  to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/errorpages/'
+                properties:
+                  query:
+                    description: Query defines the URL for the error page (hosted
+                      by service). The {status} variable can be used in order to insert
+                      the status code in the URL.
+                    type: string
+                  service:
+                    description: 'Service defines the reference to a Kubernetes Service
+                      that will serve the error page. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/errorpages/#service'
+                    properties:
+                      kind:
+                        description: Kind defines the kind of the Service.
+                        enum:
+                        - Service
+                        - TraefikService
                         type: string
-                      type: array
-                    authResponseHeaders:
-                      items:
+                      name:
+                        description: Name defines the name of the referenced Kubernetes
+                          Service or TraefikService. The differentiation between the
+                          two is specified in the Kind field.
                         type: string
-                      type: array
-                    authResponseHeadersRegex:
-                      type: string
-                    tls:
-                      description: ClientTLS holds TLS specific configurations as client.
-                      properties:
-                        caOptional:
-                          type: boolean
-                        caSecret:
-                          type: string
-                        certSecret:
-                          type: string
-                        insecureSkipVerify:
-                          type: boolean
-                      type: object
-                    trustForwardHeader:
-                      type: boolean
-                  type: object
-                headers:
-                  description: Headers holds the custom header configuration.
-                  properties:
-                    accessControlAllowCredentials:
-                      description: AccessControlAllowCredentials is only valid if true.
-                        false is ignored.
-                      type: boolean
-                    accessControlAllowHeaders:
-                      description: AccessControlAllowHeaders must be used in response
-                        to a preflight request with Access-Control-Request-Headers set.
-                      items:
+                      namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Kubernetes Service or TraefikService.
                         type: string
-                      type: array
-                    accessControlAllowMethods:
-                      description: AccessControlAllowMethods must be used in response
-                        to a preflight request with Access-Control-Request-Method set.
-                      items:
-                        type: string
-                      type: array
-                    accessControlAllowOriginList:
-                      description: AccessControlAllowOriginList is a list of allowable
-                        origins. Can also be a wildcard origin "*".
-                      items:
-                        type: string
-                      type: array
-                    accessControlAllowOriginListRegex:
-                      description: AccessControlAllowOriginListRegex is a list of allowable
-                        origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
-                      items:
-                        type: string
-                      type: array
-                    accessControlExposeHeaders:
-                      description: AccessControlExposeHeaders sets valid headers for
-                        the response.
-                      items:
-                        type: string
-                      type: array
-                    accessControlMaxAge:
-                      description: AccessControlMaxAge sets the time that a preflight
-                        request may be cached.
-                      format: int64
-                      type: integer
-                    addVaryHeader:
-                      description: AddVaryHeader controls if the Vary header is automatically
-                        added/updated when the AccessControlAllowOriginList is set.
-                      type: boolean
-                    allowedHosts:
-                      items:
-                        type: string
-                      type: array
-                    browserXssFilter:
-                      type: boolean
-                    contentSecurityPolicy:
-                      type: string
-                    contentTypeNosniff:
-                      type: boolean
-                    customBrowserXSSValue:
-                      type: string
-                    customFrameOptionsValue:
-                      type: string
-                    customRequestHeaders:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    customResponseHeaders:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    featurePolicy:
-                      description: 'Deprecated: use PermissionsPolicy instead.'
-                      type: string
-                    forceSTSHeader:
-                      type: boolean
-                    frameDeny:
-                      type: boolean
-                    hostsProxyHeaders:
-                      items:
-                        type: string
-                      type: array
-                    isDevelopment:
-                      type: boolean
-                    permissionsPolicy:
-                      type: string
-                    publicKey:
-                      type: string
-                    referrerPolicy:
-                      type: string
-                    sslForceHost:
-                      description: 'Deprecated: use RedirectRegex instead.'
-                      type: boolean
-                    sslHost:
-                      description: 'Deprecated: use RedirectRegex instead.'
-                      type: string
-                    sslProxyHeaders:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    sslRedirect:
-                      description: 'Deprecated: use EntryPoint redirection or RedirectScheme
-                      instead.'
-                      type: boolean
-                    sslTemporaryRedirect:
-                      description: 'Deprecated: use EntryPoint redirection or RedirectScheme
-                      instead.'
-                      type: boolean
-                    stsIncludeSubdomains:
-                      type: boolean
-                    stsPreload:
-                      type: boolean
-                    stsSeconds:
-                      format: int64
-                      type: integer
-                  type: object
-                inFlightReq:
-                  description: InFlightReq limits the number of requests being processed
-                    and served concurrently.
-                  properties:
-                    amount:
-                      format: int64
-                      type: integer
-                    sourceCriterion:
-                      description: SourceCriterion defines what criterion is used to
-                        group requests as originating from a common source. If none
-                        are set, the default is to use the request's remote address
-                        field. All fields are mutually exclusive.
-                      properties:
-                        ipStrategy:
-                          description: IPStrategy holds the ip strategy configuration.
-                          properties:
-                            depth:
-                              type: integer
-                            excludedIPs:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        requestHeaderName:
-                          type: string
-                        requestHost:
-                          type: boolean
-                      type: object
-                  type: object
-                ipWhiteList:
-                  description: IPWhiteList holds the ip white list configuration.
-                  properties:
-                    ipStrategy:
-                      description: IPStrategy holds the ip strategy configuration.
-                      properties:
-                        depth:
-                          type: integer
-                        excludedIPs:
-                          items:
+                      passHostHeader:
+                        description: PassHostHeader defines whether the client Host
+                          header is forwarded to the upstream Kubernetes Service.
+                          By default, passHostHeader is true.
+                        type: boolean
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Port defines the port of a Kubernetes Service.
+                          This can be a reference to a named port.
+                        x-kubernetes-int-or-string: true
+                      responseForwarding:
+                        description: ResponseForwarding defines how Traefik forwards
+                          the response from the upstream Kubernetes Service to the
+                          client.
+                        properties:
+                          flushInterval:
+                            description: 'FlushInterval defines the interval, in milliseconds,
+                              in between flushes to the client while copying the response
+                              body. A negative value means to flush immediately after
+                              each write to the client. This configuration is ignored
+                              when ReverseProxy recognizes a response as a streaming
+                              response; for such responses, writes are flushed to
+                              the client immediately. Default: 100ms'
                             type: string
-                          type: array
-                      type: object
-                    sourceRange:
-                      items:
+                        type: object
+                      scheme:
+                        description: Scheme defines the scheme to use for the request
+                          to the upstream Kubernetes Service. It defaults to https
+                          when Kubernetes Service port is 443, http otherwise.
                         type: string
-                      type: array
-                  type: object
-                passTLSClientCert:
-                  description: PassTLSClientCert holds the TLS client cert headers configuration.
-                  properties:
-                    info:
-                      description: TLSClientCertificateInfo holds the client TLS certificate
-                        info configuration.
-                      properties:
-                        issuer:
-                          description: TLSClientCertificateIssuerDNInfo holds the client
-                            TLS certificate distinguished name info configuration. cf
-                            https://tools.ietf.org/html/rfc3739
-                          properties:
-                            commonName:
-                              type: boolean
-                            country:
-                              type: boolean
-                            domainComponent:
-                              type: boolean
-                            locality:
-                              type: boolean
-                            organization:
-                              type: boolean
-                            province:
-                              type: boolean
-                            serialNumber:
-                              type: boolean
-                          type: object
-                        notAfter:
-                          type: boolean
-                        notBefore:
-                          type: boolean
-                        sans:
-                          type: boolean
-                        serialNumber:
-                          type: boolean
-                        subject:
-                          description: TLSClientCertificateSubjectDNInfo holds the client
-                            TLS certificate distinguished name info configuration. cf
-                            https://tools.ietf.org/html/rfc3739
-                          properties:
-                            commonName:
-                              type: boolean
-                            country:
-                              type: boolean
-                            domainComponent:
-                              type: boolean
-                            locality:
-                              type: boolean
-                            organization:
-                              type: boolean
-                            organizationalUnit:
-                              type: boolean
-                            province:
-                              type: boolean
-                            serialNumber:
-                              type: boolean
-                          type: object
-                      type: object
-                    pem:
-                      type: boolean
-                  type: object
-                plugin:
-                  additionalProperties:
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                rateLimit:
-                  description: RateLimit holds the rate limiting configuration for a
-                    given router.
-                  properties:
-                    average:
-                      format: int64
-                      type: integer
-                    burst:
-                      format: int64
-                      type: integer
-                    period:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      x-kubernetes-int-or-string: true
-                    sourceCriterion:
-                      description: SourceCriterion defines what criterion is used to
-                        group requests as originating from a common source. If none
-                        are set, the default is to use the request's remote address
-                        field. All fields are mutually exclusive.
-                      properties:
-                        ipStrategy:
-                          description: IPStrategy holds the ip strategy configuration.
-                          properties:
-                            depth:
-                              type: integer
-                            excludedIPs:
-                              items:
+                      serversTransport:
+                        description: ServersTransport defines the name of ServersTransport
+                          resource to use. It allows to configure the transport between
+                          Traefik and your servers. Can only be used on a Kubernetes
+                          Service.
+                        type: string
+                      sticky:
+                        description: 'Sticky defines the sticky sessions configuration.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                        properties:
+                          cookie:
+                            description: Cookie defines the sticky cookie configuration.
+                            properties:
+                              httpOnly:
+                                description: HTTPOnly defines whether the cookie can
+                                  be accessed by client-side APIs, such as JavaScript.
+                                type: boolean
+                              name:
+                                description: Name defines the Cookie name.
                                 type: string
-                              type: array
-                          type: object
-                        requestHeaderName:
+                              sameSite:
+                                description: 'SameSite defines the same site policy.
+                                  More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                type: string
+                              secure:
+                                description: Secure defines whether the cookie can
+                                  only be transmitted over an encrypted connection
+                                  (i.e. HTTPS).
+                                type: boolean
+                            type: object
+                        type: object
+                      strategy:
+                        description: Strategy defines the load balancing strategy
+                          between the servers. RoundRobin is the only supported value
+                          at the moment.
+                        type: string
+                      weight:
+                        description: Weight defines the weight and should only be
+                          specified when Name references a TraefikService object (and
+                          to be precise, one that embeds a Weighted Round Robin).
+                        type: integer
+                    required:
+                    - name
+                    type: object
+                  status:
+                    description: Status defines which status or range of statuses
+                      should result in an error page. It can be either a status code
+                      as a number (500), as multiple comma-separated numbers (500,502),
+                      as ranges by separating two codes with a dash (500-599), or
+                      a combination of the two (404,418,500-599).
+                    items:
+                      type: string
+                    type: array
+                type: object
+              forwardAuth:
+                description: 'ForwardAuth holds the forward auth middleware configuration.
+                  This middleware delegates the request authentication to a Service.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/forwardauth/'
+                properties:
+                  address:
+                    description: Address defines the authentication server address.
+                    type: string
+                  authRequestHeaders:
+                    description: AuthRequestHeaders defines the list of the headers
+                      to copy from the request to the authentication server. If not
+                      set or empty then all request headers are passed.
+                    items:
+                      type: string
+                    type: array
+                  authResponseHeaders:
+                    description: AuthResponseHeaders defines the list of headers to
+                      copy from the authentication server response and set on forwarded
+                      request, replacing any existing conflicting headers.
+                    items:
+                      type: string
+                    type: array
+                  authResponseHeadersRegex:
+                    description: 'AuthResponseHeadersRegex defines the regex to match
+                      headers to copy from the authentication server response and
+                      set on forwarded request, after stripping all headers that match
+                      the regex. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/forwardauth/#authresponseheadersregex'
+                    type: string
+                  tls:
+                    description: TLS defines the configuration used to secure the
+                      connection to the authentication server.
+                    properties:
+                      caOptional:
+                        type: boolean
+                      caSecret:
+                        description: CASecret is the name of the referenced Kubernetes
+                          Secret containing the CA to validate the server certificate.
+                          The CA certificate is extracted from key `tls.ca` or `ca.crt`.
+                        type: string
+                      certSecret:
+                        description: CertSecret is the name of the referenced Kubernetes
+                          Secret containing the client certificate. The client certificate
+                          is extracted from the keys `tls.crt` and `tls.key`.
+                        type: string
+                      insecureSkipVerify:
+                        description: InsecureSkipVerify defines whether the server
+                          certificates should be validated.
+                        type: boolean
+                    type: object
+                  trustForwardHeader:
+                    description: 'TrustForwardHeader defines whether to trust (ie:
+                      forward) all X-Forwarded-* headers.'
+                    type: boolean
+                type: object
+              headers:
+                description: 'Headers holds the headers middleware configuration.
+                  This middleware manages the requests and responses headers. More
+                  info: https://doc.traefik.io/traefik/v2.8/middlewares/http/headers/#customrequestheaders'
+                properties:
+                  accessControlAllowCredentials:
+                    description: AccessControlAllowCredentials defines whether the
+                      request can include user credentials.
+                    type: boolean
+                  accessControlAllowHeaders:
+                    description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
+                      values sent in preflight response.
+                    items:
+                      type: string
+                    type: array
+                  accessControlAllowMethods:
+                    description: AccessControlAllowMethods defines the Access-Control-Request-Method
+                      values sent in preflight response.
+                    items:
+                      type: string
+                    type: array
+                  accessControlAllowOriginList:
+                    description: AccessControlAllowOriginList is a list of allowable
+                      origins. Can also be a wildcard origin "*".
+                    items:
+                      type: string
+                    type: array
+                  accessControlAllowOriginListRegex:
+                    description: AccessControlAllowOriginListRegex is a list of allowable
+                      origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    items:
+                      type: string
+                    type: array
+                  accessControlExposeHeaders:
+                    description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
+                      values sent in preflight response.
+                    items:
+                      type: string
+                    type: array
+                  accessControlMaxAge:
+                    description: AccessControlMaxAge defines the time that a preflight
+                      request may be cached.
+                    format: int64
+                    type: integer
+                  addVaryHeader:
+                    description: AddVaryHeader defines whether the Vary header is
+                      automatically added/updated when the AccessControlAllowOriginList
+                      is set.
+                    type: boolean
+                  allowedHosts:
+                    description: AllowedHosts defines the fully qualified list of
+                      allowed domain names.
+                    items:
+                      type: string
+                    type: array
+                  browserXssFilter:
+                    description: BrowserXSSFilter defines whether to add the X-XSS-Protection
+                      header with the value 1; mode=block.
+                    type: boolean
+                  contentSecurityPolicy:
+                    description: ContentSecurityPolicy defines the Content-Security-Policy
+                      header value.
+                    type: string
+                  contentTypeNosniff:
+                    description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
+                      header with the nosniff value.
+                    type: boolean
+                  customBrowserXSSValue:
+                    description: CustomBrowserXSSValue defines the X-XSS-Protection
+                      header value. This overrides the BrowserXssFilter option.
+                    type: string
+                  customFrameOptionsValue:
+                    description: CustomFrameOptionsValue defines the X-Frame-Options
+                      header value. This overrides the FrameDeny option.
+                    type: string
+                  customRequestHeaders:
+                    additionalProperties:
+                      type: string
+                    description: CustomRequestHeaders defines the header names and
+                      values to apply to the request.
+                    type: object
+                  customResponseHeaders:
+                    additionalProperties:
+                      type: string
+                    description: CustomResponseHeaders defines the header names and
+                      values to apply to the response.
+                    type: object
+                  featurePolicy:
+                    description: 'Deprecated: use PermissionsPolicy instead.'
+                    type: string
+                  forceSTSHeader:
+                    description: ForceSTSHeader defines whether to add the STS header
+                      even when the connection is HTTP.
+                    type: boolean
+                  frameDeny:
+                    description: FrameDeny defines whether to add the X-Frame-Options
+                      header with the DENY value.
+                    type: boolean
+                  hostsProxyHeaders:
+                    description: HostsProxyHeaders defines the header keys that may
+                      hold a proxied hostname value for the request.
+                    items:
+                      type: string
+                    type: array
+                  isDevelopment:
+                    description: IsDevelopment defines whether to mitigate the unwanted
+                      effects of the AllowedHosts, SSL, and STS options when developing.
+                      Usually testing takes place using HTTP, not HTTPS, and on localhost,
+                      not your production domain. If you would like your development
+                      environment to mimic production with complete Host blocking,
+                      SSL redirects, and STS headers, leave this as false.
+                    type: boolean
+                  permissionsPolicy:
+                    description: PermissionsPolicy defines the Permissions-Policy
+                      header value. This allows sites to control browser features.
+                    type: string
+                  publicKey:
+                    description: PublicKey is the public key that implements HPKP
+                      to prevent MITM attacks with forged certificates.
+                    type: string
+                  referrerPolicy:
+                    description: ReferrerPolicy defines the Referrer-Policy header
+                      value. This allows sites to control whether browsers forward
+                      the Referer header to other sites.
+                    type: string
+                  sslForceHost:
+                    description: 'Deprecated: use RedirectRegex instead.'
+                    type: boolean
+                  sslHost:
+                    description: 'Deprecated: use RedirectRegex instead.'
+                    type: string
+                  sslProxyHeaders:
+                    additionalProperties:
+                      type: string
+                    description: 'SSLProxyHeaders defines the header keys with associated
+                      values that would indicate a valid HTTPS request. It can be
+                      useful when using other proxies (example: "X-Forwarded-Proto":
+                      "https").'
+                    type: object
+                  sslRedirect:
+                    description: 'Deprecated: use EntryPoint redirection or RedirectScheme
+                      instead.'
+                    type: boolean
+                  sslTemporaryRedirect:
+                    description: 'Deprecated: use EntryPoint redirection or RedirectScheme
+                      instead.'
+                    type: boolean
+                  stsIncludeSubdomains:
+                    description: STSIncludeSubdomains defines whether the includeSubDomains
+                      directive is appended to the Strict-Transport-Security header.
+                    type: boolean
+                  stsPreload:
+                    description: STSPreload defines whether the preload flag is appended
+                      to the Strict-Transport-Security header.
+                    type: boolean
+                  stsSeconds:
+                    description: STSSeconds defines the max-age of the Strict-Transport-Security
+                      header. If set to 0, the header is not set.
+                    format: int64
+                    type: integer
+                type: object
+              inFlightReq:
+                description: 'InFlightReq holds the in-flight request middleware configuration.
+                  This middleware limits the number of requests being processed and
+                  served concurrently. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/inflightreq/'
+                properties:
+                  amount:
+                    description: Amount defines the maximum amount of allowed simultaneous
+                      in-flight request. The middleware responds with HTTP 429 Too
+                      Many Requests if there are already amount requests in progress
+                      (based on the same sourceCriterion strategy).
+                    format: int64
+                    type: integer
+                  sourceCriterion:
+                    description: 'SourceCriterion defines what criterion is used to
+                      group requests as originating from a common source. If several
+                      strategies are defined at the same time, an error will be raised.
+                      If none are set, the default is to use the requestHost. More
+                      info: https://doc.traefik.io/traefik/v2.8/middlewares/http/inflightreq/#sourcecriterion'
+                    properties:
+                      ipStrategy:
+                        description: 'IPStrategy holds the IP strategy configuration
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
+                        properties:
+                          depth:
+                            description: Depth tells Traefik to use the X-Forwarded-For
+                              header and take the IP located at the depth position
+                              (starting from the right).
+                            type: integer
+                          excludedIPs:
+                            description: ExcludedIPs configures Traefik to scan the
+                              X-Forwarded-For header and select the first IP not in
+                              the list.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      requestHeaderName:
+                        description: RequestHeaderName defines the name of the header
+                          used to group incoming requests.
+                        type: string
+                      requestHost:
+                        description: RequestHost defines whether to consider the request
+                          Host as the source.
+                        type: boolean
+                    type: object
+                type: object
+              ipWhiteList:
+                description: 'IPWhiteList holds the IP whitelist middleware configuration.
+                  This middleware accepts / refuses requests based on the client IP.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/'
+                properties:
+                  ipStrategy:
+                    description: 'IPStrategy holds the IP strategy configuration used
+                      by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
+                    properties:
+                      depth:
+                        description: Depth tells Traefik to use the X-Forwarded-For
+                          header and take the IP located at the depth position (starting
+                          from the right).
+                        type: integer
+                      excludedIPs:
+                        description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
+                          header and select the first IP not in the list.
+                        items:
                           type: string
-                        requestHost:
-                          type: boolean
-                      type: object
-                  type: object
-                redirectRegex:
-                  description: RedirectRegex holds the redirection configuration.
-                  properties:
-                    permanent:
-                      type: boolean
-                    regex:
+                        type: array
+                    type: object
+                  sourceRange:
+                    description: SourceRange defines the set of allowed IPs (or ranges
+                      of allowed IPs by using CIDR notation).
+                    items:
                       type: string
-                    replacement:
-                      type: string
-                  type: object
-                redirectScheme:
-                  description: RedirectScheme holds the scheme redirection configuration.
-                  properties:
-                    permanent:
-                      type: boolean
-                    port:
-                      type: string
-                    scheme:
-                      type: string
-                  type: object
-                replacePath:
-                  description: ReplacePath holds the ReplacePath configuration.
-                  properties:
-                    path:
-                      type: string
-                  type: object
-                replacePathRegex:
-                  description: ReplacePathRegex holds the ReplacePathRegex configuration.
-                  properties:
-                    regex:
-                      type: string
-                    replacement:
-                      type: string
-                  type: object
-                retry:
-                  description: Retry holds the retry configuration.
-                  properties:
-                    attempts:
-                      type: integer
-                    initialInterval:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      x-kubernetes-int-or-string: true
-                  type: object
-                stripPrefix:
-                  description: StripPrefix holds the StripPrefix configuration.
-                  properties:
-                    forceSlash:
-                      type: boolean
-                    prefixes:
-                      items:
+                    type: array
+                type: object
+              passTLSClientCert:
+                description: 'PassTLSClientCert holds the pass TLS client cert middleware
+                  configuration. This middleware adds the selected data from the passed
+                  client TLS certificate to a header. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/passtlsclientcert/'
+                properties:
+                  info:
+                    description: Info selects the specific client certificate details
+                      you want to add to the X-Forwarded-Tls-Client-Cert-Info header.
+                    properties:
+                      issuer:
+                        description: Issuer defines the client certificate issuer
+                          details to add to the X-Forwarded-Tls-Client-Cert-Info header.
+                        properties:
+                          commonName:
+                            description: CommonName defines whether to add the organizationalUnit
+                              information into the issuer.
+                            type: boolean
+                          country:
+                            description: Country defines whether to add the country
+                              information into the issuer.
+                            type: boolean
+                          domainComponent:
+                            description: DomainComponent defines whether to add the
+                              domainComponent information into the issuer.
+                            type: boolean
+                          locality:
+                            description: Locality defines whether to add the locality
+                              information into the issuer.
+                            type: boolean
+                          organization:
+                            description: Organization defines whether to add the organization
+                              information into the issuer.
+                            type: boolean
+                          province:
+                            description: Province defines whether to add the province
+                              information into the issuer.
+                            type: boolean
+                          serialNumber:
+                            description: SerialNumber defines whether to add the serialNumber
+                              information into the issuer.
+                            type: boolean
+                        type: object
+                      notAfter:
+                        description: NotAfter defines whether to add the Not After
+                          information from the Validity part.
+                        type: boolean
+                      notBefore:
+                        description: NotBefore defines whether to add the Not Before
+                          information from the Validity part.
+                        type: boolean
+                      sans:
+                        description: Sans defines whether to add the Subject Alternative
+                          Name information from the Subject Alternative Name part.
+                        type: boolean
+                      serialNumber:
+                        description: SerialNumber defines whether to add the client
+                          serialNumber information.
+                        type: boolean
+                      subject:
+                        description: Subject defines the client certificate subject
+                          details to add to the X-Forwarded-Tls-Client-Cert-Info header.
+                        properties:
+                          commonName:
+                            description: CommonName defines whether to add the organizationalUnit
+                              information into the subject.
+                            type: boolean
+                          country:
+                            description: Country defines whether to add the country
+                              information into the subject.
+                            type: boolean
+                          domainComponent:
+                            description: DomainComponent defines whether to add the
+                              domainComponent information into the subject.
+                            type: boolean
+                          locality:
+                            description: Locality defines whether to add the locality
+                              information into the subject.
+                            type: boolean
+                          organization:
+                            description: Organization defines whether to add the organization
+                              information into the subject.
+                            type: boolean
+                          organizationalUnit:
+                            description: OrganizationalUnit defines whether to add
+                              the organizationalUnit information into the subject.
+                            type: boolean
+                          province:
+                            description: Province defines whether to add the province
+                              information into the subject.
+                            type: boolean
+                          serialNumber:
+                            description: SerialNumber defines whether to add the serialNumber
+                              information into the subject.
+                            type: boolean
+                        type: object
+                    type: object
+                  pem:
+                    description: PEM sets the X-Forwarded-Tls-Client-Cert header with
+                      the escaped certificate.
+                    type: boolean
+                type: object
+              plugin:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: 'Plugin defines the middleware plugin configuration.
+                  More info: https://doc.traefik.io/traefik/plugins/'
+                type: object
+              rateLimit:
+                description: 'RateLimit holds the rate limit configuration. This middleware
+                  ensures that services will receive a fair amount of requests, and
+                  allows one to define what fair is. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ratelimit/'
+                properties:
+                  average:
+                    description: Average is the maximum rate, by default in requests/s,
+                      allowed for the given source. It defaults to 0, which means
+                      no rate limiting. The rate is actually defined by dividing Average
+                      by Period. So for a rate below 1req/s, one needs to define a
+                      Period larger than a second.
+                    format: int64
+                    type: integer
+                  burst:
+                    description: Burst is the maximum number of requests allowed to
+                      arrive in the same arbitrarily small period of time. It defaults
+                      to 1.
+                    format: int64
+                    type: integer
+                  period:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'Period, in combination with Average, defines the
+                      actual maximum rate, such as: r = Average / Period. It defaults
+                      to a second.'
+                    x-kubernetes-int-or-string: true
+                  sourceCriterion:
+                    description: SourceCriterion defines what criterion is used to
+                      group requests as originating from a common source. If several
+                      strategies are defined at the same time, an error will be raised.
+                      If none are set, the default is to use the request's remote
+                      address field (as an ipStrategy).
+                    properties:
+                      ipStrategy:
+                        description: 'IPStrategy holds the IP strategy configuration
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
+                        properties:
+                          depth:
+                            description: Depth tells Traefik to use the X-Forwarded-For
+                              header and take the IP located at the depth position
+                              (starting from the right).
+                            type: integer
+                          excludedIPs:
+                            description: ExcludedIPs configures Traefik to scan the
+                              X-Forwarded-For header and select the first IP not in
+                              the list.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      requestHeaderName:
+                        description: RequestHeaderName defines the name of the header
+                          used to group incoming requests.
                         type: string
-                      type: array
-                  type: object
-                stripPrefixRegex:
-                  description: StripPrefixRegex holds the StripPrefixRegex configuration.
-                  properties:
-                    regex:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                      requestHost:
+                        description: RequestHost defines whether to consider the request
+                          Host as the source.
+                        type: boolean
+                    type: object
+                type: object
+              redirectRegex:
+                description: 'RedirectRegex holds the redirect regex middleware configuration.
+                  This middleware redirects a request using regex matching and replacement.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/redirectregex/#regex'
+                properties:
+                  permanent:
+                    description: Permanent defines whether the redirection is permanent
+                      (301).
+                    type: boolean
+                  regex:
+                    description: Regex defines the regex used to match and capture
+                      elements from the request URL.
+                    type: string
+                  replacement:
+                    description: Replacement defines how to modify the URL to have
+                      the new target URL.
+                    type: string
+                type: object
+              redirectScheme:
+                description: 'RedirectScheme holds the redirect scheme middleware
+                  configuration. This middleware redirects requests from a scheme/port
+                  to another. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/redirectscheme/'
+                properties:
+                  permanent:
+                    description: Permanent defines whether the redirection is permanent
+                      (301).
+                    type: boolean
+                  port:
+                    description: Port defines the port of the new URL.
+                    type: string
+                  scheme:
+                    description: Scheme defines the scheme of the new URL.
+                    type: string
+                type: object
+              replacePath:
+                description: 'ReplacePath holds the replace path middleware configuration.
+                  This middleware replaces the path of the request URL and store the
+                  original path in an X-Replaced-Path header. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/replacepath/'
+                properties:
+                  path:
+                    description: Path defines the path to use as replacement in the
+                      request URL.
+                    type: string
+                type: object
+              replacePathRegex:
+                description: 'ReplacePathRegex holds the replace path regex middleware
+                  configuration. This middleware replaces the path of a URL using
+                  regex matching and replacement. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/replacepathregex/'
+                properties:
+                  regex:
+                    description: Regex defines the regular expression used to match
+                      and capture the path from the request URL.
+                    type: string
+                  replacement:
+                    description: Replacement defines the replacement path format,
+                      which can include captured variables.
+                    type: string
+                type: object
+              retry:
+                description: 'Retry holds the retry middleware configuration. This
+                  middleware reissues requests a given number of times to a backend
+                  server if that server does not reply. As soon as the server answers,
+                  the middleware stops retrying, regardless of the response status.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/retry/'
+                properties:
+                  attempts:
+                    description: Attempts defines how many times the request should
+                      be retried.
+                    type: integer
+                  initialInterval:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: InitialInterval defines the first wait time in the
+                      exponential backoff series. The maximum interval is calculated
+                      as twice the initialInterval. If unspecified, requests will
+                      be retried immediately. The value of initialInterval should
+                      be provided in seconds or as a valid duration format, see https://pkg.go.dev/time#ParseDuration.
+                    x-kubernetes-int-or-string: true
+                type: object
+              stripPrefix:
+                description: 'StripPrefix holds the strip prefix middleware configuration.
+                  This middleware removes the specified prefixes from the URL path.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/stripprefix/'
+                properties:
+                  forceSlash:
+                    description: 'ForceSlash ensures that the resulting stripped path
+                      is not the empty string, by replacing it with / when necessary.
+                      Default: true.'
+                    type: boolean
+                  prefixes:
+                    description: Prefixes defines the prefixes to strip from the request
+                      URL.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              stripPrefixRegex:
+                description: 'StripPrefixRegex holds the strip prefix regex middleware
+                  configuration. This middleware removes the matching prefixes from
+                  the URL path. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/stripprefixregex/'
+                properties:
+                  regex:
+                    description: Regex defines the regular expression to match the
+                      path prefix from the request URL.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/middlewarestcp.yaml
+++ b/traefik/crds/middlewarestcp.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,48 +16,54 @@ spec:
     singular: middlewaretcp
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: MiddlewareTCP is a specification for a MiddlewareTCP resource.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.
+          More info: https://doc.traefik.io/traefik/v2.8/middlewares/overview/'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: MiddlewareTCPSpec holds the MiddlewareTCP configuration.
-              properties:
-                inFlightConn:
-                  description: TCPInFlightConn holds the TCP in flight connection configuration.
-                  properties:
-                    amount:
-                      format: int64
-                      type: integer
-                  type: object
-                ipWhiteList:
-                  description: TCPIPWhiteList holds the TCP ip white list configuration.
-                  properties:
-                    sourceRange:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MiddlewareTCPSpec defines the desired state of a MiddlewareTCP.
+            properties:
+              inFlightConn:
+                description: InFlightConn defines the InFlightConn middleware configuration.
+                properties:
+                  amount:
+                    description: Amount defines the maximum amount of allowed simultaneous
+                      connections. The middleware closes the connection if there are
+                      already amount connections opened.
+                    format: int64
+                    type: integer
+                type: object
+              ipWhiteList:
+                description: IPWhiteList defines the IPWhiteList middleware configuration.
+                properties:
+                  sourceRange:
+                    description: SourceRange defines the allowed IPs (or ranges of
+                      allowed IPs by using CIDR notation).
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/serverstransports.yaml
+++ b/traefik/crds/serverstransports.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,104 +16,110 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ServersTransport is a specification for a ServersTransport resource.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'ServersTransport is the CRD implementation of a ServersTransport.
+          If no serversTransport is specified, the default@internal will be used.
+          The default@internal serversTransport is created from the static configuration.
+          More info: https://doc.traefik.io/traefik/v2.8/routing/services/#serverstransport_1'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ServersTransportSpec options to configure communication between
-                Traefik and the servers.
-              properties:
-                certificatesSecrets:
-                  description: Certificates for mTLS.
-                  items:
-                    type: string
-                  type: array
-                disableHTTP2:
-                  description: Disable HTTP/2 for connections with backend servers.
-                  type: boolean
-                forwardingTimeouts:
-                  description: Timeouts for requests forwarded to the backend servers.
-                  properties:
-                    dialTimeout:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: DialTimeout is the amount of time to wait until a
-                        connection to a backend server can be established. If zero,
-                        no timeout exists.
-                      x-kubernetes-int-or-string: true
-                    idleConnTimeout:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: IdleConnTimeout is the maximum period for which an
-                        idle HTTP keep-alive connection will remain open before closing
-                        itself.
-                      x-kubernetes-int-or-string: true
-                    pingTimeout:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: PingTimeout is the timeout after which the HTTP/2
-                        connection will be closed if a response to ping is not received.
-                      x-kubernetes-int-or-string: true
-                    readIdleTimeout:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: ReadIdleTimeout is the timeout after which a health
-                        check using ping frame will be carried out if no frame is received
-                        on the HTTP/2 connection. If zero, no health check is performed.
-                      x-kubernetes-int-or-string: true
-                    responseHeaderTimeout:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: ResponseHeaderTimeout is the amount of time to wait
-                        for a server's response headers after fully writing the request
-                        (including its body, if any). If zero, no timeout exists.
-                      x-kubernetes-int-or-string: true
-                  type: object
-                insecureSkipVerify:
-                  description: Disable SSL certificate verification.
-                  type: boolean
-                maxIdleConnsPerHost:
-                  description: If non-zero, controls the maximum idle (keep-alive) to
-                    keep per-host. If zero, DefaultMaxIdleConnsPerHost is used.
-                  type: integer
-                peerCertURI:
-                  description: URI used to match against SAN URI during the peer certificate
-                    verification.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServersTransportSpec defines the desired state of a ServersTransport.
+            properties:
+              certificatesSecrets:
+                description: CertificatesSecrets defines a list of secret storing
+                  client certificates for mTLS.
+                items:
                   type: string
-                rootCAsSecrets:
-                  description: Add cert file for self-signed certificate.
-                  items:
-                    type: string
-                  type: array
-                serverName:
-                  description: ServerName used to contact the server.
+                type: array
+              disableHTTP2:
+                description: DisableHTTP2 disables HTTP/2 for connections with backend
+                  servers.
+                type: boolean
+              forwardingTimeouts:
+                description: ForwardingTimeouts defines the timeouts for requests
+                  forwarded to the backend servers.
+                properties:
+                  dialTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: DialTimeout is the amount of time to wait until a
+                      connection to a backend server can be established.
+                    x-kubernetes-int-or-string: true
+                  idleConnTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: IdleConnTimeout is the maximum period for which an
+                      idle HTTP keep-alive connection will remain open before closing
+                      itself.
+                    x-kubernetes-int-or-string: true
+                  pingTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: PingTimeout is the timeout after which the HTTP/2
+                      connection will be closed if a response to ping is not received.
+                    x-kubernetes-int-or-string: true
+                  readIdleTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ReadIdleTimeout is the timeout after which a health
+                      check using ping frame will be carried out if no frame is received
+                      on the HTTP/2 connection.
+                    x-kubernetes-int-or-string: true
+                  responseHeaderTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ResponseHeaderTimeout is the amount of time to wait
+                      for a server's response headers after fully writing the request
+                      (including its body, if any).
+                    x-kubernetes-int-or-string: true
+                type: object
+              insecureSkipVerify:
+                description: InsecureSkipVerify disables SSL certificate verification.
+                type: boolean
+              maxIdleConnsPerHost:
+                description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
+                  to keep per-host.
+                type: integer
+              peerCertURI:
+                description: PeerCertURI defines the peer cert URI used to match against
+                  SAN URI during the peer certificate verification.
+                type: string
+              rootCAsSecrets:
+                description: RootCAsSecrets defines a list of CA secret used to validate
+                  self-signed certificate.
+                items:
                   type: string
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                type: array
+              serverName:
+                description: ServerName defines the server name used to contact the
+                  server.
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,74 +16,94 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: TLSOption is a specification for a TLSOption resource.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'TLSOption is the CRD implementation of a Traefik TLS Option,
+          allowing to configure some parameters of the TLS connection. More info:
+          https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: TLSOptionSpec configures TLS for an entry point.
-              properties:
-                alpnProtocols:
-                  items:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSOptionSpec defines the desired state of a TLSOption.
+            properties:
+              alpnProtocols:
+                description: 'ALPNProtocols defines the list of supported application
+                  level protocols for the TLS handshake, in order of preference. More
+                  info: https://doc.traefik.io/traefik/v2.8/https/tls/#alpn-protocols'
+                items:
+                  type: string
+                type: array
+              cipherSuites:
+                description: 'CipherSuites defines the list of supported cipher suites
+                  for TLS versions up to TLS 1.2. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#cipher-suites'
+                items:
+                  type: string
+                type: array
+              clientAuth:
+                description: ClientAuth defines the server's policy for TLS Client
+                  Authentication.
+                properties:
+                  clientAuthType:
+                    description: ClientAuthType defines the client authentication
+                      type to apply.
+                    enum:
+                    - NoClientCert
+                    - RequestClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - RequireAndVerifyClientCert
                     type: string
-                  type: array
-                cipherSuites:
-                  items:
-                    type: string
-                  type: array
-                clientAuth:
-                  description: ClientAuth defines the parameters of the client authentication
-                    part of the TLS connection, if any.
-                  properties:
-                    clientAuthType:
-                      description: ClientAuthType defines the client authentication
-                        type to apply.
-                      enum:
-                        - NoClientCert
-                        - RequestClientCert
-                        - RequireAnyClientCert
-                        - VerifyClientCertIfGiven
-                        - RequireAndVerifyClientCert
+                  secretNames:
+                    description: SecretNames defines the names of the referenced Kubernetes
+                      Secret storing certificate details.
+                    items:
                       type: string
-                    secretNames:
-                      description: SecretName is the name of the referenced Kubernetes
-                        Secret to specify the certificate details.
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                curvePreferences:
-                  items:
-                    type: string
-                  type: array
-                maxVersion:
+                    type: array
+                type: object
+              curvePreferences:
+                description: 'CurvePreferences defines the preferred elliptic curves
+                  in a specific order. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#curve-preferences'
+                items:
                   type: string
-                minVersion:
-                  type: string
-                preferServerCipherSuites:
-                  type: boolean
-                sniStrict:
-                  type: boolean
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                type: array
+              maxVersion:
+                description: 'MaxVersion defines the maximum TLS version that Traefik
+                  will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12,
+                  VersionTLS13. Default: None.'
+                type: string
+              minVersion:
+                description: 'MinVersion defines the minimum TLS version that Traefik
+                  will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12,
+                  VersionTLS13. Default: VersionTLS10.'
+                type: string
+              preferServerCipherSuites:
+                description: PreferServerCipherSuites defines whether the server chooses
+                  a cipher suite among his own instead of among the client's. It is
+                  enabled automatically when minVersion or maxVersion are set.
+                type: boolean
+              sniStrict:
+                description: SniStrict defines whether Traefik allows connections
+                  from clients connections that do not specify a server_name extension.
+                type: boolean
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/tlsstores.yaml
+++ b/traefik/crds/tlsstores.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,46 +16,60 @@ spec:
     singular: tlsstore
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: TLSStore is a specification for a TLSStore resource.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'TLSStore is the CRD implementation of a Traefik TLS Store. For
+          the time being, only the TLSStore named default is supported. This means
+          that you cannot have two stores that are named default in different Kubernetes
+          namespaces. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#certificates-stores'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: TLSStoreSpec configures a TLSStore resource.
-              properties:
-                defaultCertificate:
-                  description: DefaultCertificate holds a secret name for the TLSOption
-                    resource.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSStoreSpec defines the desired state of a TLSStore.
+            properties:
+              certificates:
+                description: Certificates is a list of secret names, each secret holding
+                  a key/certificate pair to add to the store.
+                items:
+                  description: Certificate holds a secret name for the TLSStore resource.
                   properties:
                     secretName:
                       description: SecretName is the name of the referenced Kubernetes
                         Secret to specify the certificate details.
                       type: string
                   required:
-                    - secretName
+                  - secretName
                   type: object
-              required:
-                - defaultCertificate
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                type: array
+              defaultCertificate:
+                description: DefaultCertificate defines the default certificate configuration.
+                properties:
+                  secretName:
+                    description: SecretName is the name of the referenced Kubernetes
+                      Secret to specify the certificate details.
+                    type: string
+                required:
+                - secretName
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/crds/traefikservices.yaml
+++ b/traefik/crds/traefikservices.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,252 +16,363 @@ spec:
     singular: traefikservice
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: TraefikService is the specification for a service (that an IngressRoute
-            refers to) that is usually not a terminal service (i.e. not a pod of servers),
-            as opposed to a Kubernetes Service. That is to say, it usually refers to
-            other (children) services, which themselves can be TraefikServices or Services.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'TraefikService is the CRD implementation of a Traefik Service.
+          TraefikService object allows to:  - Apply weight to Services on load-balancing  -
+          Mirror traffic on services More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-traefikservice'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ServiceSpec defines whether a TraefikService is a load-balancer
-                of services or a mirroring service.
-              properties:
-                mirroring:
-                  description: Mirroring defines a mirroring service, which is composed
-                    of a main load-balancer, and a list of mirrors.
-                  properties:
-                    kind:
-                      enum:
-                        - Service
-                        - TraefikService
-                      type: string
-                    maxBodySize:
-                      format: int64
-                      type: integer
-                    mirrors:
-                      items:
-                        description: MirrorService defines one of the mirrors of a Mirroring
-                          service.
-                        properties:
-                          kind:
-                            enum:
-                              - Service
-                              - TraefikService
-                            type: string
-                          name:
-                            description: Name is a reference to a Kubernetes Service
-                              object (for a load-balancer of servers), or to a TraefikService
-                              object (service load-balancer, mirroring, etc). The differentiation
-                              between the two is specified in the Kind field.
-                            type: string
-                          namespace:
-                            type: string
-                          passHostHeader:
-                            type: boolean
-                          percent:
-                            type: integer
-                          port:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                          responseForwarding:
-                            description: ResponseForwarding holds configuration for
-                              the forward of the response.
-                            properties:
-                              flushInterval:
-                                type: string
-                            type: object
-                          scheme:
-                            type: string
-                          serversTransport:
-                            type: string
-                          sticky:
-                            description: Sticky holds the sticky configuration.
-                            properties:
-                              cookie:
-                                description: Cookie holds the sticky configuration based
-                                  on cookie.
-                                properties:
-                                  httpOnly:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  sameSite:
-                                    type: string
-                                  secure:
-                                    type: boolean
-                                type: object
-                            type: object
-                          strategy:
-                            type: string
-                          weight:
-                            description: Weight should only be specified when Name references
-                              a TraefikService object (and to be precise, one that embeds
-                              a Weighted Round Robin).
-                            type: integer
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    name:
-                      description: Name is a reference to a Kubernetes Service object
-                        (for a load-balancer of servers), or to a TraefikService object
-                        (service load-balancer, mirroring, etc). The differentiation
-                        between the two is specified in the Kind field.
-                      type: string
-                    namespace:
-                      type: string
-                    passHostHeader:
-                      type: boolean
-                    port:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      x-kubernetes-int-or-string: true
-                    responseForwarding:
-                      description: ResponseForwarding holds configuration for the forward
-                        of the response.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TraefikServiceSpec defines the desired state of a TraefikService.
+            properties:
+              mirroring:
+                description: Mirroring defines the Mirroring service configuration.
+                properties:
+                  kind:
+                    description: Kind defines the kind of the Service.
+                    enum:
+                    - Service
+                    - TraefikService
+                    type: string
+                  maxBodySize:
+                    description: MaxBodySize defines the maximum size allowed for
+                      the body of the request. If the body is larger, the request
+                      is not mirrored. Default value is -1, which means unlimited
+                      size.
+                    format: int64
+                    type: integer
+                  mirrors:
+                    description: Mirrors defines the list of mirrors where Traefik
+                      will duplicate the traffic.
+                    items:
+                      description: MirrorService holds the mirror configuration.
                       properties:
-                        flushInterval:
+                        kind:
+                          description: Kind defines the kind of the Service.
+                          enum:
+                          - Service
+                          - TraefikService
                           type: string
-                      type: object
-                    scheme:
-                      type: string
-                    serversTransport:
-                      type: string
-                    sticky:
-                      description: Sticky holds the sticky configuration.
-                      properties:
-                        cookie:
-                          description: Cookie holds the sticky configuration based on
-                            cookie.
+                        name:
+                          description: Name defines the name of the referenced Kubernetes
+                            Service or TraefikService. The differentiation between
+                            the two is specified in the Kind field.
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
+                          type: string
+                        passHostHeader:
+                          description: PassHostHeader defines whether the client Host
+                            header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
+                          type: boolean
+                        percent:
+                          description: 'Percent defines the part of the traffic to
+                            mirror. Supported values: 0 to 100.'
+                          type: integer
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
+                          x-kubernetes-int-or-string: true
+                        responseForwarding:
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
                           properties:
-                            httpOnly:
-                              type: boolean
-                            name:
+                            flushInterval:
+                              description: 'FlushInterval defines the interval, in
+                                milliseconds, in between flushes to the client while
+                                copying the response body. A negative value means
+                                to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes
+                                a response as a streaming response; for such responses,
+                                writes are flushed to the client immediately. Default:
+                                100ms'
                               type: string
-                            sameSite:
-                              type: string
-                            secure:
-                              type: boolean
                           type: object
+                        scheme:
+                          description: Scheme defines the scheme to use for the request
+                            to the upstream Kubernetes Service. It defaults to https
+                            when Kubernetes Service port is 443, http otherwise.
+                          type: string
+                        serversTransport:
+                          description: ServersTransport defines the name of ServersTransport
+                            resource to use. It allows to configure the transport
+                            between Traefik and your servers. Can only be used on
+                            a Kubernetes Service.
+                          type: string
+                        sticky:
+                          description: 'Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                          properties:
+                            cookie:
+                              description: Cookie defines the sticky cookie configuration.
+                              properties:
+                                httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
+                                  type: boolean
+                                name:
+                                  description: Name defines the Cookie name.
+                                  type: string
+                                sameSite:
+                                  description: 'SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                  type: string
+                                secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
+                                  type: boolean
+                              type: object
+                          type: object
+                        strategy:
+                          description: Strategy defines the load balancing strategy
+                            between the servers. RoundRobin is the only supported
+                            value at the moment.
+                          type: string
+                        weight:
+                          description: Weight defines the weight and should only be
+                            specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
+                          type: integer
+                      required:
+                      - name
                       type: object
-                    strategy:
-                      type: string
-                    weight:
-                      description: Weight should only be specified when Name references
-                        a TraefikService object (and to be precise, one that embeds
-                        a Weighted Round Robin).
-                      type: integer
-                  required:
-                    - name
-                  type: object
-                weighted:
-                  description: WeightedRoundRobin defines a load-balancer of services.
-                  properties:
-                    services:
-                      items:
-                        description: Service defines an upstream to proxy traffic.
+                    type: array
+                  name:
+                    description: Name defines the name of the referenced Kubernetes
+                      Service or TraefikService. The differentiation between the two
+                      is specified in the Kind field.
+                    type: string
+                  namespace:
+                    description: Namespace defines the namespace of the referenced
+                      Kubernetes Service or TraefikService.
+                    type: string
+                  passHostHeader:
+                    description: PassHostHeader defines whether the client Host header
+                      is forwarded to the upstream Kubernetes Service. By default,
+                      passHostHeader is true.
+                    type: boolean
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port defines the port of a Kubernetes Service. This
+                      can be a reference to a named port.
+                    x-kubernetes-int-or-string: true
+                  responseForwarding:
+                    description: ResponseForwarding defines how Traefik forwards the
+                      response from the upstream Kubernetes Service to the client.
+                    properties:
+                      flushInterval:
+                        description: 'FlushInterval defines the interval, in milliseconds,
+                          in between flushes to the client while copying the response
+                          body. A negative value means to flush immediately after
+                          each write to the client. This configuration is ignored
+                          when ReverseProxy recognizes a response as a streaming response;
+                          for such responses, writes are flushed to the client immediately.
+                          Default: 100ms'
+                        type: string
+                    type: object
+                  scheme:
+                    description: Scheme defines the scheme to use for the request
+                      to the upstream Kubernetes Service. It defaults to https when
+                      Kubernetes Service port is 443, http otherwise.
+                    type: string
+                  serversTransport:
+                    description: ServersTransport defines the name of ServersTransport
+                      resource to use. It allows to configure the transport between
+                      Traefik and your servers. Can only be used on a Kubernetes Service.
+                    type: string
+                  sticky:
+                    description: 'Sticky defines the sticky sessions configuration.
+                      More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
                         properties:
-                          kind:
-                            enum:
-                              - Service
-                              - TraefikService
-                            type: string
-                          name:
-                            description: Name is a reference to a Kubernetes Service
-                              object (for a load-balancer of servers), or to a TraefikService
-                              object (service load-balancer, mirroring, etc). The differentiation
-                              between the two is specified in the Kind field.
-                            type: string
-                          namespace:
-                            type: string
-                          passHostHeader:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie can be
+                              accessed by client-side APIs, such as JavaScript.
                             type: boolean
-                          port:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                          responseForwarding:
-                            description: ResponseForwarding holds configuration for
-                              the forward of the response.
-                            properties:
-                              flushInterval:
-                                type: string
-                            type: object
-                          scheme:
+                          name:
+                            description: Name defines the Cookie name.
                             type: string
-                          serversTransport:
+                          sameSite:
+                            description: 'SameSite defines the same site policy. More
+                              info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
                             type: string
-                          sticky:
-                            description: Sticky holds the sticky configuration.
-                            properties:
-                              cookie:
-                                description: Cookie holds the sticky configuration based
-                                  on cookie.
-                                properties:
-                                  httpOnly:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  sameSite:
-                                    type: string
-                                  secure:
-                                    type: boolean
-                                type: object
-                            type: object
-                          strategy:
-                            type: string
-                          weight:
-                            description: Weight should only be specified when Name references
-                              a TraefikService object (and to be precise, one that embeds
-                              a Weighted Round Robin).
-                            type: integer
-                        required:
-                          - name
+                          secure:
+                            description: Secure defines whether the cookie can only
+                              be transmitted over an encrypted connection (i.e. HTTPS).
+                            type: boolean
                         type: object
-                      type: array
-                    sticky:
-                      description: Sticky holds the sticky configuration.
+                    type: object
+                  strategy:
+                    description: Strategy defines the load balancing strategy between
+                      the servers. RoundRobin is the only supported value at the moment.
+                    type: string
+                  weight:
+                    description: Weight defines the weight and should only be specified
+                      when Name references a TraefikService object (and to be precise,
+                      one that embeds a Weighted Round Robin).
+                    type: integer
+                required:
+                - name
+                type: object
+              weighted:
+                description: Weighted defines the Weighted Round Robin configuration.
+                properties:
+                  services:
+                    description: Services defines the list of Kubernetes Service and/or
+                      TraefikService to load-balance, with weight.
+                    items:
+                      description: Service defines an upstream HTTP service to proxy
+                        traffic to.
                       properties:
-                        cookie:
-                          description: Cookie holds the sticky configuration based on
-                            cookie.
+                        kind:
+                          description: Kind defines the kind of the Service.
+                          enum:
+                          - Service
+                          - TraefikService
+                          type: string
+                        name:
+                          description: Name defines the name of the referenced Kubernetes
+                            Service or TraefikService. The differentiation between
+                            the two is specified in the Kind field.
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
+                          type: string
+                        passHostHeader:
+                          description: PassHostHeader defines whether the client Host
+                            header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
+                          type: boolean
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
+                          x-kubernetes-int-or-string: true
+                        responseForwarding:
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
                           properties:
-                            httpOnly:
-                              type: boolean
-                            name:
+                            flushInterval:
+                              description: 'FlushInterval defines the interval, in
+                                milliseconds, in between flushes to the client while
+                                copying the response body. A negative value means
+                                to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes
+                                a response as a streaming response; for such responses,
+                                writes are flushed to the client immediately. Default:
+                                100ms'
                               type: string
-                            sameSite:
-                              type: string
-                            secure:
-                              type: boolean
                           type: object
+                        scheme:
+                          description: Scheme defines the scheme to use for the request
+                            to the upstream Kubernetes Service. It defaults to https
+                            when Kubernetes Service port is 443, http otherwise.
+                          type: string
+                        serversTransport:
+                          description: ServersTransport defines the name of ServersTransport
+                            resource to use. It allows to configure the transport
+                            between Traefik and your servers. Can only be used on
+                            a Kubernetes Service.
+                          type: string
+                        sticky:
+                          description: 'Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                          properties:
+                            cookie:
+                              description: Cookie defines the sticky cookie configuration.
+                              properties:
+                                httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
+                                  type: boolean
+                                name:
+                                  description: Name defines the Cookie name.
+                                  type: string
+                                sameSite:
+                                  description: 'SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                  type: string
+                                secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
+                                  type: boolean
+                              type: object
+                          type: object
+                        strategy:
+                          description: Strategy defines the load balancing strategy
+                            between the servers. RoundRobin is the only supported
+                            value at the moment.
+                          type: string
+                        weight:
+                          description: Weight defines the weight and should only be
+                            specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
+                          type: integer
+                      required:
+                      - name
                       type: object
-                  type: object
-              type: object
-          required:
-            - metadata
-            - spec
-          type: object
-      served: true
-      storage: true
+                    type: array
+                  sticky:
+                    description: 'Sticky defines whether sticky sessions are enabled.
+                      More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#stickiness-and-load-balancing'
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
+                        properties:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie can be
+                              accessed by client-side APIs, such as JavaScript.
+                            type: boolean
+                          name:
+                            description: Name defines the Cookie name.
+                            type: string
+                          sameSite:
+                            description: 'SameSite defines the same site policy. More
+                              info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                            type: string
+                          secure:
+                            description: Secure defines whether the cookie can only
+                              be transmitted over an encrypted connection (i.e. HTTPS).
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:2.7.1
+          value: traefik:2.8.0
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:2.7.1
+          value: traefik/traefik:2.8.0
 
   - it: should have no resource limit by default
     asserts:


### PR DESCRIPTION
### What does this PR do?

This pull request updates the Traefik version to [`v2.8.0`](https://github.com/traefik/traefik/releases/tag/v2.8.0).

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)