### PR TITLE
Support setting dashboard entryPoints for ingressRoute resource

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.30.1
+version: 10.30.2
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -18,7 +18,9 @@ metadata:
     {{- end }}
 spec:
   entryPoints:
-    - traefik
+  {{- range .Values.ingressRoute.dashboard.entryPoints }}
+  - {{ .  | nindent 4 }}
+  {{ end }}
   routes:
   - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
     kind: Rule

--- a/traefik/tests/dashboard-hook-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-hook-ingressroute_test.yaml
@@ -1,0 +1,26 @@
+suite: Dashboard IngressRoute configuration
+templates:
+  - dashboard-hook-ingressroute.yaml
+tests:
+  - it: should allow disabling dashboard exposure using ingressRoute
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should have traefik as default entryPoints
+    asserts:
+      - equal:
+          path: spec.entryPoints
+          value: ["traefik"]
+  - it: should support setting websecure as entryPoint
+    set:
+      ingressRoute:
+        dashboard:
+          entryPoints: ["websecure"]      
+    asserts:
+      - equal:
+          path: spec.entryPoints
+          value: ["websecure"]

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -120,6 +120,8 @@ ingressRoute:
     annotations: {}
     # Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)
     labels: {}
+    # Specify the target containers for the dashboard ingress route, (e.g. traefik, web, websecure).
+    entryPoints: ["traefik"]
 
 rollingUpdate:
   maxUnavailable: 1


### PR DESCRIPTION
### What does this PR do?

This allows overriding `entryPoints` when the dashboard is to be exposed over `web` , or `websecure`.

### Motivation

In certain cases, people need to expose the dashboard through `web` 80 or `websecure` 443. 
It's not feasible through `values.yaml` as it not available, thus requires applying it manually as specified in README. 

This makes it difficult to manage when used as dependency. 
For example [k3s auto-updating `HelmChart` CRD](https://rancher.com/docs/k3s/latest/en/helm/#using-the-helm-crd) would override the configured values back to the fixed default`traefik`. 
[See this](https://forums.rancher.com/t/traefik-dashboard-404/36180/2).


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

- [x] Added unit tests, and all test suite is passing:
<details>
  <summary>Tests output</summary>

```bash
== Cleaning...
== Cleaning Finished
== Checking global requirements...
== Checking requirements for linting...
== Requirements for linting are met.
== Linting Chart...
Linting charts...
>>> helm version --template {{ .Version }}
>>> git rev-parse --is-inside-work-tree
>>> git merge-base traefik/master HEAD
>>> git diff --find-renames --name-only 803a973ef9c1055a0a6e889623c8d2451733f362 -- ./

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 traefik => (version: "10.30.2", path: "traefik")
------------------------------------------------------------------------------------------------------------------------

>>> helm dependency build traefik
Linting chart "traefik => (version: \"10.30.2\", path: \"traefik\")"
Checking chart "traefik => (version: \"10.30.2\", path: \"traefik\")" for a version bump...
>>> git cat-file -e traefik/master:traefik/Chart.yaml
>>> git show traefik/master:traefik/Chart.yaml
Old chart version: 10.30.1
New chart version: 10.30.2
Chart version ok.
>>> yamale --schema chart_schema.yaml traefik/Chart.yaml
Validating ~/lab/traefik-helm-chart/traefik/Chart.yaml...
Validation success! 👍
>>> yamllint --config-file lintconf.yaml traefik/Chart.yaml
>>> yamllint --config-file lintconf.yaml traefik/values.yaml
Validating maintainers...
>>> git ls-remote --get-url traefik
>>> helm lint traefik
==> Linting traefik

1 chart(s) linted, 0 chart(s) failed
------------------------------------------------------------------------------------------------------------------------
 ✔︎ traefik => (version: "10.30.2", path: "traefik")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
== Linting Finished
== Checking that plugin helm-unittest is available...
== plugin helm-unittest is ready
== Unit Testing Chart...

### Chart [ traefik ] ./traefik

 PASS  Main Container configuration	traefik/tests/container-config_test.yaml
 PASS  DaemonSet configuration	traefik/tests/daemonset-config_test.yaml
 PASS  Dashboard IngressRoute configuration	traefik/tests/dashboard-hook-ingressroute_test.yaml
 PASS  default install	traefik/tests/default-install_test.yaml
 PASS  Deployment configuration	traefik/tests/deployment-config_test.yaml
 PASS  Gateway configuration	traefik/tests/gateway-config_test.yaml
 PASS  GatewayClass configuration	traefik/tests/gatewayclass-config_test.yaml
 PASS  Pod configuration	traefik/tests/pod-config_test.yaml
 PASS  PodDisruptionBudget configuration	traefik/tests/poddisruptionbudget-config_test.yaml
 PASS  PodSecurityPolicy configuration	traefik/tests/podsecuritypolicy-config_test.yaml
 PASS  Traefik configuration	traefik/tests/ports-config_test.yaml
 PASS  RBAC configuration	traefik/tests/rbac-config_test.yaml
 PASS  Service configuration	traefik/tests/service-config_test.yaml
 PASS  Traefik configuration	traefik/tests/traefik-config_test.yaml

Charts:      1 passed, 1 total
Test Suites: 14 passed, 14 total
Tests:       127 passed, 127 total
Snapshot:    0 passed, 0 total
Time:        752.954952ms

== Unit Tests Finished...
== Building Chart...
Successfully packaged chart and saved it to: ~/lab/traefik-helm-chart/dist/traefik-10.30.2.tgz
...
```
</details>

### Additional Notes

Thank you!