### PR TITLE
:goal_net: Fail gracefully when hostNetwork is enabled and hostPort != containerPort

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 12.0.1
+version: 12.0.2
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -64,6 +64,11 @@
         ports:
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}
+          {{- if and $config.hostPort $config.port }}
+            {{- if ne ($config.hostPort | int) ($config.port | int) }}
+              {{- fail "ERROR: All hostPort must match their respective containerPort when `hostNetwork` is enabled" }}
+            {{- end }}
+          {{- end }}
         - name: {{ $name | quote }}
           containerPort: {{ $config.port }}
           {{- if $config.hostPort }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -441,3 +441,16 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.web.http.middlewares="
+  - it: should fail when user want to use hostnetwork with hostport != containerport
+    set:
+      hostNetwork: true
+      ports:
+        websecure:
+          port: 443
+          hostPort: 443
+        web:
+          port: 8081
+          hostPort: 81
+    asserts:
+      - failedTemplate:
+          errorMessage: "All hostPort must match their respective containerPort when `hostNetwork` is enabled"


### PR DESCRIPTION
### What does this PR do?

Fail gracefully when users ask to deploy Traefik with this kind of values.yaml file, which cannot be deployed :
```yaml
    set:
      hostNetwork: true
      ports:
        websecure:
          port: 443
          hostPort: 443
        web:
          port: 8081
          hostPort: 81
```


### Motivation

Fixes #336 #337

### More

- [ ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)
