### PR TITLE
:test_tube: Fail gracefully when asked to provide a service without ports

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.30.1
+version: 10.30.2
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -2,6 +2,7 @@
 
 {{ $tcpPorts := dict }}
 {{ $udpPorts := dict }}
+{{ $exposedPorts := false }}
 {{- range $name, $config := .Values.ports }}
   {{- if or $config.http3 (eq (toString $config.protocol) "UDP") }}
     {{ $_ := set $udpPorts $name $config }}
@@ -9,6 +10,13 @@
   {{- if eq (toString (default "TCP" $config.protocol)) "TCP" }}
     {{ $_ := set $tcpPorts $name $config }}
   {{- end }}
+  {{- if (eq $config.expose true) }}
+    {{ $exposedPorts = true }}
+  {{- end }}
+{{- end }}
+
+{{- if (eq $exposedPorts false) }}
+  {{ fail "You need to expose at least one port or set enabled=false to service" }}
 {{- end }}
 
 apiVersion: v1

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -268,3 +268,13 @@ tests:
     - equal:
         path: items[1].spec.ports[0].protocol
         value: UDP
+  - it: should fail when there is no exposed port
+    set:
+      ports:
+        web:
+          expose: false
+        websecure:
+          expose: false
+    asserts:
+    - failedTemplate:
+        errorMessage: "You need to expose at least one port or set enabled=false to service"


### PR DESCRIPTION
### What does this PR do?

Fail gracefully when asked to provide a service and there are no ports to expose

### Motivation

Fix #641

### More

- [ ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)


