### PR TITLE
:sparkles: add optional topologySpreadConstraints

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,12 +1,49 @@
 # Change Log
 
-## 15.0.0 
+## 15.1.0 
+
+**Release date:** 2022-10-13
 
 ![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* Enable TLS by default on `websecure` (#560)
+* feat: Add optional topologySpreadConstraints
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index fc2c371..8b4f626 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -593,6 +593,14 @@ affinity: {}
+ 
+ nodeSelector: {}
+ tolerations: []
++topologySpreadConstraints: []
++# # This example topologySpreadConstraints forces the scheduler to put traefik pods
++# # on nodes where no other traefik pods are scheduled.
++#  - labelSelector:
++#      matchLabels:
++#        app: {{ template "traefik.name" . }}
++#    maxSkew: 1
++#    topologyKey: kubernetes.io/hostname
++#    whenUnsatisfiable: DoNotSchedule
+ 
+ # Pods can have priority.
+ # Priority indicates the importance of a Pod relative to other Pods.
+```
+
+## 15.0.0 
+
+**Release date:** 2022-10-13
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :rocket: Enable TLS by default on `websecure` port (#657) 
 
 ### Default value changes
 

--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 15.1.0 
 
-**Release date:** 2022-10-13
+**Release date:** 2022-10-14
 
 ![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
@@ -26,7 +26,7 @@ index fc2c371..8b4f626 100644
 +# # on nodes where no other traefik pods are scheduled.
 +#  - labelSelector:
 +#      matchLabels:
-+#        app: {{ template "traefik.name" . }}
++#        app: '{{ template "traefik.name" . }}'
 +#    maxSkew: 1
 +#    topologyKey: kubernetes.io/hostname
 +#    whenUnsatisfiable: DoNotSchedule

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 15.0.0
+version: 15.1.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -466,6 +466,9 @@
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and .Values.topologySpreadConstraints (semverCompare "<1.19.0" .Capabilities.KubeVersion.Version) }}
+        {{- fail "ERROR: topologySpreadConstraints are supported only on kubernetes >= v1.19" -}} 
+      {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -466,11 +466,11 @@
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.topologySpreadConstraints (semverCompare "<1.19.0" .Capabilities.KubeVersion.Version) }}
+      {{- if .Values.topologySpreadConstraints }}
+      {{- if (semverCompare "<1.19.0" .Capabilities.KubeVersion.Version) }}
         {{- fail "ERROR: topologySpreadConstraints are supported only on kubernetes >= v1.19" -}} 
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .Values.topologySpreadConstraints) . | nindent 8 }}
       {{- end }}
 {{ end -}}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -466,4 +466,8 @@
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{ end -}}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -128,10 +128,10 @@ tests:
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
           value: whatever
-  - it: should set a topologySpreadConstraints
+  - it: should set a topologySpreadConstraints on kubernetes >= 1.19
     capabilities:
       majorVersion: 1
-      minorVersion: 22
+      minorVersion: 19
     set:
       topologySpreadConstraints:
       - labelSelector:
@@ -146,6 +146,24 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.app
           value: whatever
+  - it: should set a templated topologySpreadConstraints on kubernetes >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: '{{ template "traefik.name" . }}'
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.app
+          value: traefik
   - it: should set fail to set topologySpreadConstraints on kubernetes 1.18
     capabilities:
       majorVersion: 1

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -106,3 +106,40 @@ tests:
       - equal:
           path: spec.template.spec.volumes[2].secret.secretName
           value: "RELEASE-NAME-custom-secret"
+  - it: should set a podAntiaffinity
+    set:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - whatever
+            topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].key
+          value: app
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
+          value: whatever
+  - it: should set a topologySpreadConstraints
+    set:
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: whatever
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.app
+          value: whatever

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -129,6 +129,9 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
           value: whatever
   - it: should set a topologySpreadConstraints
+    capabilities:
+      majorVersion: 1
+      minorVersion: 22
     set:
       topologySpreadConstraints:
       - labelSelector:
@@ -143,3 +146,14 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.app
           value: whatever
+  - it: should set fail to set topologySpreadConstraints on kubernetes 1.18
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+    asserts:
+      - failedTemplate:
+          errorMessage: "topologySpreadConstraints are supported only on kubernetes >= v1.19"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -598,7 +598,7 @@ topologySpreadConstraints: []
 # # on nodes where no other traefik pods are scheduled.
 #  - labelSelector:
 #      matchLabels:
-#        app: {{ template "traefik.name" . }}
+#        app: '{{ template "traefik.name" . }}'
 #    maxSkew: 1
 #    topologyKey: kubernetes.io/hostname
 #    whenUnsatisfiable: DoNotSchedule

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -593,6 +593,14 @@ affinity: {}
 
 nodeSelector: {}
 tolerations: []
+topologySpreadConstraints: []
+# # This example topologySpreadConstraints forces the scheduler to put traefik pods
+# # on nodes where no other traefik pods are scheduled.
+#  - labelSelector:
+#      matchLabels:
+#        app: {{ template "traefik.name" . }}
+#    maxSkew: 1
+#    topologyKey: kubernetes.io/hostname
 
 # Pods can have priority.
 # Priority indicates the importance of a Pod relative to other Pods.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -601,6 +601,7 @@ topologySpreadConstraints: []
 #        app: {{ template "traefik.name" . }}
 #    maxSkew: 1
 #    topologyKey: kubernetes.io/hostname
+#    whenUnsatisfiable: DoNotSchedule
 
 # Pods can have priority.
 # Priority indicates the importance of a Pod relative to other Pods.


### PR DESCRIPTION
### What does this PR do?

Adds optional topologySpreadConstraints.

### Motivation

Asked by users. 
Fixes #465 
Inspired and supersede #466

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

