### PR TITLE
add namespaceOverride template to manifests

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.24.0
+version: 10.24.1
 appVersion: 2.8.0
 keywords:
   - traefik

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -8,6 +8,17 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "traefik.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "traefik.chart" -}}
@@ -46,7 +57,7 @@ service generated.
 Users can provide an override for an explicit service they want bound via `.Values.providers.kubernetesIngress.publishedService.pathOverride`
 */}}
 {{- define "providers.kubernetesIngress.publishedServicePath" -}}
-{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "traefik.fullname" .) -}}
+{{- $defServiceName := printf "%s/%s" (include "traefik.namespace" .) (include "traefik.fullname" .) -}}
 {{- $servicePath := default $defServiceName .Values.providers.kubernetesIngress.publishedService.pathOverride }}
 {{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}
@@ -55,8 +66,8 @@ Users can provide an override for an explicit service they want bound via `.Valu
 Construct a comma-separated list of whitelisted namespaces
 */}}
 {{- define "providers.kubernetesIngress.namespaces" -}}
-{{- default .Release.Namespace (join "," .Values.providers.kubernetesIngress.namespaces) }}
+{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngress.namespaces) }}
 {{- end -}}
 {{- define "providers.kubernetesCRD.namespaces" -}}
-{{- default .Release.Namespace (join "," .Values.providers.kubernetesCRD.namespaces) }}
+{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesCRD.namespaces) }}
 {{- end -}}

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -15,6 +15,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -3,6 +3,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
+  namespace: {{ template "traefik.namespace" . }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     {{- with .Values.ingressRoute.dashboard.annotations }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -17,6 +17,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   name: traefik-gateway
-  namespace: {{ default template "traefik.namespace" . .Values.experimental.kubernetesGateway.namespace }}
+  namespace: {{ .Values.experimental.kubernetesGateway.namespace | default (include "traefik.namespace" .) }}
 spec:
   gatewayClassName: traefik
   listeners:

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   name: traefik-gateway
-  namespace: {{ default .Release.Namespace .Values.experimental.kubernetesGateway.namespace }}
+  namespace: {{ default template "traefik.namespace" . .Values.experimental.kubernetesGateway.namespace }}
 spec:
   gatewayClassName: traefik
   listeners:

--- a/traefik/templates/hpa.yaml
+++ b/traefik/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/poddisruptionbudget.yaml
+++ b/traefik/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/pvc.yaml
+++ b/traefik/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
   annotations:
   {{- with .Values.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -56,7 +56,7 @@ rules:
   - apiGroups:
       - policy
     resourceNames:
-      - {{ template "traefik.fullname" . }}
+      - {{ template "traefik.namespace" . }}
     resources:
       - podsecuritypolicies
     verbs:

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "traefik.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "traefik.namespace" . }}
 {{- end -}}

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "traefik.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "traefik.namespace" . }}
 {{- end -}}

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "traefik.serviceAccountName" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -15,6 +15,7 @@ apiVersion: v1
 kind: List
 metadata:
   name: {{ template "traefik.fullname" . }}
+  namespace: {{ template "traefik.namespace" . }}
 items:
 {{- if $tcpPorts }}
   - apiVersion: v1

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -22,6 +22,7 @@ items:
     kind: Service
     metadata:
       name: {{ template "traefik.fullname" . }}
+      namespace: {{ template "traefik.namespace" . }}
       labels:
         app.kubernetes.io/name: {{ template "traefik.name" . }}
         helm.sh/chart: {{ template "traefik.chart" . }}

--- a/traefik/templates/tlsoption.yaml
+++ b/traefik/templates/tlsoption.yaml
@@ -3,6 +3,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: TLSOption
 metadata:
   name: {{ $name }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" $ }}
     helm.sh/chart: {{ template "traefik.chart" $ }}


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds a way to override namespace for Traefik helm chart if it is being used as dependency in another helm (umbrella) chart.


### Motivation

<!-- What inspired you to submit this pull request? -->
Traefik is a great thing, and it should be easy to include it as dependency for other projects.


### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

<!-- Anything else we should know when reviewing? -->
```
$ helm template --set namespaceOverride=yaegi . | kubeval --ignore-missing-schemas
WARN - Set to ignore missing schemas
PASS - traefik/templates/rbac/serviceaccount.yaml contains a valid ServiceAccount (release-name-traefik)
PASS - traefik/templates/rbac/clusterrole.yaml contains a valid ClusterRole (release-name-traefik)
PASS - traefik/templates/rbac/clusterrolebinding.yaml contains a valid ClusterRoleBinding (release-name-traefik)
PASS - traefik/templates/deployment.yaml contains a valid Deployment (yaegi.release-name-traefik)
WARN - traefik/templates/dashboard-hook-ingressroute.yaml containing a IngressRoute (yaegi.release-name-traefik-dashboard) was not validated against a schema
PASS - traefik/templates/dashboard-hook-ingressroute.yaml contains a valid Service (release-name-traefik)
$
```