### PR TITLE
🎨 Don't require exposed Ports when enabling Hub

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,14 +1,30 @@
 # Change Log
 
-## 19.0.2 
+## 19.0.3 
 
-**Release date:** 2022-10-31
+**Release date:** 2022-11-03
 
 ![AppVersion: 2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=2.9.4&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* 💬 Support volume secrets with '.' in name (#695) 
+* 🎨 Don't require exposed Ports when enabling Hub (#700)
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
+## 19.0.2 
+
+**Release date:** 2022-11-03
+
+![AppVersion: 2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=2.9.4&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* :speech_balloon: Support volume secrets with '.' in name (#695) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 19.0.2
+version: 19.0.3
 appVersion: 2.9.4
 keywords:
   - traefik
@@ -25,4 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - 💬 Support volume secrets with '.' in name
+    - 🎨 Don't require exposed Ports when enabling Hub

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -22,11 +22,11 @@
   {{- end -}}
 {{- end -}}
 
-{{- if (eq $exposedPorts false) -}}
+{{- if and (eq $exposedPorts false) (not .Values.hub.enabled) -}}
   {{- fail "You need to expose at least one port or set enabled=false to service" -}}
 {{- end -}}
 
-{{- if (or $tcpPorts .Values.service.single) }}
+{{- if and $exposedPorts (or $tcpPorts .Values.service.single) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,7 +45,7 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- if (and $udpPorts (not .Values.service.single)) }}
+{{- if and $exposedPorts (and $udpPorts (not .Values.service.single)) }}
 ---
 apiVersion: v1
 kind: Service

--- a/traefik/tests/hub-integration-config_test.yaml
+++ b/traefik/tests/hub-integration-config_test.yaml
@@ -2,6 +2,7 @@ suite: Hub integration
 templates:
   - deployment.yaml
   - service-hub.yaml
+  - service.yaml
 tests:
   - it: should not enable Hub by default
     asserts:
@@ -154,3 +155,16 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "You cannot specify insecure and certs on TLS for Traefik Hub at the same time"
+  - it: should not provide Service when hub is enabled without web and websecure ports
+    template: deployment.yaml
+    set:
+      hub:
+        enabled: true
+      ports:
+        web: null
+        websecure: null
+    templates:
+      - service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
### What does this PR do?

Allows to install Traefik with Traefik Hub, enabled Service and without exposed Ports.

### Motivation

When Traefik Hub is enabled, it makes sense to support no Service by default. It allows 
```bash
helm upgrade --install traefik traefik/traefik \
  --namespace hub-agent --create-namespace \
  --set hub.enabled=true \
  --set ports.web=null --set ports.websecure=null 
```
instead of 
```bash
helm upgrade --install traefik traefik/traefik \
  --namespace hub-agent --create-namespace \
  --set hub.enabled=true \
  --set ports.web=null --set ports.websecure=null --set service.enabled=false
```

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

