### PR TITLE
🐛 Fix namespaceSelector on ServiceMonitor

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,10 +1,17 @@
 # Change Log
 
+## 20.5.1  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2022-11-23
+
+* 🐛 Fix namespaceSelector on ServiceMonitor (#737)
+
+
 ## 20.5.0  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-**Release date:** 2022-11-22
+**Release date:** 2022-11-23
 
-* 🚀 Add complete support on metrics options
+* 🚀 Add complete support on metrics options (#735)
 * 🐛 make tests use fixed version
 
 ### Default value changes

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 20.5.0
+version: 20.5.1
 appVersion: v2.9.4
 keywords:
   - traefik
@@ -25,5 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - 🚀 Add complete support on metrics options
-    - 🐛 make tests use fixed version
+    - 🐛 Fix namespaceSelector on ServiceMonitor

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -52,7 +52,7 @@ spec:
 {{- end }}
   {{- if .Values.metrics.prometheus.serviceMonitor.namespaceSelector }}
   namespaceSelector:
-    {{ toYaml .Values.metrics.prometheus.serviceMonitor.namespaceSelector | indent 4 -}}
+{{ toYaml .Values.metrics.prometheus.serviceMonitor.namespaceSelector | indent 4 -}}
   {{ else }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
### What does this PR do?

Fix wrong indentation on namespaceSelector of (optional) `ServiceMonitor` integration.

### Motivation

Fixes #736 

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

