### PR TITLE
:rocket: Enable TLS by default on `websecure` port

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,80 @@
 # Change Log
 
+## 15.0.0 
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Enable TLS by default on `websecure` (#560)
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 400a29a..fc2c371 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -389,7 +389,7 @@ ports:
+     # Set TLS at the entrypoint
+     # https://doc.traefik.io/traefik/routing/entrypoints/#tls
+     tls:
+-      enabled: false
++      enabled: true
+       # this is the name of a TLSOption definition
+       options: ""
+       certResolver: ""
+```
+
+## 14.0.2 
+
+**Release date:** 2022-10-13
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :memo: Add Changelog (#661) 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
+## 14.0.1 
+
+**Release date:** 2022-10-11
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :memo: Update workaround for permissions 660 on acme.json 
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index a4e4ff2..400a29a 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -45,10 +45,10 @@ deployment:
+   # Additional initContainers (e.g. for setting file permission as shown below)
+   initContainers: []
+     # The "volume-permissions" init container is required if you run into permission issues.
+-    # Related issue: https://github.com/traefik/traefik/issues/6972
++    # Related issue: https://github.com/traefik/traefik/issues/6825
+     # - name: volume-permissions
+-    #   image: busybox:1.31.1
+-    #   command: ["sh", "-c", "chmod -Rv 600 /data/*"]
++    #   image: busybox:1.35
++    #   command: ["sh", "-c", "touch /data/acme.json && chmod -Rv 600 /data/* && chown 65532:65532 /data/acme.json"]
+     #   volumeMounts:
+     #     - name: data
+     #       mountPath: /data
+```
+
 ## 14.0.0 
 
 **Release date:** 2022-10-11

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 14.0.2
+version: 15.0.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -238,22 +238,22 @@ tests:
           port: 9000
           healthchecksPort: 9001
           exposedPort: 9000
-      asserts:
-        - equal:
-            path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-            content: 9001
-        - equal:
-            path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-            content: 9001
-        - equal:
-            path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
-            content: "HTTP"
-        - contains:
-            path: spec.template.spec.containers[0].args
-            content: "--ping"
-        - contains:
-            path: spec.template.spec.containers[0].args
-            content: "--ping.entrypoint=web"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 9001
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 9001
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: "HTTP"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ping"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ping.entrypoint=web"
   - it: should set custom probe scheme
     set:
       additionalArguments:
@@ -265,19 +265,34 @@ tests:
           healthchecksPort: 8443
           healthchecksScheme: HTTPS
           exposedPort: 9000
-      asserts:
-        - equal:
-            path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-            content: 8443
-        - equal:
-            path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-            content: 8443
-        - equal:
-            path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
-            content: "HTTPS"
-        - contains:
-            path: spec.template.spec.containers[0].args
-            content: "--ping"
-        - contains:
-            path: spec.template.spec.containers[0].args
-            content: "--ping.entrypoint=websecure"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8443
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8443
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: "HTTPS"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ping"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ping.entrypoint=websecure"
+  - it: should enable tls on websecure entrypoints by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http.tls=true"
+  - it: should be possible to disable tls on websecure entrypoint
+    set:
+      ports:
+        websecure:
+          tls:
+            enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http.tls=true"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -389,7 +389,7 @@ ports:
     # Set TLS at the entrypoint
     # https://doc.traefik.io/traefik/routing/entrypoints/#tls
     tls:
-      enabled: false
+      enabled: true
       # this is the name of a TLSOption definition
       options: ""
       certResolver: ""


### PR DESCRIPTION
Here is my change regarding the issuenumber 560:

https://github.com/traefik/traefik-helm-chart/issues/560

Traefik should use TLS by default