### PR TITLE
Merge TCP and UDP ports into a single service

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ kubectl apply --server-side --force-conflicts -k https://github.com/traefik/trae
 
 Note: You can replace `master` with a specific version of this chart, according to your need.
 
+### Upgrading 17.x to 18.x
+
+Since v18.x, this chart by default merges TCP and UDP ports into a single (LoadBalancer) service.
+Load balancers with mixed protocols are in [beta as of Kubernetes v1.24](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types).
+Availability may depend on your Kubernetes provider.
+
+To retain the old default behavior, set `service.single` to `false` in your values.
+
+To support HTTP/3 with a single service, the default exposed port was changed,
+as a service cannot have two ports with same port number but different protocols [due to a bug in Kubernetes](https://github.com/kubernetes/kubernetes/issues/39188).
+
+If you were previously using HTTP/3, you should update your values as follows:
+  - replace the old value (`true`) of `ports.websecure.http3` with a key `expose: true`
+  - if you use a separate UDP service and want to retain the old (exposed) port, set `ports.websecure.http3.exposedPort` to `443`
+
 ## Contributing
 
 If you want to contribute to this chart, please read the [Contributing Guide](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -121,18 +121,23 @@ Note: You can replace `master` with a specific version of this chart, according 
 
 ### Upgrading 17.x to 18.x
 
-Since v18.x, this chart by default merges TCP and UDP ports into a single (LoadBalancer) service.
-Load balancers with mixed protocols are in [beta as of Kubernetes v1.24](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types).
+Since v18.x, this chart by default merges TCP and UDP ports into a single (LoadBalancer) `Service`.
+Load balancers with mixed protocols are available since v1.20 and in 
+[beta as of Kubernetes v1.24](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types).
 Availability may depend on your Kubernetes provider.
 
 To retain the old default behavior, set `service.single` to `false` in your values.
 
-To support HTTP/3 with a single service, the default exposed port was changed,
-as a service cannot have two ports with same port number but different protocols [due to a bug in Kubernetes](https://github.com/kubernetes/kubernetes/issues/39188).
+When using TCP and UDP with a single service, you may encounter
+[this issue](https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741)
+from Kubernetes.
+
+On HTTP/3, if you want to avoid this issue, you can set
+`ports.websecure.http3.advertisedPort` to an other value than `443`
 
 If you were previously using HTTP/3, you should update your values as follows:
-  - replace the old value (`true`) of `ports.websecure.http3` with a key `expose: true`
-  - if you use a separate UDP service and want to retain the old (exposed) port, set `ports.websecure.http3.exposedPort` to `443`
+  - Replace the old value (`true`) of `ports.websecure.http3` with a key `enabled: true`
+  - Remove `experimental.http3.enabled=true` entry
 
 ## Contributing
 

--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,59 @@
 # Change Log
 
+## 18.0.0 
+
+**Release date:** 2022-10-21
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Update Changelog and Chart version 
+* Remove unneeded quote function from port in service template 
+* Fix: http3 config flags should not be enabled by default 
+* Add additional test for exposing http3 without enabling tls 
+* Split service tests based on single vs split service flag 
+* Merge TCP and UDP ports into single service by default 
+* Add service-ports helper to _service.tpl 
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 807bd09..fc5aff3 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -421,10 +421,16 @@ ports:
+     # The port protocol (TCP/UDP)
+     protocol: TCP
+     # nodePort: 32443
+-    # Enable HTTP/3.
+-    # Requires enabling experimental http3 feature and tls.
+-    # Note that you cannot have a UDP entrypoint with the same port.
+-    # http3: true
++    http3:
++      port: 8443
++      # hostPort: 8443
++      # Enable HTTP/3.
++      # Requires enabling experimental http3 feature and tls.
++      expose: false
++      # Note that you cannot have another UDP entrypoint with the same (exposed) port.
++      exposedPort: 8443
++      # The port protocol (TCP/UDP)
++      protocol: UDP
+     # Set TLS at the entrypoint
+     # https://doc.traefik.io/traefik/routing/entrypoints/#tls
+     tls:
+@@ -500,6 +506,7 @@ tlsStore: {}
+ # from.
+ service:
+   enabled: true
++  single: true
+   type: LoadBalancer
+   # Additional annotations applied to both TCP and UDP services (e.g. for cloud provider specific config)
+   annotations: {}
+```
+
 ## 17.0.5 
 
 **Release date:** 2022-10-21

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 17.0.5
+version: 18.0.0
 appVersion: 2.9.1
 keywords:
   - traefik
@@ -25,4 +25,10 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - 📝 Add annotations changelog for artifacthub.io & update Maintainers
+    - Update Changelog and Chart version
+    - Remove unneeded quote function from port in service template
+    - Fix: http3 config flags should not be enabled by default
+    - Add additional test for exposing http3 without enabling tls
+    - Split service tests based on single vs split service flag
+    - Merge TCP and UDP ports into single service by default
+    - Add service-ports helper to _service.tpl

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -25,10 +25,6 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - Update Changelog and Chart version
-    - Remove unneeded quote function from port in service template
-    - Fix: http3 config flags should not be enabled by default
-    - Add additional test for exposing http3 without enabling tls
-    - Split service tests based on single vs split service flag
-    - Merge TCP and UDP ports into single service by default
-    - Add service-ports helper to _service.tpl
+    - Provides single service using `MixedProtocolLBService`, by default.
+    - Dual service is still possible by setting `service.single=false`
+    - Refactor and improve http3 deployments

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -301,9 +301,6 @@
           - "--providers.kubernetesgateway"
           - "--experimental.kubernetesgateway"
           {{- end }}
-          {{- if .Values.experimental.http3.enabled }}
-          - "--experimental.http3=true"
-          {{- end }}
           {{- with .Values.providers.kubernetesCRD }}
           {{- if (and .enabled (or .namespaces (and $.Values.rbac.enabled $.Values.rbac.namespaced))) }}
           - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" $ }}"
@@ -343,9 +340,14 @@
           {{- end }}
           {{- end }}
           {{- if $config.http3 }}
-          {{- if $config.http3.expose }}
+          {{- if $config.http3.enabled }}
+          - "--experimental.http3=true"
           {{- if semverCompare ">=2.6.0" (default $.Chart.AppVersion $.Values.image.tag)}}
-          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.exposedPort }}"
+          {{- if $config.http3.advertisedPort }}
+          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.advertisedPort }}"
+          {{- else }}
+          - "--entrypoints.{{ $entrypoint }}.http3"
+          {{- end }}
           {{- else }}
           - "--entrypoints.{{ $entrypoint }}.enableHTTP3=true"
           {{- end }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -344,7 +344,7 @@
           {{- end }}
           {{- if $config.http3 }}
           {{- if semverCompare ">=2.6.0" (default $.Chart.AppVersion $.Values.image.tag)}}
-          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ default $config.port $config.exposedPort }}"
+          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.exposedPort }}"
           {{- else }}
           - "--entrypoints.{{ $entrypoint }}.enableHTTP3=true"
           {{- end }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -343,10 +343,12 @@
           {{- end }}
           {{- end }}
           {{- if $config.http3 }}
+          {{- if $config.http3.expose }}
           {{- if semverCompare ">=2.6.0" (default $.Chart.AppVersion $.Values.image.tag)}}
           - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.exposedPort }}"
           {{- else }}
           - "--entrypoints.{{ $entrypoint }}.enableHTTP3=true"
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -32,3 +32,17 @@
   {{- toYaml . | nindent 2 }}
   {{- end -}}
 {{- end }}
+
+{{- define "traefik.service-ports" }}
+  {{- range $name, $config := . }}
+  {{- if $config.expose }}
+  - port: {{ default $config.port $config.exposedPort }}
+    name: {{ $name }}
+    targetPort: {{ $name | quote }}
+    protocol: {{ default "TCP" $config.protocol }}
+    {{- if $config.nodePort }}
+    nodePort: {{ $config.nodePort }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -37,8 +37,8 @@
   {{- range $name, $config := . }}
   {{- if $config.expose }}
   - port: {{ default $config.port $config.exposedPort }}
-    name: {{ $name }}
-    targetPort: {{ $name | quote }}
+    name: {{ $name | quote }}
+    targetPort: {{ $name }}
     protocol: {{ default "TCP" $config.protocol }}
     {{- if $config.nodePort }}
     nodePort: {{ $config.nodePort }}

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -44,5 +44,17 @@
     nodePort: {{ $config.nodePort }}
     {{- end }}
   {{- end }}
+  {{- if $config.http3 }}
+  {{- if $config.http3.enabled }}
+  {{- $http3Port := default $config.exposedPort $config.http3.advertisedPort }}
+  - port: {{ $http3Port }}
+    name: "{{ $name }}-http3"
+    targetPort: {{ $config.port }}
+    protocol: UDP
+    {{- if $config.nodePort }}
+    nodePort: {{ $config.nodePort }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -3,21 +3,13 @@
 {{- $tcpPorts := dict -}}
 {{- $udpPorts := dict -}}
 {{- $exposedPorts := false -}}
-{{- $experimentalHttp3Enabled := .Values.experimental.http3.enabled -}}
 {{- range $name, $config := .Values.ports -}}
   {{- if $config.http3 -}}
-    {{- if (and $config.http3.expose (not $config.tls.enabled)) -}}
-      {{- fail "ERROR: You cannot expose http3 without enabling tls" -}}
+  {{- if $config.http3.enabled -}}
+    {{- if (not $config.tls.enabled) -}}
+      {{- fail "ERROR: You cannot enable http3 without enabling tls" -}}
     {{- end -}}
-    {{- if (and $config.http3.expose (not $experimentalHttp3Enabled)) -}}
-      {{- fail "ERROR: You cannot expose http3 port without enabling http3 experimental feature" -}}
-    {{- end -}}
-    {{/* Due to https://github.com/kubernetes/kubernetes/issues/58477 it is not possible
-      to define the HTTP/3 UDP port as a (named) containerPort. TCP and UDP containerPort
-      will have the same value for 'port' which will break the chart upgrade. Therefore
-      we manually refer to port number for HTTP/3. */}}
-    {{- $http3Name := (toString $config.port) }}
-    {{- $_ := set $udpPorts $http3Name $config.http3 -}}
+  {{- end -}}
   {{- end -}}
   {{- if eq (toString $config.protocol) "UDP" -}}
     {{ $_ := set $udpPorts $name $config -}}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -7,7 +7,7 @@
 {{- range $name, $config := .Values.ports -}}
   {{- if $config.http3 -}}
     {{- if (and $config.http3.expose (not $config.tls.enabled)) -}}
-      {{- fail "ERROR: You need to enable tls to expose http3 port" -}}
+      {{- fail "ERROR: You cannot expose http3 without enabling tls" -}}
     {{- end -}}
     {{- if (and $config.http3.expose (not $experimentalHttp3Enabled)) -}}
       {{- fail "ERROR: You cannot expose http3 port without enabling http3 experimental feature" -}}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -1,29 +1,39 @@
 {{- if .Values.service.enabled -}}
 
-{{ $tcpPorts := dict }}
-{{ $udpPorts := dict }}
-{{ $exposedPorts := false }}
+{{- $tcpPorts := dict -}}
+{{- $udpPorts := dict -}}
+{{- $exposedPorts := false -}}
 {{ $experimentalHttp3Enabled := .Values.experimental.http3.enabled }}
-{{- range $name, $config := .Values.ports }}
+{{- range $name, $config := .Values.ports -}}
   {{- if (and $config.http3 (not $experimentalHttp3Enabled)) }}
     {{ fail "ERROR: You cannot use HTTP3 on an entrypoint without enabling http3 experimental feature" }}
   {{- end }}
-  {{- if or $config.http3 (eq (toString $config.protocol) "UDP") }}
-    {{ $_ := set $udpPorts $name $config }}
-  {{- end }}
-  {{- if eq (toString (default "TCP" $config.protocol)) "TCP" }}
-    {{ $_ := set $tcpPorts $name $config }}
-  {{- end }}
-  {{- if (eq $config.expose true) }}
-    {{ $exposedPorts = true }}
-  {{- end }}
-{{- end }}
+  {{- if $config.http3 -}}
+    {{/* Due to https://github.com/kubernetes/kubernetes/issues/58477 it is not possible
+      to define the HTTP/3 UDP port as a (named) containerPort. TCP and UDP containerPort
+      will have the same value for 'port' which will break the chart upgrade. Therefore
+      we manually refer to port number for HTTP/3. */}}
+    {{- $http3Name := (toString $config.port) }}
+    {{- $http3Config := deepCopy $config -}}
+    {{- $http3Config := set $http3Config "protocol" "UDP" -}}
+    {{- $_ := set $udpPorts $http3Name $http3Config -}}
+  {{- end -}}
+  {{- if eq (toString $config.protocol) "UDP" -}}
+    {{ $_ := set $udpPorts $name $config -}}
+  {{- end -}}
+  {{- if eq (toString (default "TCP" $config.protocol)) "TCP" -}}
+    {{ $_ := set $tcpPorts $name $config -}}
+  {{- end -}}
+  {{- if (eq $config.expose true) -}}
+    {{- $exposedPorts = true -}}
+  {{- end -}}
+{{- end -}}
 
-{{- if (eq $exposedPorts false) }}
-  {{ fail "You need to expose at least one port or set enabled=false to service" }}
-{{- end }}
+{{- if (eq $exposedPorts false) -}}
+  {{- fail "You need to expose at least one port or set enabled=false to service" -}}
+{{- end -}}
 
-{{- if  $tcpPorts }}
+{{- if $tcpPorts }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,20 +46,10 @@ metadata:
 spec:
   {{- template "traefik.service-spec" . }}
   ports:
-  {{- range $name, $config := $tcpPorts }}
-  {{- if $config.expose }}
-  - port: {{ default $config.port $config.exposedPort }}
-    name: {{ $name }}
-    targetPort: {{ $name | quote }}
-    protocol: TCP
-    {{- if $config.nodePort }}
-    nodePort: {{ $config.nodePort }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- template "traefik.service-ports" $tcpPorts }}
 {{- end }}
 
-{{- if  $udpPorts }}
+{{- if $udpPorts }}
 ---
 apiVersion: v1
 kind: Service
@@ -63,17 +63,7 @@ metadata:
 spec:
   {{- template "traefik.service-spec" . }}
   ports:
-  {{- range $name, $config := $udpPorts }}
-  {{- if $config.expose }}
-  - port: {{ default $config.port $config.exposedPort }}
-    name: {{ $name }}
-    targetPort: {{ if $config.http3 }}{{ $config.port }}{{ else }}{{ $name | quote }}{{ end }}
-    protocol: UDP
-    {{- if $config.nodePort }}
-    nodePort: {{ $config.nodePort }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- template "traefik.service-ports" $udpPorts }}
 {{- end }}
 
 {{- end -}}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -3,20 +3,21 @@
 {{- $tcpPorts := dict -}}
 {{- $udpPorts := dict -}}
 {{- $exposedPorts := false -}}
-{{ $experimentalHttp3Enabled := .Values.experimental.http3.enabled }}
+{{- $experimentalHttp3Enabled := .Values.experimental.http3.enabled -}}
 {{- range $name, $config := .Values.ports -}}
-  {{- if (and $config.http3 (not $experimentalHttp3Enabled)) }}
-    {{ fail "ERROR: You cannot use HTTP3 on an entrypoint without enabling http3 experimental feature" }}
-  {{- end }}
   {{- if $config.http3 -}}
+    {{- if (and $config.http3.expose (not $config.tls.enabled)) -}}
+      {{- fail "ERROR: You need to enable tls to expose http3 port" -}}
+    {{- end -}}
+    {{- if (and $config.http3.expose (not $experimentalHttp3Enabled)) -}}
+      {{- fail "ERROR: You cannot expose http3 port without enabling http3 experimental feature" -}}
+    {{- end -}}
     {{/* Due to https://github.com/kubernetes/kubernetes/issues/58477 it is not possible
       to define the HTTP/3 UDP port as a (named) containerPort. TCP and UDP containerPort
       will have the same value for 'port' which will break the chart upgrade. Therefore
       we manually refer to port number for HTTP/3. */}}
     {{- $http3Name := (toString $config.port) }}
-    {{- $http3Config := deepCopy $config -}}
-    {{- $http3Config := set $http3Config "protocol" "UDP" -}}
-    {{- $_ := set $udpPorts $http3Name $http3Config -}}
+    {{- $_ := set $udpPorts $http3Name $config.http3 -}}
   {{- end -}}
   {{- if eq (toString $config.protocol) "UDP" -}}
     {{ $_ := set $udpPorts $name $config -}}
@@ -33,7 +34,7 @@
   {{- fail "You need to expose at least one port or set enabled=false to service" -}}
 {{- end -}}
 
-{{- if $tcpPorts }}
+{{- if (or $tcpPorts .Values.service.single) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -47,9 +48,12 @@ spec:
   {{- template "traefik.service-spec" . }}
   ports:
   {{- template "traefik.service-ports" $tcpPorts }}
+{{- if .Values.service.single }}
+  {{- template "traefik.service-ports" $udpPorts }}
+{{- end }}
 {{- end }}
 
-{{- if $udpPorts }}
+{{- if (and $udpPorts (not .Values.service.single)) }}
 ---
 apiVersion: v1
 kind: Service

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -343,15 +343,19 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--experimental.http3=true"
-  - it: should have the http3 experimental flag if enabled via values
+  - it: should have the http3 experimental flag and use default entrypoint port when http3 enabled
     set:
-      experimental:
-        http3:
-          enabled: true
+      ports:
+        websecure:
+          http3:
+            enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--experimental.http3=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http3"
   - it: should not have http3 config flag by default
     asserts:
       - notContains:
@@ -367,12 +371,9 @@ tests:
       ports:
         websecure:
           http3:
-            expose: true
+            enabled: true
           tls:
             enabled: true
-      experimental:
-        http3:
-          enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -382,16 +383,13 @@ tests:
       ports:
         websecure:
           http3:
-            expose: true
+            enabled: true
           tls:
             enabled: true
-      experimental:
-        http3:
-          enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entrypoints.websecure.http3.advertisedPort=8443"
+          content: "--entrypoints.websecure.http3"
   - it: should join entrypoints middleware when there are multiples
     set:
       ports:

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -359,25 +359,7 @@ tests:
           content: "--entrypoints.websecure.enableHTTP3=true"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entrypoints.websecure.http3.advertisedPort=443"
-  - it: should not have http3 config flag when tls is disabled
-    set:
-      ports:
-        websecure:
-          http3:
-            expose: true
-          tls:
-            enabled: false
-      experimental:
-        http3:
-          enabled: true
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: "--entrypoints.websecure.enableHTTP3=true"
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: "--entrypoints.websecure.http3.advertisedPort=443"
+          content: "--entrypoints.websecure.http3.advertisedPort=8443"
   - it: should have http3 config flag enableHTTP3 when image tag < 2.6.0
     set:
       image:

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -364,7 +364,8 @@ tests:
     set:
       ports:
         websecure:
-          http3: true
+          http3:
+            expose: true
           tls:
             enabled: false
       experimental:
@@ -383,7 +384,8 @@ tests:
         tag: 2.5.6
       ports:
         websecure:
-          http3: true
+          http3:
+            expose: true
           tls:
             enabled: true
       experimental:
@@ -397,7 +399,8 @@ tests:
     set:
       ports:
         websecure:
-          http3: true
+          http3:
+            expose: true
           tls:
             enabled: true
       experimental:
@@ -406,7 +409,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entrypoints.websecure.http3.advertisedPort=443"
+          content: "--entrypoints.websecure.http3.advertisedPort=8443"
   - it: should join entrypoints middleware when there are multiples
     set:
       ports:

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -142,7 +142,7 @@ tests:
             protocol: UDP
             targetPort: udp
         template: service.yaml
-        documentIndex: 1
+        documentIndex: 0
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.udp.address=:51/udp"

--- a/traefik/tests/service-config-multiple_test.yaml
+++ b/traefik/tests/service-config-multiple_test.yaml
@@ -1,0 +1,212 @@
+suite: Service configuration (split TCP/UDP services)
+templates:
+  - service.yaml
+tests:
+  - it: should have TCP only annotations when specified via values
+    set:
+      service:
+        single: false
+        annotationsTCP:
+          dns-hostname: tcp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: metadata.annotations.dns-hostname
+          value: tcp.example.com
+        documentIndex: 0
+      - isNull:
+          path: metadata.annotations
+        documentIndex: 1
+  - it: should have UDP only annotations when specified via values
+    set:
+      service:
+        single: false
+        annotationsUDP:
+          dns-hostname: udp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - isNull:
+          path: metadata.annotations
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations.dns-hostname
+          value: udp.example.com
+        documentIndex: 1
+  - it: should merge protocol specific service annotations when specified via values
+    set:
+      service:
+        single: false
+        annotations:
+          azure-load-balancer-internal: true
+        annotationsTCP:
+          dns-hostname: tcp.example.com
+        annotationsUDP:
+          dns-hostname: udp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: tcp.example.com
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: udp.example.com
+        documentIndex: 1
+  - it: should merge protocol specific service annotations with annotationsTCP unspecified when specified via values
+    set:
+      service:
+        single: false
+        annotations:
+          azure-load-balancer-internal: true
+        annotationsUDP:
+          dns-hostname: udp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: udp.example.com
+        documentIndex: 1
+  - it: should merge protocol specific service annotations with annotationsUDP unspecified when specified via values
+    set:
+      service:
+        single: false
+        annotations:
+          azure-load-balancer-internal: true
+        annotationsTCP:
+          dns-hostname: tcp.example.com
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+            dns-hostname: tcp.example.com
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations
+          value:
+            azure-load-balancer-internal: true
+        documentIndex: 1
+  - it: should have custom spec elements when specified via values for UDP ports
+    set:
+      service:
+        single: false
+      ports:
+        udp:
+          port: 3000
+          expose: true
+          exposedPort: 80
+          protocol: UDP
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: udp
+      - equal:
+          path: spec.ports[0].protocol
+          value: UDP
+  - it: should not have ipFamilyPolicy on either service when not specified
+    set:
+      service:
+        single: false
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
+    asserts:
+      - isEmpty:
+          path: spec.ipFamilyPolicy
+        documentIndex: 0
+      - isEmpty:
+          path: spec.ipFamilyPolicy
+        documentIndex: 1
+  - it: should have custom ipFamilyPolicy on both services when specified via values
+    set:
+      service:
+        single: false
+        ipFamilyPolicy: PreferDualStack
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1
+  - it: should not have ipFamilies on either service when not specified
+    set:
+      service:
+        single: false
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
+    asserts:
+      - isEmpty:
+          path: spec.ipFamilies
+        documentIndex: 0
+      - isEmpty:
+          path: spec.ipFamilies
+        documentIndex: 1
+  - it: should have custom ipFamilies on both services when specified via values
+    set:
+      service:
+        single: false
+        ipFamilies:
+          - IPv6
+      ports:
+        udp:
+          port: 3000
+          protocol: UDP
+    asserts:
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv6
+          documentIndex: 0
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv6
+          documentIndex: 1

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -287,7 +287,7 @@ tests:
         value: 443
     - equal:
         path: spec.ports[0].targetPort
-        value: 8443
+        value: "8443"
     - equal:
         path: spec.ports[0].protocol
         value: UDP

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -211,3 +211,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "You cannot expose http3 port without enabling http3 experimental feature"
+  - it: should not be possible to use http3 without enabling tls
+    set:
+      experimental:
+        http3:
+          enabled: true
+      ports:
+        websecure:
+          tls:
+            enabled: false
+          http3:
+            expose: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "You cannot expose http3 without enabling tls"

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -28,122 +28,6 @@ tests:
       - equal:
           path: metadata.annotations.azure-load-balancer-internal
           value: true
-  - it: should have TCP only annotations when specified via values
-    set:
-      service:
-        annotationsTCP:
-          dns-hostname: tcp.example.com
-      ports:
-        udp:
-          port: 3000
-          expose: true
-          exposedPort: 80
-          protocol: UDP
-    asserts:
-      - equal:
-          path: metadata.annotations.dns-hostname
-          value: tcp.example.com
-        documentIndex: 0
-      - isNull:
-          path: metadata.annotations
-        documentIndex: 1
-  - it: should have UDP only annotations when specified via values
-    set:
-      service:
-        annotationsUDP:
-          dns-hostname: udp.example.com
-      ports:
-        udp:
-          port: 3000
-          expose: true
-          exposedPort: 80
-          protocol: UDP
-    asserts:
-      - isNull:
-          path: metadata.annotations
-        documentIndex: 0
-      - equal:
-          path: metadata.annotations.dns-hostname
-          value: udp.example.com
-        documentIndex: 1
-  - it: should merge protocol specific service annotations when specified via values
-    set:
-      service:
-        annotations:
-          azure-load-balancer-internal: true
-        annotationsTCP:
-          dns-hostname: tcp.example.com
-        annotationsUDP:
-          dns-hostname: udp.example.com
-      ports:
-        udp:
-          port: 3000
-          expose: true
-          exposedPort: 80
-          protocol: UDP
-    asserts:
-      - equal:
-          path: metadata.annotations
-          value:
-            azure-load-balancer-internal: true
-            dns-hostname: tcp.example.com
-        documentIndex: 0
-      - equal:
-          path: metadata.annotations
-          value:
-            azure-load-balancer-internal: true
-            dns-hostname: udp.example.com
-        documentIndex: 1
-  - it: should merge protocol specific service annotations with annotationsTCP unspecified when specified via values
-    set:
-      service:
-        annotations:
-          azure-load-balancer-internal: true
-        annotationsUDP:
-          dns-hostname: udp.example.com
-      ports:
-        udp:
-          port: 3000
-          expose: true
-          exposedPort: 80
-          protocol: UDP
-    asserts:
-      - equal:
-          path: metadata.annotations
-          value:
-            azure-load-balancer-internal: true
-        documentIndex: 0
-      - equal:
-          path: metadata.annotations
-          value:
-            azure-load-balancer-internal: true
-            dns-hostname: udp.example.com
-        documentIndex: 1
-  - it: should merge protocol specific service annotations with annotationsUDP unspecified when specified via values
-    set:
-      service:
-        annotations:
-          azure-load-balancer-internal: true
-        annotationsTCP:
-          dns-hostname: tcp.example.com
-      ports:
-        udp:
-          port: 3000
-          expose: true
-          exposedPort: 80
-          protocol: UDP
-    asserts:
-      - equal:
-          path: metadata.annotations
-          value:
-            azure-load-balancer-internal: true
-            dns-hostname: tcp.example.com
-        documentIndex: 0
-      - equal:
-          path: metadata.annotations
-          value:
-            azure-load-balancer-internal: true
-        documentIndex: 1
   - it: should have customized labels when specified via values
     set:
       service:
@@ -191,15 +75,42 @@ tests:
       - equal:
           path: spec.externalIPs[0]
           value: "1.2.3.4"
+  - it: should have custom spec elements when specified via values for TCP ports
+    set:
+      ports:
+        web:
+          expose: false
+        websecure:
+          expose: false
+        tcp:
+          port: 3000
+          expose: true
+          exposedPort: 8080
+          protocol: TCP
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: tcp
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
   - it: should have custom spec elements when specified via values for UDP ports
     set:
       ports:
+        web:
+          expose: false
+        websecure:
+          expose: false
         udp:
           port: 3000
           expose: true
-          exposedPort: 80
+          exposedPort: 8080
           protocol: UDP
-    documentIndex: 1
+    documentIndex: 0
     asserts:
       - equal:
           path: spec.ports[0].name
@@ -207,6 +118,9 @@ tests:
       - equal:
           path: spec.ports[0].protocol
           value: UDP
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
   - it: should not have ipFamilyPolicy when not specified
     set:
       ports:
@@ -217,9 +131,6 @@ tests:
       - isEmpty:
           path: spec.ipFamilyPolicy
         documentIndex: 0
-      - isEmpty:
-          path: spec.ipFamilyPolicy
-        documentIndex: 1
   - it: should have custom ipFamilyPolicy when specified via values
     set:
       service:
@@ -233,10 +144,6 @@ tests:
           path: spec.ipFamilyPolicy
           value: PreferDualStack
         documentIndex: 0
-      - equal:
-          path: spec.ipFamilyPolicy
-          value: PreferDualStack
-        documentIndex: 1
   - it: should not have ipFamilies when not specified
     set:
       ports:
@@ -247,9 +154,6 @@ tests:
       - isEmpty:
           path: spec.ipFamilies
         documentIndex: 0
-      - isEmpty:
-          path: spec.ipFamilies
-        documentIndex: 1
   - it: should have custom ipFamilies when specified via values
     set:
       service:
@@ -265,33 +169,28 @@ tests:
           value:
             - IPv6
           documentIndex: 0
-      - equal:
-          path: spec.ipFamilies
-          value:
-            - IPv6
-          documentIndex: 1
   - it: should have http3 UDP port when enabled via values
     set:
-      ports:
-        websecure:
-          http3: true
-          tls:
-            enabled: true
       experimental:
         http3:
           enabled: true
-    documentIndex: 1
+      ports:
+        websecure:
+          http3:
+            expose: true
+          tls:
+            enabled: true
+    documentIndex: 0
     asserts:
     - equal:
-        path: spec.ports[0].port
-        value: 443
+        path: spec.ports[2].port
+        value: 8443
     - equal:
-        path: spec.ports[0].targetPort
+        path: spec.ports[2].targetPort
         value: "8443"
     - equal:
-        path: spec.ports[0].protocol
+        path: spec.ports[2].protocol
         value: UDP
-      documentIndex: 1
   - it: should fail when there is no exposed port
     set:
       ports:
@@ -307,7 +206,8 @@ tests:
     set:
       ports:
         websecure:
-          http3: true
+          http3:
+            expose: true
     asserts:
       - failedTemplate:
-          errorMessage: "You cannot use HTTP3 on an entrypoint without enabling http3 experimental feature"
+          errorMessage: "You cannot expose http3 port without enabling http3 experimental feature"

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -169,25 +169,45 @@ tests:
           value:
             - IPv6
           documentIndex: 0
-  - it: should have http3 UDP port when enabled via values
+  - it: should use default websecure UDP port when http3 is enabled
     set:
-      experimental:
-        http3:
-          enabled: true
       ports:
         websecure:
           http3:
-            expose: true
+            enabled: true
           tls:
             enabled: true
     documentIndex: 0
     asserts:
     - equal:
         path: spec.ports[2].name
-        value: "8443"
+        value: "websecure-http3"
     - equal:
         path: spec.ports[2].port
+        value: 443
+    - equal:
+        path: spec.ports[2].targetPort
         value: 8443
+    - equal:
+        path: spec.ports[2].protocol
+        value: UDP
+  - it: should be possible to advertise a different http3 UDP port
+    set:
+      ports:
+        websecure:
+          http3:
+            enabled: true
+            advertisedPort: 4443
+          tls:
+            enabled: true
+    documentIndex: 0
+    asserts:
+    - equal:
+        path: spec.ports[2].name
+        value: "websecure-http3"
+    - equal:
+        path: spec.ports[2].port
+        value: 4443
     - equal:
         path: spec.ports[2].targetPort
         value: 8443
@@ -205,26 +225,14 @@ tests:
     - failedTemplate:
         errorMessage: "You need to expose at least one port or set enabled=false to service"
         documentIndex: 1
-  - it: should not be possible to use http3 without enabling experimental http3 feature
-    set:
-      ports:
-        websecure:
-          http3:
-            expose: true
-    asserts:
-      - failedTemplate:
-          errorMessage: "You cannot expose http3 port without enabling http3 experimental feature"
   - it: should not be possible to use http3 without enabling tls
     set:
-      experimental:
-        http3:
-          enabled: true
       ports:
         websecure:
           tls:
             enabled: false
           http3:
-            expose: true
+            enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "You cannot expose http3 without enabling tls"
+          errorMessage: "You cannot enable http3 without enabling tls"

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -183,11 +183,14 @@ tests:
     documentIndex: 0
     asserts:
     - equal:
+        path: spec.ports[2].name
+        value: "8443"
+    - equal:
         path: spec.ports[2].port
         value: 8443
     - equal:
         path: spec.ports[2].targetPort
-        value: "8443"
+        value: 8443
     - equal:
         path: spec.ports[2].protocol
         value: UDP

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -421,10 +421,16 @@ ports:
     # The port protocol (TCP/UDP)
     protocol: TCP
     # nodePort: 32443
-    # Enable HTTP/3.
-    # Requires enabling experimental http3 feature and tls.
-    # Note that you cannot have a UDP entrypoint with the same port.
-    # http3: true
+    http3:
+      port: 8443
+      # hostPort: 8443
+      # Enable HTTP/3.
+      # Requires enabling experimental http3 feature and tls.
+      expose: false
+      # Note that you cannot have another UDP entrypoint with the same (exposed) port.
+      exposedPort: 8443
+      # The port protocol (TCP/UDP)
+      protocol: UDP
     # Set TLS at the entrypoint
     # https://doc.traefik.io/traefik/routing/entrypoints/#tls
     tls:
@@ -500,6 +506,7 @@ tlsStore: {}
 # from.
 service:
   enabled: true
+  single: true
   type: LoadBalancer
   # Additional annotations applied to both TCP and UDP services (e.g. for cloud provider specific config)
   annotations: {}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -87,8 +87,6 @@ ingressClass:
 
 # Enable experimental features
 experimental:
-  http3:
-    enabled: false
   plugins:
     enabled: false
   kubernetesGateway:
@@ -421,18 +419,19 @@ ports:
     # The port protocol (TCP/UDP)
     protocol: TCP
     # nodePort: 32443
+    #
+    ## Enable HTTP/3 on the entrypoint
+    ## Enabling it will also enable http3 experimental feature
+    ## https://doc.traefik.io/traefik/routing/entrypoints/#http3
+    ## There are known limitations when trying to listen on same ports for
+    ## TCP & UDP (Http3). There is a workaround in this chart using dual Service.
+    ## https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741
     http3:
-      port: 8443
-      # hostPort: 8443
-      # Enable HTTP/3.
-      # Requires enabling experimental http3 feature and tls.
-      expose: false
-      # Note that you cannot have another UDP entrypoint with the same (exposed) port.
-      exposedPort: 8443
-      # The port protocol (TCP/UDP)
-      protocol: UDP
-    # Set TLS at the entrypoint
-    # https://doc.traefik.io/traefik/routing/entrypoints/#tls
+      enabled: false
+    # advertisedPort: 4443
+    #
+    ## Set TLS at the entrypoint
+    ## https://doc.traefik.io/traefik/routing/entrypoints/#tls
     tls:
       enabled: true
       # this is the name of a TLSOption definition


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Merge TCP and UDP ports into a single service by default. Since Kubernetes 1.20, mixed protocol loadbalancers are supported. 

This is partly based on the work in https://github.com/traefik/traefik-helm-chart/pull/420.


### Motivation

The main goal is to allow an easy way to use HTTP/3 with a single load balancer using this chart.

### More

- [x] Yes, I updated the [chart version](https://github.com/traefik/traefik-helm-chart/blob/9b32ed1b414cc0be1ad46bcb335fcfc93ded06f3/traefik/Chart.yaml#L5)

### Additional Notes

This is a work in progress; I have yet to
- [x] add additional tests
- [x] try and test this in practice somehow

I'm mostly looking for feedback to my approach and to users having attempted to try similar things in the past and/or are currently using UDP ports or HTTP/3.
