### PR TITLE
:art: Use forked version of helm-changelog with better formating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ lint:
 
 changelog:
 	@echo "== Updating Changelogs..."
-	@docker run -it --rm -v $(CURDIR):/data mogensen/helm-changelog:latest
+	@docker run -it --rm -v $(CURDIR):/data ghcr.io/mloiseleur/helm-changelog:v0.0.2
 	@./hack/changelog.sh
 	@echo "== Updating finished"


### PR DESCRIPTION
### What does this PR do?

Update `changelog` Makefile target with forked version.

### Motivation

Changelog is way more readable : it removes 2k (unneeded) lines from it.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

