### PR TITLE
🚀 Add native support for Traefik Hub

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,6 +1,53 @@
 # Change Log
 
-## 18.0.0
+## 18.1.0 
+
+**Release date:** 2022-10-27
+
+![AppVersion: 2.9.1](https://img.shields.io/static/v1?label=AppVersion&message=2.9.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* 🚀 Add native support for Traefik Hub 
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index acce704..02d1f89 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -5,6 +5,27 @@ image:
+   tag: ""
+   pullPolicy: IfNotPresent
+ 
++#
++# Configure integration with Traefik Hub
++#
++hub:
++  ## Enabling Hub will:
++  # * enable Traefik Hub integration on Traefik
++  # * add `traefikhub-tunl` endpoint
++  # * enable addRoutersLabels on prometheus metrics
++  # * enable allowExternalNameServices on KubernetesIngress provider
++  # * enable allowCrossNamespace on KubernetesCRD provider
++  # * add an internal (ClusterIP) Service, dedicated for Traefik Hub
++  enabled: false
++  ## Default port can be changed
++  # tunnelPort: 9901
++  ## TLS is optional. Insecure is mutually exclusive with any other options
++  # tls:
++  #   insecure: false
++  #   ca: "/path/to/ca.pem"
++  #   cert: "/path/to/cert.pem"
++  #   key: "/path/to/key.pem"
++
+ #
+ # Configure the deployment
+ #
+```
+
+## 18.0.0 
 
 **Release date:** 2022-10-26
 
@@ -8,19 +55,17 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* Provides single service using `MixedProtocolLBService` feature gate, by default.
-* Dual service is still possible by setting `service.single=false`
-* Refactor and improve http3 deployments
+* Refactor http3 and merge TCP with UDP ports into a single service (#656) 
 
 ### Default value changes
 
 ```diff
 diff --git a/traefik/values.yaml b/traefik/values.yaml
-index fc5aff3..8ba1f11 100644
+index 807bd09..acce704 100644
 --- a/traefik/values.yaml
 +++ b/traefik/values.yaml
 @@ -87,8 +87,6 @@ ingressClass:
-
+ 
  # Enable experimental features
  experimental:
 -  http3:
@@ -28,10 +73,16 @@ index fc5aff3..8ba1f11 100644
    plugins:
      enabled: false
    kubernetesGateway:
-@@ -421,18 +419,19 @@ ports:
+@@ -421,12 +419,19 @@ ports:
      # The port protocol (TCP/UDP)
      protocol: TCP
      # nodePort: 32443
+-    # Enable HTTP/3.
+-    # Requires enabling experimental http3 feature and tls.
+-    # Note that you cannot have a UDP entrypoint with the same port.
+-    # http3: true
+-    # Set TLS at the entrypoint
+-    # https://doc.traefik.io/traefik/routing/entrypoints/#tls
 +    #
 +    ## Enable HTTP/3 on the entrypoint
 +    ## Enabling it will also enable http3 experimental feature
@@ -39,7 +90,7 @@ index fc5aff3..8ba1f11 100644
 +    ## There are known limitations when trying to listen on same ports for
 +    ## TCP & UDP (Http3). There is a workaround in this chart using dual Service.
 +    ## https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741
-     http3:
++    http3:
 +      enabled: false
 +    # advertisedPort: 4443
 +    #
@@ -48,7 +99,7 @@ index fc5aff3..8ba1f11 100644
      tls:
        enabled: true
        # this is the name of a TLSOption definition
-@@ -500,6 +506,7 @@ tlsStore: {}
+@@ -500,6 +505,7 @@ tlsStore: {}
  # from.
  service:
    enabled: true
@@ -56,7 +107,6 @@ index fc5aff3..8ba1f11 100644
    type: LoadBalancer
    # Additional annotations applied to both TCP and UDP services (e.g. for cloud provider specific config)
    annotations: {}
-
 ```
 
 ## 17.0.5 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 18.0.0
+version: 18.1.0
 appVersion: 2.9.1
 keywords:
   - traefik
@@ -25,6 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - Provides single service using `MixedProtocolLBService`, by default.
-    - Dual service is still possible by setting `service.single=false`
-    - Refactor and improve http3 deployments
+    - 🚀 Add support for Traefik Hub

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -1,0 +1,20 @@
+
+
+Traefik Proxy {{ .Chart.AppVersion }} has been deployed successfully 
+on {{ .Release.Namespace }} namespace !
+
+{{- if .Values.hub.enabled }}
+{{- if coalesce (ne .Release.Namespace "hub-agent") .Values.hub.tunnelPort (ne (.Values.ports.metrics.port | int) 9100) }}
+
+Traefik Hub integration is enabled ! With your specific parameters, 
+`metricsURL`, `tunnelHost` and `tunnelPort` needs to be set accordingly
+on hub-agent Helm Chart. Based on this Chart, it should be:
+
+  --set controllerDeployment.traefik.metricsURL=traefik-hub.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.ports.metrics.port }}/metrics
+  --set tunnelDeployment.traefik.tunnelHost=traefik-hub.{{ .Release.Namespace }}.svc.cluster.local
+  --set tunnelDeployment.traefik.tunnelPort={{ default 9901 .Values.hub.tunnelPort }}
+
+See https://doc.traefik.io/traefik-hub/install/#traefik-hub-agent-install-with-helmchart
+
+{{- end }}
+{{- end }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -131,7 +131,7 @@
           {{- if .Values.metrics.prometheus }}
           - "--metrics.prometheus=true"
           - "--metrics.prometheus.entrypoint={{ .Values.metrics.prometheus.entryPoint }}"
-          {{- if .Values.metrics.prometheus.addRoutersLabels }}
+          {{- if (or .Values.metrics.prometheus.addRoutersLabels .Values.hub.enabled) }}
           - "--metrics.prometheus.addRoutersLabels=true"
           {{- end }}
           {{- end }}
@@ -269,10 +269,10 @@
           {{- if .Values.providers.kubernetesCRD.ingressClass }}
           - "--providers.kubernetescrd.ingressClass={{ .Values.providers.kubernetesCRD.ingressClass }}"
           {{- end }}
-          {{- if .Values.providers.kubernetesCRD.allowCrossNamespace }}
+          {{- if (or .Values.providers.kubernetesCRD.allowCrossNamespace .Values.hub.enabled) }}
           - "--providers.kubernetescrd.allowCrossNamespace=true"
           {{- end }}
-          {{- if .Values.providers.kubernetesCRD.allowExternalNameServices }}
+          {{- if (or .Values.providers.kubernetesCRD.allowExternalNameServices .Values.hub.enabled) }}
           - "--providers.kubernetescrd.allowExternalNameServices=true"
           {{- end }}
           {{- if .Values.providers.kubernetesCRD.allowEmptyServices }}
@@ -418,6 +418,10 @@
           - "--certificatesresolvers.{{ $resolver }}.acme.{{ $option }}={{ $setting }}"
           {{- end }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.hub.enabled }}
+          - "--experimental.hub"
+          - "--hub"
           {{- end }}
           {{- with .Values.additionalArguments }}
           {{- range . }}

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -7,7 +7,7 @@
 {{- end }}
 
 {{- define "traefik.service-spec" -}}
-  {{- $type := .Values.hub.enabled | ternary "ClusterIP" (default "LoadBalancer" .Values.service.type) }}
+  {{- $type := default "LoadBalancer" .Values.service.type }}
   type: {{ $type }}
   {{- with .Values.service.spec }}
   {{- toYaml . | nindent 2 }}

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -7,7 +7,7 @@
 {{- end }}
 
 {{- define "traefik.service-spec" -}}
-  {{- $type := default "LoadBalancer" .Values.service.type }}
+  {{- $type := .Values.hub.enabled | ternary "ClusterIP" (default "LoadBalancer" .Values.service.type) }}
   type: {{ $type }}
   {{- with .Values.service.spec }}
   {{- toYaml . | nindent 2 }}

--- a/traefik/templates/service-hub.yaml
+++ b/traefik/templates/service-hub.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.hub.enabled -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-hub
+  {{- template "traefik.service-metadata" . }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "traefik.labelselector" . | nindent 4 }}
+  ports:
+  - port: {{ .Values.ports.metrics.port }}
+    name: "metrics"
+    targetPort: metrics
+    protocol: TCP
+    {{- if .Values.ports.metrics.nodePort }}
+    nodePort: {{ .Values.ports.metrics.nodePort }}
+    {{- end }}
+  - port: {{ default 9901 .Values.hub.tunnelPort }}
+    name: "traefikhub-tunl"
+    targetPort: traefikhub-tunl
+    protocol: TCP
+{{- end -}}

--- a/traefik/tests/hub-integration-config_test.yaml
+++ b/traefik/tests/hub-integration-config_test.yaml
@@ -1,0 +1,156 @@
+suite: Hub integration
+templates:
+  - deployment.yaml
+  - service-hub.yaml
+tests:
+  - it: should not enable Hub by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub"
+        template: deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: service-hub.yaml
+  - it: should contains minimal static configuration when enabled
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.hub"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics.prometheus.addRoutersLabels=true"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tls.insecure=true"
+  - it: should provide dedicated internal service for Hub when enabled
+    template: service-hub.yaml
+    set:
+      hub:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: metadata.name
+          value: traefik-hub
+      - contains:
+          path: spec.ports
+          content:
+            port: 9100
+            name: "metrics"
+            targetPort: metrics
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            port: 9901
+            name: "traefikhub-tunl"
+            targetPort: traefikhub-tunl
+            protocol: TCP
+  - it: should use specified ports for Hub when enabled
+    template: service-hub.yaml
+    set:
+      hub:
+        enabled: true
+        tunnelPort: 8001
+      ports:
+        metrics:
+          port: 8000
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            port: 8000
+            name: "metrics"
+            targetPort: metrics
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            port: 8001
+            name: "traefikhub-tunl"
+            targetPort: traefikhub-tunl
+            protocol: TCP
+  - it: should use default ports on entrypoints when enabled
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.traefikhub-tunl.address=:9901"
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: "traefikhub-tunl"
+            containerPort: 9901
+            protocol: "TCP"
+  - it: should configure custom ports on entrypoints when specified
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+        tunnelPort: 8001
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.traefikhub-tunl.address=:8001"
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: "traefikhub-tunl"
+            containerPort: 8001
+            protocol: "TCP"
+  - it: should configure TLS when specified
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+        tls:
+          ca: "/path/to/ca.pem"
+          cert: "/path/to/cert.pem"
+          key: "/path/to/key.pem"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tls.ca=/path/to/ca.pem"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tls.cert=/path/to/cert.pem"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tls.key=/path/to/key.pem"
+  - it: should enable TLS insecure connection when specified
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+        tls:
+          insecure: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tls.insecure=true"
+  - it: should fail when TLS insecure & certs are both specified
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+        tls:
+          insecure: true
+          ca: "/path/to/ca.pem"
+          cert: "/path/to/cert.pem"
+          key: "/path/to/key.pem"
+    asserts:
+      - failedTemplate:
+          errorMessage: "You cannot specify insecure and certs on TLS for Traefik Hub at the same time"

--- a/traefik/tests/ingressclass-config_test.yaml
+++ b/traefik/tests/ingressclass-config_test.yaml
@@ -1,4 +1,4 @@
-suite: HPA configuration
+suite: IngressClass configuration
 templates:
   - ingressclass.yaml
 tests:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -5,6 +5,16 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# Enabling Hub integration will enable xxx
+hub:
+  enabled: false
+  # Enabling Hub will enable :
+  # * experimental Hub feature
+  # * addRoutersLabels on prometheus metrics
+  # * allowExternalNameServices on KubernetesIngress provider
+  # * allowExternalNameServices on KubernetesCRD provider
+  # * force service to be ClusterIP
+
 #
 # Configure the deployment
 #

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -5,15 +5,26 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
-# Enabling Hub integration will enable xxx
+#
+# Configure integration with Traefik Hub
+#
 hub:
+  ## Enabling Hub will:
+  # * enable Traefik Hub integration on Traefik
+  # * add `traefikhub-tunl` endpoint
+  # * enable addRoutersLabels on prometheus metrics
+  # * enable allowExternalNameServices on KubernetesIngress provider
+  # * enable allowCrossNamespace on KubernetesCRD provider
+  # * add an internal (ClusterIP) Service, dedicated for Traefik Hub
   enabled: false
-  # Enabling Hub will enable :
-  # * experimental Hub feature
-  # * addRoutersLabels on prometheus metrics
-  # * allowExternalNameServices on KubernetesIngress provider
-  # * allowExternalNameServices on KubernetesCRD provider
-  # * force service to be ClusterIP
+  ## Default port can be changed
+  # tunnelPort: 9901
+  ## TLS is optional. Insecure is mutually exclusive with any other options
+  # tls:
+  #   insecure: false
+  #   ca: "/path/to/ca.pem"
+  #   cert: "/path/to/cert.pem"
+  #   key: "/path/to/key.pem"
 
 #
 # Configure the deployment
@@ -515,6 +526,8 @@ tlsStore: {}
 # from.
 service:
   enabled: true
+  ## Single service is using `MixedProtocolLBService` feature gate.
+  ## When set to false, it will create two Service, one for TCP and one for UDP.
   single: true
   type: LoadBalancer
   # Additional annotations applied to both TCP and UDP services (e.g. for cloud provider specific config)


### PR DESCRIPTION
### What does this PR do?

Add native support for Traefik Hub in this Chart.

### Motivation

Deploying Traefik Proxy for Traefik Hub needs this kind of install command:

```bash
helm upgrade --install traefik traefik/traefik \
  --namespace hub-agent --create-namespace \
  --set=additionalArguments='{--experimental.hub,--hub}' \
  --set metrics.prometheus.addRoutersLabels=true \
  --set providers.kubernetesIngress.allowExternalNameServices=true \
  --set ports.web=null --set ports.websecure=null --set ports.metrics.expose=true \
  --set ports.traefikhub-tunl.port=9901 --set ports.traefikhub-tunl.expose=true 
  --set ports.traefikhub-tunl.exposedPort=9901 --set ports.traefikhub-tunl.protocol="TCP" \
  --set service.type="ClusterIP" --set fullnameOverride=traefik-hub 
```
With this PR, the idea is to reduce arguments to something like this:

```bash
helm upgrade --install traefik traefik/traefik \
  --namespace hub-agent --create-namespace \
  --set hub.enabled=true
```

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

