### PR TITLE
Add (optional) dedicated metrics service

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,10 +1,39 @@
 # Change Log
 
+## 20.4.0  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2022-11-18
+
+* Add (optional) dedicated metrics service
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index ca15f6a..46690aa 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -266,7 +266,13 @@ metrics:
+   #    address: localhost:8125
+ ##
+ ##  enable optional CRDs for Prometheus Operator
+ ##
++  ## Create a dedicated metrics service for use with ServiceMonitor
++  ## When hub.enabled is set to true, it's not needed: it will use hub service.
++  #  service:
++  #    enabled: false
++  #    labels: {}
++  #    annotations: {}
+   #  serviceMonitor:
+   #    metricRelabelings: []
+   #      - sourceLabels: [__name__]
+```
+
 ## 20.3.1  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2022-11-21
 
-* 🐛 Fix namespace override which was missing on `ServiceAccount`
+* 🐛 Fix namespace override which was missing on `ServiceAccount` (#731)
 
 
 ## 20.3.0  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - 🐛 Fix namespace override which was missing on `ServiceAccount`
+    - Add (optional) dedicated metrics service

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 20.3.1
+version: 20.4.0
 appVersion: v2.9.4
 keywords:
   - traefik
@@ -24,6 +24,5 @@ maintainers:
     email: charlie.haley@traefik.io
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
-  artifacthub.io/changes: "- Adds support for namespace overrides in subchart use\n- Document recent changes in the README (#717)\n"
   artifacthub.io/changes: |
     - 🐛 Fix namespace override which was missing on `ServiceAccount`

--- a/traefik/templates/_service-metrics.tpl
+++ b/traefik/templates/_service-metrics.tpl
@@ -1,0 +1,21 @@
+{{- define "traefik.metrics-service-metadata" }}
+  labels:
+  {{- include "traefik.metricsservicelabels" . | nindent 4 -}}
+  {{- with .Values.metrics.prometheus.service.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{/* Labels used for metrics-relevant selector*/}}
+{{/* This is an immutable field: this should not change between upgrade */}}
+{{- define "traefik.metricslabelselector" -}}
+{{- include "traefik.labelselector" . }}
+app.kubernetes.io/component: metrics
+{{- end }}
+
+{{/* Shared labels used in metadata of metrics-service and servicemonitor */}}
+{{- define "traefik.metricsservicelabels" -}}
+{{ include "traefik.metricslabelselector" . }}
+helm.sh/chart: {{ template "traefik.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/traefik/templates/_service-metrics.tpl
+++ b/traefik/templates/_service-metrics.tpl
@@ -19,3 +19,4 @@ app.kubernetes.io/component: metrics
 helm.sh/chart: {{ template "traefik.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+

--- a/traefik/templates/service-metrics.yaml
+++ b/traefik/templates/service-metrics.yaml
@@ -1,0 +1,24 @@
+{{- if (and .Values.metrics.prometheus.service.enabled (not .Values.hub.enabled)) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-metrics
+  namespace: {{ template "traefik.namespace" . }}
+  {{- template "traefik.metrics-service-metadata" . }}
+  annotations:
+  {{- with .Values.metrics.prometheus.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "traefik.metricslabelselector" . | nindent 4 }}
+  ports:
+  - port: {{ .Values.ports.metrics.port }}
+    name: "metrics"
+    targetPort: metrics
+    protocol: TCP
+    {{- if .Values.ports.metrics.nodePort }}
+    nodePort: {{ .Values.ports.metrics.nodePort }}
+    {{- end }}
+{{- end -}}

--- a/traefik/templates/service-metrics.yaml
+++ b/traefik/templates/service-metrics.yaml
@@ -1,8 +1,13 @@
-{{- if (and .Values.metrics.prometheus.service.enabled (not .Values.hub.enabled)) -}}
+{{- $fullname := include "traefik.fullname" . }}
+{{- if ge (len $fullname) 50 }}
+  {{- fail "ERROR: Cannot create a metrics service when name contains more than 50 characters" }}
+{{- end }}
+
+{{- if (and (.Values.metrics.prometheus.service).enabled (not .Values.hub.enabled)) -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: traefik-metrics
+  name: {{ $fullname }}-metrics
   namespace: {{ template "traefik.namespace" . }}
   {{- template "traefik.metrics-service-metadata" . }}
   annotations:
@@ -12,7 +17,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    {{- include "traefik.metricslabelselector" . | nindent 4 }}
+    {{- include "traefik.labelselector" . | nindent 4 }}
   ports:
   - port: {{ .Values.ports.metrics.port }}
     name: "metrics"

--- a/traefik/templates/service-metrics.yaml
+++ b/traefik/templates/service-metrics.yaml
@@ -27,3 +27,4 @@ spec:
     nodePort: {{ .Values.ports.metrics.nodePort }}
     {{- end }}
 {{- end -}}
+

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -11,7 +11,11 @@ metadata:
   namespace: {{ . }}
   {{- end }}
   labels:
+    {{- if (and .Values.metrics.prometheus.service.enabled (not .Values.hub.enabled)) }}
+    {{- include "traefik.metricsservicelabels" . | nindent 4 }}
+    {{- else }}
     {{- include "traefik.labels" . | nindent 4 }}
+    {{- end }}
     {{- with .Values.metrics.prometheus.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -56,6 +60,10 @@ spec:
   {{- end }}
   selector:
     matchLabels:
+      {{- if (and .Values.metrics.prometheus.service.enabled (not .Values.hub.enabled)) }}
+      {{- include "traefik.metricslabelselector" . | nindent 6 }}
+      {{- else }}
       {{- include "traefik.labelselector" . | nindent 6 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ . }}
   {{- end }}
   labels:
-    {{- if (and .Values.metrics.prometheus.service.enabled (not .Values.hub.enabled)) }}
+    {{- if (and (.Values.metrics.prometheus.service).enabled (not .Values.hub.enabled)) }}
     {{- include "traefik.metricsservicelabels" . | nindent 4 }}
     {{- else }}
     {{- include "traefik.labels" . | nindent 4 }}
@@ -60,7 +60,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- if (and .Values.metrics.prometheus.service.enabled (not .Values.hub.enabled)) }}
+      {{- if (and (.Values.metrics.prometheus.service).enabled (not .Values.hub.enabled)) }}
       {{- include "traefik.metricslabelselector" . | nindent 6 }}
       {{- else }}
       {{- include "traefik.labelselector" . | nindent 6 }}

--- a/traefik/tests/service-metrics-config_test.yaml
+++ b/traefik/tests/service-metrics-config_test.yaml
@@ -6,6 +6,17 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should not provide a dedicated metrics service when hub is enabled
+    set:
+      hub:
+        enabled: true
+      metrics:
+        prometheus:
+          service:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should provide a dedicated metrics service when enabled set to true
     set:
       metrics:
@@ -28,12 +39,11 @@ tests:
       - equal:
           path: metadata.annotations.custom-annotation
           value: custom-value
-      - isSubset:
+      - equal:
           path: spec.selector
-          content:
+          value:
             app.kubernetes.io/name: traefik
             app.kubernetes.io/instance: RELEASE-NAME-NAMESPACE
-            app.kubernetes.io/component: metrics
       - contains:
           path: spec.ports
           content:

--- a/traefik/tests/service-metrics-config_test.yaml
+++ b/traefik/tests/service-metrics-config_test.yaml
@@ -1,0 +1,43 @@
+suite: Metrics Service configuration
+templates:
+  - service-metrics.yaml
+tests:
+  - it: should not provide a dedicated metrics service by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should provide a dedicated metrics service when enabled set to true
+    set:
+      metrics:
+        prometheus:
+          service:
+            enabled: true
+            labels:
+              custom-label: custom-value
+            annotations:
+              custom-annotation: custom-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: metadata.labels.custom-label
+          value: custom-value
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: custom-value
+      - isSubset:
+          path: spec.selector
+          content:
+            app.kubernetes.io/name: traefik
+            app.kubernetes.io/instance: RELEASE-NAME-NAMESPACE
+            app.kubernetes.io/component: metrics
+      - contains:
+          path: spec.ports
+          content:
+            port: 9100
+            name: "metrics"
+            targetPort: metrics
+            protocol: TCP

--- a/traefik/tests/service-metrics-config_test.yaml
+++ b/traefik/tests/service-metrics-config_test.yaml
@@ -24,9 +24,9 @@ tests:
           service:
             enabled: true
             labels:
-              custom-label: custom-value
+              custom-label: label-value
             annotations:
-              custom-annotation: custom-value
+              custom-annotation: annotation-value
     asserts:
       - hasDocuments:
           count: 1
@@ -35,10 +35,10 @@ tests:
           value: ClusterIP
       - equal:
           path: metadata.labels.custom-label
-          value: custom-value
+          value: label-value
       - equal:
           path: metadata.annotations.custom-annotation
-          value: custom-value
+          value: annotation-value
       - equal:
           path: spec.selector
           value:

--- a/traefik/tests/servicemonitor-config_test.yaml
+++ b/traefik/tests/servicemonitor-config_test.yaml
@@ -56,3 +56,42 @@ tests:
       - equal:
           path: spec.selector.matchLabels.[app.kubernetes.io/name]
           value: traefik
+  - it: should provide ServiceMonitor pointing to metrics service, when hub is disabled and prometheus.service.enabled is true
+    values:
+      - ./values/servicemonitor.yaml
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    set:
+      hub:
+        enabled: false
+      metrics:
+        prometheus:
+          service:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.selector.matchLabels.[app.kubernetes.io/component]
+          value: metrics
+  - it: should provide ServiceMonitor pointing to hub service, when hub is enabled
+    values:
+      - ./values/servicemonitor.yaml
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    set:
+      hub:
+        enabled: true
+      metrics:
+        prometheus:
+          service:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotSubset:
+          path: spec.selector.matchLabels
+          content:
+            app.kubernetes.io/component: metrics

--- a/traefik/tests/values/servicemonitor.yaml
+++ b/traefik/tests/values/servicemonitor.yaml
@@ -1,7 +1,6 @@
 metrics:
   prometheus:
     serviceMonitor:
-      enabled: true
       additionalLabels:
         release: traefik-release
       namespace: another-namespace

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -266,9 +266,9 @@ metrics:
   #    address: localhost:8125
 ##
 ##  enable optional CRDs for Prometheus Operator
-## 
-    # create a dedicated metrics service for use with servicemonitor
-    # will only be created, when enabled set to true and hub.enabled is false
+##
+  ## Create a dedicated metrics service for use with ServiceMonitor
+  ## When hub.enabled is set to true, it's not needed: it will use hub service.
   #  service:
   #    enabled: false
   #    labels: {}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -266,7 +266,13 @@ metrics:
   #    address: localhost:8125
 ##
 ##  enable optional CRDs for Prometheus Operator
-##
+## 
+    # create a dedicated metrics service for use with servicemonitor
+    # will only be created, when enabled set to true and hub.enabled is false
+    service:
+      enabled: false
+  #   labels: {}
+  #   annotations: {}
   #  serviceMonitor:
   #    metricRelabelings: []
   #      - sourceLabels: [__name__]

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -269,10 +269,10 @@ metrics:
 ## 
     # create a dedicated metrics service for use with servicemonitor
     # will only be created, when enabled set to true and hub.enabled is false
-    service:
-      enabled: false
-  #   labels: {}
-  #   annotations: {}
+  #  service:
+  #    enabled: false
+  #    labels: {}
+  #    annotations: {}
   #  serviceMonitor:
   #    metricRelabelings: []
   #      - sourceLabels: [__name__]


### PR DESCRIPTION
Signed-off-by: Freddy Grieshaber <freddy.grieshaber+github@gmail.com>

Resolves #726 

### What does this PR do?

This PR adds a dedicated service object to serve the metrics port when Traefik Hub is not enabled.

### Motivation

Until now, it was coupled with the "hub" service. As one might want to use the metrics & servicemonitor without enabling the hub-integration, this PR decouples the hub and the metrics feature.

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

