### PR TITLE
🐛 change chart release index_dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,6 @@ jobs:
           repository: charts
           branch: master
           target_dir: traefik
+          index_dir: .
           commit_username: traefiker
           commit_email: 30906710+traefiker@users.noreply.github.com


### PR DESCRIPTION
### What does this PR do?

`index_dir` by default, defaults to the `target_dir`. Our upstream `/charts` repo separates the packaged artifacts and the index.yaml. This PR updates the releaser to look for the index.yaml in the project root.