### PR TITLE
Fix fix provider namespace changes

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 15.2.1
+version: 15.2.2
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -305,12 +305,12 @@
           - "--experimental.http3=true"
           {{- end }}
           {{- with .Values.providers.kubernetesCRD }}
-          {{- if (and .enabled (or $.Values.rbac.enabled (not (empty .namespaces)))) }}
+          {{- if (and .enabled (or .namespaces (and $.Values.rbac.enabled $.Values.rbac.namespaced))) }}
           - "--providers.kubernetescrd.namespaces={{ template "providers.kubernetesCRD.namespaces" $ }}"
           {{- end }}
           {{- end }}
           {{- with .Values.providers.kubernetesIngress }}
-          {{- if (and .enabled (or $.Values.rbac.enabled (not (empty .namespaces)))) }}
+          {{- if (and .enabled (or .namespaces (and $.Values.rbac.enabled $.Values.rbac.namespaced))) }}
           - "--providers.kubernetesingress.namespaces={{ template "providers.kubernetesIngress.namespaces" $ }}"
           {{- end }}
           {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -318,7 +318,7 @@ tests:
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--providers.kubernetescrd.namespaces="
+          content: "--providers.kubernetescrd.namespaces=NAMESPACE"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--providers.kubernetesingress.namespaces="
+          content: "--providers.kubernetesingress.namespaces=NAMESPACE"


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

- 6ff19cb **Fix test for #669**

  `spec.template.spec.containers[0].args` is an array, so `notContains` is
  testing that the given string does not exist in the array, not whether
  it is present as an arbitrary substring.
  
  Issues like this can be detected before release by following a
  "red-green" approach when writing tests (e.g. write a failing test, like
  this one, then make the code change to fix it).

- e478289 **Fix #669**

  The original fix in #670 didn't actually fix the issue, rather the test
  was broken and the fix didn't change anything (`or` already
  operates on 'emptiness' as described in
  https://helm.sh/docs/chart_template_guide/function_list/#or – e.g. `.namespaces` and `not (empty .namespaces)` have the same meaning inside `or`).

### Motivation

#669 is still an issue.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

