### PR TITLE
:bug: Should check hostNetwork when hostPort != containerPort

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 12.0.2
+version: 12.0.3
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -62,9 +62,10 @@
           {{- toYaml . | nindent 10 }}
           {{- end }}
         ports:
+        {{ $hostNetwork := .Values.hostNetwork }}
         {{- range $name, $config := .Values.ports }}
         {{- if $config }}
-          {{- if and $config.hostPort $config.port }}
+          {{- if and $hostNetwork (and $config.hostPort $config.port) }}
             {{- if ne ($config.hostPort | int) ($config.port | int) }}
               {{- fail "ERROR: All hostPort must match their respective containerPort when `hostNetwork` is enabled" }}
             {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -454,3 +454,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "All hostPort must match their respective containerPort when `hostNetwork` is enabled"
+  - it: should pass when user want to set hostport != containerport without hostNetwork
+    set:
+      hostNetwork: false
+      ports:
+        websecure:
+          port: 443
+          hostPort: 443
+        web:
+          port: 8081
+          hostPort: 81
+    asserts:
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1


### PR DESCRIPTION
### What does this PR do?

hostNetwork was not checked correctly in#650.

### Motivation

Fixes #651 

### More

- [ ] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

