### PR TITLE
:bug: Fix `ClusterRole`, `ClusterRoleBinding` names and `app.kubernetes.io/instance` label

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 17.0.0
+
+**Release date:** 2022-10-20
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :bug: Fix `ClusterRole`, `ClusterRoleBinding` names and `app.kubernetes.io/instance` label
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 16.2.0 
 
 **Release date:** 2022-10-20
@@ -8,7 +24,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* Add forwardedHeaders and proxyProtocol config 
+* Add forwardedHeaders and proxyProtocol config (#673) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 16.2.0
+version: 17.0.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -32,31 +32,12 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
-{{/* Generate common labels */}}
-{{- define "traefik.commonLabels" -}}
+{{/* Generate basic labels */}}
+{{- define "traefik.labels" -}}
 app.kubernetes.io/name: {{ template "traefik.name" . }}
 helm.sh/chart: {{ template "traefik.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/* Generate basic labels */}}
-{{- define "traefik.labels" -}}
-{{ template "traefik.commonLabels" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Generate basic labels for ClusterRole and ClusterRoleBinding.
-Adds the namespace to app.kubernetes.io/instance when it is
-a namespaced release.
-*/}}
-{{- define "traefik.clusterRoleLabels" -}}
-{{ template "traefik.commonLabels" . }}
-{{ if .Values.rbac.namespaced -}}
 app.kubernetes.io/instance: {{ .Release.Name }}-{{ .Release.Namespace }}
-{{- else -}}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
 {{- end }}
 
 {{/*

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -53,11 +53,7 @@ Adds the namespace to name to prevent duplicate resource names when there
 are multiple namespaced releases with the same release name.
 */}}
 {{- define "traefik.clusterRoleName" -}}
-{{- if .Values.rbac.namespaced -}}
 {{- template "traefik.fullname" . -}}-{{ .Release.Namespace }}
-{{- else -}}
-{{- template "traefik.fullname" . -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -53,7 +53,7 @@ Adds the namespace to name to prevent duplicate resource names when there
 are multiple namespaced releases with the same release name.
 */}}
 {{- define "traefik.clusterRoleName" -}}
-{{- template "traefik.fullname" . -}}-{{ .Release.Namespace }}
+{{- (printf "%s-%s" (include "traefik.fullname" .) .Release.Namespace) | trunc 63 | trimSuffix "-" }}
 {{- end -}}
 
 {{/*

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -3,9 +3,9 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.clusterRoleName" . }}
   labels:
-    {{- include "traefik.labels" . | nindent 4 }}
+    {{- include "traefik.clusterRoleLabels" . | nindent 4 }}
     {{- range .Values.rbac.aggregateTo }}
     rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
     {{- end }}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.clusterRoleName" . }}
   labels:
-    {{- include "traefik.clusterRoleLabels" . | nindent 4 }}
+    {{- include "traefik.labels" . | nindent 4 }}
     {{- range .Values.rbac.aggregateTo }}
     rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
     {{- end }}

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -3,13 +3,13 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.clusterRoleName" . }}
   labels:
-    {{- include "traefik.labels" . | nindent 4 }}
+    {{- include "traefik.clusterRoleLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.clusterRoleName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "traefik.serviceAccountName" . }}

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.clusterRoleName" . }}
   labels:
-    {{- include "traefik.clusterRoleLabels" . | nindent 4 }}
+    {{- include "traefik.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/traefik/tests/default-install_test.yaml
+++ b/traefik/tests/default-install_test.yaml
@@ -29,11 +29,11 @@ tests:
         template: service.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-traefik
+          value: RELEASE-NAME-traefik-NAMESPACE
         template: rbac/clusterrole.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-traefik
+          value: RELEASE-NAME-traefik-NAMESPACE
         template: rbac/clusterrolebinding.yaml
       - equal:
           path: metadata.name

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -70,6 +70,15 @@ tests:
                 - list
                 - watch
         template: rbac/clusterrole.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: ^.*-NAMESPACE$
+        template: rbac/clusterrole.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: ^.*-NAMESPACE$
+        template: rbac/clusterrolebinding.yaml
+
   - it: should use existing ServiceAccount
     set:
       serviceAccount:


### PR DESCRIPTION
### What does this PR do?

1. It adds the name of the namespace to `ClusterRole` and `ClusterRoleBinding` names.
2. It appends the namespace to `app.kubernetes.io/instance` label.

### Motivation

This is to prevent `ClusterRole` and `ClusterRoleBinding` resources with the same names when there are multiple releases with the same name but in different namespaces.

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

