### PR TITLE
:bug: Set dashboard ingressroute as an Helm resource

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 15.2.0
+version: 15.2.1
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -4,7 +4,6 @@ kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   annotations:
-    helm.sh/hook: "post-install,post-upgrade"
     {{- with .Values.ingressRoute.dashboard.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -1,6 +1,6 @@
 suite: Dashboard IngressRoute configuration
 templates:
-  - dashboard-hook-ingressroute.yaml
+  - dashboard-ingressroute.yaml
 tests:
   - it: should allow disabling dashboard exposure using ingressRoute
     set:


### PR DESCRIPTION
### What does this PR do?

Set dashboard `IngressRoute` as a regular helm resource instead of a hook.

### Motivation

It's not needed anymore to install it with a hook. 
Fixes #115

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed
- [ ] Is there a way to avoid break during upgrade between hook version and regular version ? 
```bash
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. 
Unable to continue with update: IngressRoute "traefik-dashboard" in namespace "default" exists and cannot be imported into the current release: invalid ownership metadata;
annotation validation error: missing key "meta.helm.sh/release-name": must be set to "traefik"; 
annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "default"
```
