### PR TITLE
🐛 fix tag version checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.chart_version.outputs.CHART_VERSION }}
-        if: steps.tag_exists.outputs.TAG_EXISTS == false
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Create release
         uses: ncipollo/release-action@v1
@@ -52,7 +52,7 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-        if: steps.tag_exists.outputs.TAG_EXISTS == false
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Publish Helm chart
         uses: stefanprodan/helm-gh-pages@master
@@ -67,4 +67,4 @@ jobs:
           index_dir: .
           commit_username: traefiker
           commit_email: 30906710+traefiker@users.noreply.github.com
-        if: steps.tag_exists.outputs.TAG_EXISTS == false
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'


### PR DESCRIPTION
### What does this PR do?

This PR fixes the string checking on the GitHub action to prevent skipping tagging/release when the tag doesn't exist.