### PR TITLE
feat: add lifecycle for prestop and poststart

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.27.0
+version: 10.28.0
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -55,6 +55,10 @@
             path: /ping
             port: {{ default .Values.ports.traefik.port .Values.ports.traefik.healthchecksPort }}
           {{- toYaml .Values.livenessProbe | nindent 10 }}
+        lifecycle:
+          {{- with .Values.deployment.lifecycle }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -61,3 +61,39 @@ tests:
       - equal:
           path: spec.revisionHistoryLimit
           value: 1
+  - it: should have a preStop hook with specified values
+    set:
+      deployment:
+        kind: DaemonSet
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 40"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 40"]
+  - it: should have a postStart hook with specified values
+    set:
+      deployment:
+        kind: DaemonSet
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /ping
+              port: 9000
+              host: localhost
+              scheme: HTTP
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.host
+          value: localhost
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.scheme
+          value: HTTP

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -88,3 +88,37 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 30
+  - it: should have a preStop hook with specified values
+    set:
+      deployment:
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 40"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 40"]
+  - it: should have a postStart hook with specified values
+    set:
+      deployment:
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /ping
+              port: 9000
+              host: localhost
+              scheme: HTTP
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.host
+          value: localhost
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.httpGet.scheme
+          value: HTTP

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -59,6 +59,17 @@ deployment:
   # Additional imagePullSecrets
   imagePullSecrets: []
     # - name: myRegistryKeySecretName
+  # Pod lifecycle actions
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "sleep 40"]
+    # postStart:
+    #   httpGet:
+    #     path: /ping
+    #     port: 9000
+    #     host: localhost
+    #     scheme: HTTP
 
 # Pod disruption budget
 podDisruptionBudget:


### PR DESCRIPTION
### What does this PR do?

Add the lifecycle property to the pod template.

### Motivation

In order to allow minimal downtime, we need to setup a preStop command on our Traefik deployments.

```yaml
        lifecycle:
          preStop:
            exec:
              command:
              - /bin/sh
              - -c
              - sleep 40
```

### More

- [X] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

This PR is based on this [one](https://github.com/traefik/traefik-helm-chart/pull/567), but we only need the lifecycle configuration.