### PR TITLE
🐛 change chart release charts_dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ secrets.CHARTS_TOKEN }}
-          charts_dir: traefik
+          charts_dir: .
           charts_url: https://traefik.github.io/charts
           owner: traefik
           repository: charts


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the deployment mechanism, the `helm-gh-pages` expects sub-directories under the charts_dir, in our case we can just search the repo root.