### PR TITLE
:bug: Fix ingressClass support when rbac.namespaced=true (#499)

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.25.1
+version: 10.26.0
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.rbac.enabled (not .Values.rbac.namespaced) -}}
+{{- if .Values.rbac.enabled -}}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,6 +10,16 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+{{- if not .Values.rbac.namespaced -}}
   - apiGroups:
       - ""
     resources:
@@ -24,7 +35,6 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
-      - ingressclasses
     verbs:
       - get
       - list
@@ -92,5 +102,6 @@ rules:
       - tlsroutes/status
     verbs:
       - update
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.rbac.enabled (not .Values.rbac.namespaced) }}
+{{- if .Values.rbac.enabled -}}
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -24,7 +24,6 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
-      - ingressclasses
     verbs:
       - get
       - list

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -57,12 +57,19 @@ tests:
       - isKind:
           of: RoleBinding
         template: rbac/rolebinding.yaml
-      - hasDocuments:
-          count: 0
+      - notContains:
+          path: rules
+          content:
+            - apiGroups:
+                - extensions
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - get
+                - list
+                - watch
         template: rbac/clusterrole.yaml
-      - hasDocuments:
-          count: 0
-        template: rbac/clusterrolebinding.yaml
   - it: should use existing ServiceAccount
     set:
       serviceAccount:


### PR DESCRIPTION
### What does this PR do?

Fix ingressClass support when rbac.namespaced=true

### Motivation

It works out of the box as expected

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)