### PR TITLE
🐛 Fix namespace override which was missing on `ServiceAccount`

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,10 +1,17 @@
 # Change Log
 
+## 20.3.1  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2022-11-21
+
+* 🐛 Fix namespace override which was missing on `ServiceAccount`
+
+
 ## 20.3.0  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-**Release date:** 2022-11-16
+**Release date:** 2022-11-17
 
-* Add option to override instance label value
+* Add overwrite option for instance label value (#725)
 
 ### Default value changes
 

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 20.3.0
+version: 20.3.1
 appVersion: v2.9.4
 keywords:
   - traefik
@@ -25,3 +25,5 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: "- Adds support for namespace overrides in subchart use\n- Document recent changes in the README (#717)\n"
+  artifacthub.io/changes: |
+    - 🐛 Fix namespace override which was missing on `ServiceAccount`

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "traefik.serviceAccountName" . }}
+  namespace: {{ template "traefik.namespace" . }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
   annotations:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -173,6 +173,10 @@ tests:
           path: metadata.namespace
           value: NAMESPACE
         template: rbac/role.yaml
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+        template: rbac/serviceaccount.yaml
   - it: should accept overridden namespace
     set:
       namespaceOverride: "traefik-ns-override"
@@ -183,3 +187,7 @@ tests:
           path: metadata.namespace
           value: "traefik-ns-override"
         template: rbac/role.yaml
+      - equal:
+          path: metadata.namespace
+          value: "traefik-ns-override"
+        template: rbac/serviceaccount.yaml


### PR DESCRIPTION
### What does this PR do?

It adds namespace override on `ServiceAccount`. It was missing on this object.

### Motivation

See #690.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

