### PR TITLE
:bug: Allow to watch on specific namespaces without using rbac.namespaced

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## 15.2.0 
+
+**Release date:** 2022-10-17
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :bug: Allow to watch on specific namespaces without using rbac.namespaced (#666)
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 781ac15..76aac93 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -555,7 +555,7 @@ rbac:
+   enabled: true
+ 
+   # If set to false, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
+-  # If set to true, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
++  # If set to true, installs Role and RoleBinding. Providers will only watch target namespace.
+   namespaced: false
+ 
+ # Enable to create a PodSecurityPolicy and assign it to the Service Account via RoleBinding or ClusterRoleBinding
+```
+
 ## 15.1.1 
 
 **Release date:** 2022-10-17
@@ -8,7 +36,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* :goal_net: Fail gracefully when http3 is not enabled correctly 
+* :goal_net: Fail gracefully when http3 is not enabled correctly (#667) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 15.1.1
+version: 15.2.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -304,12 +304,14 @@
           {{- if .Values.experimental.http3.enabled }}
           - "--experimental.http3=true"
           {{- end }}
-          {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
-          {{- if .Values.providers.kubernetesCRD.enabled }}
-          - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" . }}"
+          {{- with .Values.providers.kubernetesCRD }}
+          {{- if (and .enabled (or $.Values.rbac.enabled .namespaces)) }}
+          - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" $ }}"
           {{- end }}
-          {{- if .Values.providers.kubernetesIngress.enabled }}
-          - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" . }}"
+          {{- end }}
+          {{- with .Values.providers.kubernetesIngress }}
+          {{- if (and .enabled (or $.Values.rbac.enabled .namespaces)) }}
+          - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" $ }}"
           {{- end }}
           {{- end }}
           {{- range $entrypoint, $config := $.Values.ports }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -296,3 +296,19 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.websecure.http.tls=true"
+  - it: should allow to set namespace on providers by default, without rbac.namespaced
+    set:
+      providers:
+        kubernetesCRD:
+          enabled: true
+          namespaces: [ ns1, ns2 ]
+        kubernetesIngress:
+          enabled: true
+          namespaces: [ ns3, ns4 ]
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.namespaces=ns1,ns2"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.namespaces=ns3,ns4"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -555,7 +555,7 @@ rbac:
   enabled: true
 
   # If set to false, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
-  # If set to true, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
+  # If set to true, installs Role and RoleBinding. Providers will only watch target namespace.
   namespaced: false
 
 # Enable to create a PodSecurityPolicy and assign it to the Service Account via RoleBinding or ClusterRoleBinding


### PR DESCRIPTION
### What does this PR do?

It allows to configure namespaces on provider as expected, even without using `rbac.namespaced`

### Motivation

Fixes #395 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

