### PR TITLE
:fire: Remove `Pilot` and `fallbackApiVersion`

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,40 @@
 # Change Log
 
+## 16.0.0 
+
+**Release date:** 2022-10-19
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :fire: Remove `Pilot` and `fallbackApiVersion` 
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 03fdaed..7e335b5 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -84,15 +84,6 @@ ingressClass:
+   # true is not unit-testable yet, pending https://github.com/rancher/helm-unittest/pull/12
+   enabled: false
+   isDefaultClass: false
+-  # Use to force a networking.k8s.io API Version for certain CI/CD applications. E.g. "v1beta1"
+-  fallbackApiVersion: ""
+-
+-# Activate Pilot integration
+-pilot:
+-  enabled: false
+-  token: ""
+-  # Toggle Pilot Dashboard
+-  # dashboard: false
+ 
+ # Enable experimental features
+ experimental:
+```
+
 ## 15.3.1 
 
 **Release date:** 2022-10-18
@@ -8,7 +43,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* :art: Improve `IngressRoute` structure 
+* :art: Improve `IngressRoute` structure (#674) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 15.3.1
+version: 16.0.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -388,12 +388,6 @@
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.pilot.enabled }}
-          - "--pilot.token={{ .Values.pilot.token }}"
-          {{- end }}
-          {{- if hasKey .Values.pilot "dashboard" }}
-          - "--pilot.dashboard={{ .Values.pilot.dashboard }}"
-          {{- end }}
           {{- range $resolver, $config := $.Values.certResolvers }}
           {{- range $option, $setting := $config }}
           {{- if kindIs "map" $setting }}

--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -6,8 +6,6 @@
 apiVersion: networking.k8s.io/v1
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
-  {{- else if or (eq .Values.ingressClass.fallbackApiVersion "v1beta1") (eq .Values.ingressClass.fallbackApiVersion "v1") }}
-apiVersion: {{ printf "networking.k8s.io/%s" .Values.ingressClass.fallbackApiVersion }}
   {{- else }}
     {{- fail "\n\n ERROR: You must have at least networking.k8s.io/v1beta1 to use ingressClass" }}
   {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -260,19 +260,6 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             "--certificatesresolvers.myAcmeResolver.acme.tlsChallenge=true"
-  - it: should have the pilot dashboard enabled by default
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: "--pilot.dashboard=false"
-  - it: should have the pilot dashboard disabled
-    set:
-      pilot:
-        dashboard: false
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--pilot.dashboard=false"
   - it: should have prometheus annotations with specified values
     set:
       ports:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -84,15 +84,6 @@ ingressClass:
   # true is not unit-testable yet, pending https://github.com/rancher/helm-unittest/pull/12
   enabled: false
   isDefaultClass: false
-  # Use to force a networking.k8s.io API Version for certain CI/CD applications. E.g. "v1beta1"
-  fallbackApiVersion: ""
-
-# Activate Pilot integration
-pilot:
-  enabled: false
-  token: ""
-  # Toggle Pilot Dashboard
-  # dashboard: false
 
 # Enable experimental features
 experimental:


### PR DESCRIPTION
### What does this PR do?

It removes a workaround to force api even when it was not available in some ci/cd.

### Motivation

The workaround is not needed anymore, it has been [fixed](https://github.com/argoproj/argo-rollouts/issues/1507) on ArgoCD.
Fixes #473

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

