### PR TITLE
🔧 Adds more settings & rename (wrong) scrapeInterval to (valid) interval on ServiceMonitor

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,55 @@
 # Change Log
 
+## 19.0.4 
+
+**Release date:** 2022-11-07
+
+![AppVersion: 2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=2.9.4&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* 🔧 Adds more settings & rename (wrong) scrapeInterval to (valid) interval on ServiceMonitor 
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index b24c1cb..413aa88 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -261,10 +261,6 @@ metrics:
+ ##  enable optional CRDs for Prometheus Operator
+ ##
+   #  serviceMonitor:
+-  #    additionalLabels:
+-  #      foo: bar
+-  #    namespace: "another-namespace"
+-  #    namespaceSelector: {}
+   #    metricRelabelings: []
+   #      - sourceLabels: [__name__]
+   #        separator: ;
+@@ -279,9 +275,17 @@ metrics:
+   #        replacement: $1
+   #        action: replace
+   #    jobLabel: traefik
+-  #    scrapeInterval: 30s
+-  #    scrapeTimeout: 5s
++  #    interval: 30s
+   #    honorLabels: true
++  #    # (Optional)
++  #    # scrapeTimeout: 5s
++  #    # honorTimestamps: true
++  #    # enableHttp2: true
++  #    # followRedirects: true
++  #    # additionalLabels:
++  #    #   foo: bar
++  #    # namespace: "another-namespace"
++  #    # namespaceSelector: {}
+   #  prometheusRule:
+   #    additionalLabels: {}
+   #    namespace: "another-namespace"
+```
+
 ## 19.0.3 
 
 **Release date:** 2022-11-03
@@ -8,7 +58,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* 🎨 Don't require exposed Ports when enabling Hub (#700)
+* 🎨 Don't require exposed Ports when enabling Hub (#700) 
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 19.0.3
+version: 19.0.4
 appVersion: 2.9.4
 keywords:
   - traefik
@@ -25,4 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - 🎨 Don't require exposed Ports when enabling Hub
+    - 🔧 Adds more settings & rename (wrong) scrapeInterval to (valid) interval on ServiceMonitor

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -20,6 +20,18 @@ spec:
   endpoints:
     - port: metrics
       path: /{{ .Values.metrics.prometheus.entryPoint }}
+      {{- with .Values.metrics.prometheus.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.prometheus.serviceMonitor.honorTimestamps }}
+      honorTimestamps: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.prometheus.serviceMonitor.enableHttp2 }}
+      enableHttp2: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.prometheus.serviceMonitor.followRedirects }}
+      followRedirects: {{ . }}
+      {{- end }}
       {{- with .Values.metrics.prometheus.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/traefik/tests/servicemonitor-config_test.yaml
+++ b/traefik/tests/servicemonitor-config_test.yaml
@@ -29,7 +29,12 @@ tests:
           content:
             port: metrics
             path: /metrics
+            enableHttp2: true
+            followRedirects: true
+            honorLabels: true
+            honorTimestamps: true
             scrapeTimeout: 5s
+            interval: 30s
             metricRelabelings:
             - action: drop
               regex: ^fluentd_output_status_buffer_(oldest|newest)_.+

--- a/traefik/tests/values/servicemonitor.yaml
+++ b/traefik/tests/values/servicemonitor.yaml
@@ -21,7 +21,10 @@ metrics:
          replacement: $1
          action: replace
       jobLabel: another-label
-      scrapeInterval: 30s
+      interval: 30s
       scrapeTimeout: 5s
       honorLabels: true
+      honorTimestamps: true
+      enableHttp2: true
+      followRedirects: true
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -261,10 +261,6 @@ metrics:
 ##  enable optional CRDs for Prometheus Operator
 ##
   #  serviceMonitor:
-  #    additionalLabels:
-  #      foo: bar
-  #    namespace: "another-namespace"
-  #    namespaceSelector: {}
   #    metricRelabelings: []
   #      - sourceLabels: [__name__]
   #        separator: ;
@@ -279,9 +275,17 @@ metrics:
   #        replacement: $1
   #        action: replace
   #    jobLabel: traefik
-  #    scrapeInterval: 30s
-  #    scrapeTimeout: 5s
+  #    interval: 30s
   #    honorLabels: true
+  #    # (Optional)
+  #    # scrapeTimeout: 5s
+  #    # honorTimestamps: true
+  #    # enableHttp2: true
+  #    # followRedirects: true
+  #    # additionalLabels:
+  #    #   foo: bar
+  #    # namespace: "another-namespace"
+  #    # namespaceSelector: {}
   #  prometheusRule:
   #    additionalLabels: {}
   #    namespace: "another-namespace"


### PR DESCRIPTION
### What does this PR do?

Add `honorLabels`, `honorTimestamps`, `enableHttp2`, `followRedirects` and fix `interval` settings on _ServiceMonitor_ CRD.


### Motivation

Fixes #702 


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

