### PR TITLE
Suggest an alternative port for metrics

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.24.4
+version: 10.24.5
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -344,10 +344,9 @@ ports:
       #     - foo.example.com
       #     - bar.example.com
   metrics:
-    port: 9100
     # When using hostNetwork, use another port to avoid conflict with node exporter:
     # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
-    # port: 9982
+    port: 9100
     # hostPort: 9100
     # Defines whether the port is exposed if service.type is LoadBalancer or
     # NodePort.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -345,6 +345,9 @@ ports:
       #     - bar.example.com
   metrics:
     port: 9100
+    # When using hostNetwork, use another port to avoid conflict with node exporter:
+    # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+    # port: 9982
     # hostPort: 9100
     # Defines whether the port is exposed if service.type is LoadBalancer or
     # NodePort.


### PR DESCRIPTION
When using hostNetwork and metrics default port (9100), there can be a conflict with node exporter which is also listening on this port. Therefore, an alternative port has been reserved (https://github.com/prometheus/prometheus/wiki/Default-port-allocations). This PR adds a comment suggesting to use this port in the values file.
