### PR TITLE
:rocket: Add `extraObjects` value that allows creating adhoc resources

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 10.32.0
+version: 10.33.0
 appVersion: 2.8.7
 keywords:
   - traefik

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Construct a comma-separated list of whitelisted namespaces
 {{- define "providers.kubernetesCRD.namespaces" -}}
 {{- default .Release.Namespace (join "," .Values.providers.kubernetesCRD.namespaces) }}
 {{- end -}}
+
+{{/*
+Renders a complete tree, even values that contains template.
+*/}}
+{{- define "traefik.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{ else }}
+    {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end -}}

--- a/traefik/templates/extra-objects.yaml
+++ b/traefik/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ include "traefik.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/traefik/tests/extra-config_test.yaml
+++ b/traefik/tests/extra-config_test.yaml
@@ -1,0 +1,20 @@
+suite: Traefik configuration
+templates:
+  - extra-objects.yaml
+tests:
+  - it: should deploy an extra object
+    values:
+      - ./values/extra.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: data.something
+          value: "extra"
+  - it: should render a templated extra object
+    values:
+      - ./values/extra.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: data.something
+          value: "templated"

--- a/traefik/tests/values/extra.yaml
+++ b/traefik/tests/values/extra.yaml
@@ -1,0 +1,14 @@
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: "extra"
+    data:
+      something: "extra"
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: "templated"
+    data:
+      something: {{ printf "templated" }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -598,3 +598,10 @@ securityContext:
 
 podSecurityContext:
   fsGroup: 65532
+
+#
+# Extra objects to deploy (value evaluated as a template)
+#
+# In some cases, it can avoid the need for additional, extended or adhoc deployments.
+# See #595 for more details and traefik/tests/extra.yaml for example.
+extraObjects: []


### PR DESCRIPTION
### What does this PR do?

It allows to create an extraObjects value, evaluated as a template 
Fix 595

### Motivation

There are some use cases when it's better to add a few more objects as parameters of this Chart instead of using Infra-as-Code.

### More

- [ ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes