### PR TITLE
:bug: Ignore kustomization file used for CRDs upgrade

### DIFF
--- a/traefik/.helmignore
+++ b/traefik/.helmignore
@@ -1,1 +1,2 @@
 tests/
+crds/kustomization.yaml

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 12.0.5
+version: 12.0.6
 appVersion: 2.9.1
 keywords:
   - traefik


### PR DESCRIPTION
### What does this PR do?

Ignore kustomization file used for CRDs upgrade.

### Motivation

Helm installation should not fail because of this file.


### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

