### PR TITLE
Add forwardedHeaders and proxyProtocol config

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,58 @@
 # Change Log
 
+## 16.2.0 
+
+**Release date:** 2022-10-20
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Add forwardedHeaders and proxyProtocol config 
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 9b5afc4..6a90bc6 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -403,6 +403,16 @@ ports:
+     # Added in 2.2, you can make permanent redirects via entrypoints.
+     # https://docs.traefik.io/routing/entrypoints/#redirection
+     # redirectTo: websecure
++    #
++    # Trust forwarded  headers information (X-Forwarded-*).
++    # forwardedHeaders:
++    #   trustedIPs: []
++    #   insecure: false
++    #
++    # Enable the Proxy Protocol header parsing for the entry point
++    # proxyProtocol:
++    #   trustedIPs: []
++    #   insecure: false
+   websecure:
+     port: 8443
+     # hostPort: 8443
+@@ -428,6 +438,16 @@ ports:
+       #     - foo.example.com
+       #     - bar.example.com
+     #
++    # Trust forwarded  headers information (X-Forwarded-*).
++    # forwardedHeaders:
++    #   trustedIPs: []
++    #   insecure: false
++    #
++    # Enable the Proxy Protocol header parsing for the entry point
++    # proxyProtocol:
++    #   trustedIPs: []
++    #   insecure: false
++    #
+     # One can apply Middlewares on an entrypoint
+     # https://doc.traefik.io/traefik/middlewares/overview/
+     # https://doc.traefik.io/traefik/routing/entrypoints/#middlewares
+```
+
 ## 16.1.0 
 
 **Release date:** 2022-10-19
@@ -8,7 +61,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* ✨ add optional ServiceMonitor & PrometheusRule CRDs
+* ✨ add optional ServiceMonitor & PrometheusRules CRDs (#425) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 16.1.0
+version: 16.2.0
 appVersion: 2.9.1
 keywords:
   - traefik

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -349,6 +349,22 @@
           - "--entrypoints.{{ $entrypoint }}.enableHTTP3=true"
           {{- end }}
           {{- end }}
+          {{- if $config.forwardedHeaders }}
+          {{- if $config.forwardedHeaders.trustedIPs }}
+          - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.trustedIPs={{ join "," $config.forwardedHeaders.trustedIPs }}"
+          {{- end }}
+          {{- if $config.forwardedHeaders.insecure }}
+          - "--entrypoints.{{ $entrypoint }}.forwardedHeaders.insecure"
+          {{- end }}
+          {{- end }}
+          {{- if $config.proxyProtocol }}
+          {{- if $config.proxyProtocol.trustedIPs }}
+          - "--entrypoints.{{ $entrypoint }}.proxyProtocol.trustedIPs={{ join "," $config.proxyProtocol.trustedIPs }}"
+          {{- end }}
+          {{- if $config.proxyProtocol.insecure }}
+          - "--entrypoints.{{ $entrypoint }}.proxyProtocol.insecure"
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -322,3 +322,45 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.namespaces=NAMESPACE"
+  - it: should have forwardedHeaders and proxyProtocol trustedIPs configuration args when specified in values.yaml for port
+    set:
+      ports:
+        websecure:
+          forwardedHeaders:
+            trustedIPs:
+              - 127.0.0.1/32
+              - 192.168.1.7
+          proxyProtocol:
+            trustedIPs:
+              - 127.0.0.1/32
+              - 192.168.1.8
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.forwardedHeaders.trustedIPs=127.0.0.1/32,192.168.1.7"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.proxyProtocol.trustedIPs=127.0.0.1/32,192.168.1.8"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.forwardedHeaders.insecure"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.proxyProtocol.insecure"
+  - it: should have forwardedHeaders and proxyProtocol insecure configuration args when specified in values.yaml for port
+    set:
+      ports:
+        websecure:
+          forwardedHeaders:
+            insecure: True
+              - 127.0.0.1/32
+              - 192.168.1.7
+          proxyProtocol:
+            insecure: True
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.forwardedHeaders.insecure"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.proxyProtocol.insecure"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -403,6 +403,16 @@ ports:
     # Added in 2.2, you can make permanent redirects via entrypoints.
     # https://docs.traefik.io/routing/entrypoints/#redirection
     # redirectTo: websecure
+    #
+    # Trust forwarded  headers information (X-Forwarded-*).
+    # forwardedHeaders:
+    #   trustedIPs: []
+    #   insecure: false
+    #
+    # Enable the Proxy Protocol header parsing for the entry point
+    # proxyProtocol:
+    #   trustedIPs: []
+    #   insecure: false
   websecure:
     port: 8443
     # hostPort: 8443
@@ -427,6 +437,16 @@ ports:
       #   sans:
       #     - foo.example.com
       #     - bar.example.com
+    #
+    # Trust forwarded  headers information (X-Forwarded-*).
+    # forwardedHeaders:
+    #   trustedIPs: []
+    #   insecure: false
+    #
+    # Enable the Proxy Protocol header parsing for the entry point
+    # proxyProtocol:
+    #   trustedIPs: []
+    #   insecure: false
     #
     # One can apply Middlewares on an entrypoint
     # https://doc.traefik.io/traefik/middlewares/overview/


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

It extend the port configuration for the forwardedHeaders and proxyProtocol configuration per entrypoint.

### Motivation

With the current version of the helm chart, the forwardedHeaders and proxyProtocol configuration must be configured with additionalArguments.  This is somehow error-prone because it will be easily forgotten, when adding a new entrypoint.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

