### PR TITLE
:goal_net: Fail gracefully when http3 is not enabled correctly

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 15.1.1 
+
+**Release date:** 2022-10-17
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :goal_net: Fail gracefully when http3 is not enabled correctly 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 15.1.0 
 
 **Release date:** 2022-10-14
@@ -8,16 +24,16 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* feat: Add optional topologySpreadConstraints
+* :sparkles: add optional topologySpreadConstraints (#663) 
 
 ### Default value changes
 
 ```diff
 diff --git a/traefik/values.yaml b/traefik/values.yaml
-index fc2c371..8b4f626 100644
+index fc2c371..781ac15 100644
 --- a/traefik/values.yaml
 +++ b/traefik/values.yaml
-@@ -593,6 +593,14 @@ affinity: {}
+@@ -593,6 +593,15 @@ affinity: {}
  
  nodeSelector: {}
  tolerations: []

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 15.1.0
+version: 15.1.1
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -3,7 +3,11 @@
 {{ $tcpPorts := dict }}
 {{ $udpPorts := dict }}
 {{ $exposedPorts := false }}
+{{ $experimentalHttp3Enabled := .Values.experimental.http3.enabled }}
 {{- range $name, $config := .Values.ports }}
+  {{- if (and $config.http3 (not $experimentalHttp3Enabled)) }}
+    {{ fail "ERROR: You cannot use HTTP3 on an entrypoint without enabling http3 experimental feature" }}
+  {{- end }}
   {{- if or $config.http3 (eq (toString $config.protocol) "UDP") }}
     {{ $_ := set $udpPorts $name $config }}
   {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -380,6 +380,9 @@ tests:
           http3: true
           tls:
             enabled: false
+      experimental:
+        http3:
+          enabled: true
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
@@ -396,6 +399,9 @@ tests:
           http3: true
           tls:
             enabled: true
+      experimental:
+        http3:
+          enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -407,6 +413,9 @@ tests:
           http3: true
           tls:
             enabled: true
+      experimental:
+        http3:
+          enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -277,6 +277,9 @@ tests:
           http3: true
           tls:
             enabled: true
+      experimental:
+        http3:
+          enabled: true
     documentIndex: 1
     asserts:
     - equal:
@@ -300,3 +303,11 @@ tests:
     - failedTemplate:
         errorMessage: "You need to expose at least one port or set enabled=false to service"
         documentIndex: 1
+  - it: should not be possible to use http3 without enabling experimental http3 feature
+    set:
+      ports:
+        websecure:
+          http3: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "You cannot use HTTP3 on an entrypoint without enabling http3 experimental feature"


### PR DESCRIPTION
### What does this PR do?

Fail gracefully when user tries to enable http3 without enabling this experimental feature.

### Motivation

Fixes #618 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

