### PR TITLE
:memo: Move dashboard instructions from README to EXAMPLES

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -35,6 +35,18 @@ autoscaling:
         averageUtilization: 80
 ```
 
+# Access Traefik dashboard without exposing it
+
+This HelmChart does not expose the Traefik dashboard by default, for security concerns.
+Thus, there are multiple ways to expose the dashboard.
+For instance, the dashboard access could be achieved through a port-forward :
+
+```bash
+kubectl port-forward $(kubectl get pods --selector "app.kubernetes.io/name=traefik" --output=name) 9000:9000
+```
+
+Accessible with the url: http://127.0.0.1:9000/dashboard/
+
 # Publish and protect Traefik Dashboard with basic Auth
 
 To expose the dashboard in a secure way as [recommended](https://doc.traefik.io/traefik/operations/dashboard/#dashboard-router-rule)

--- a/README.md
+++ b/README.md
@@ -51,43 +51,7 @@ Complete documentation on all available parameters is in the [default file](./tr
 helm install -f myvalues.yaml traefik traefik/traefik
 ```
 
-#### Warning
-
-Helm v2 support was removed in the chart version 10.0.0.
-
-### Exposing the Traefik dashboard
-
-This HelmChart does not expose the Traefik dashboard by default, for security concerns.
-Thus, there are multiple ways to expose the dashboard.
-For instance, the dashboard access could be achieved through a port-forward :
-
-```bash
-kubectl port-forward $(kubectl get pods --selector "app.kubernetes.io/name=traefik" --output=name) 9000:9000
-```
-
-Accessible with the url: http://127.0.0.1:9000/dashboard/
-
-Another way would be to apply your own configuration, for instance,
-by defining and applying an IngressRoute CRD (`kubectl apply -f dashboard.yaml`):
-
-```yaml
-# dashboard.yaml
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  name: dashboard
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`traefik.localhost`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
-      kind: Rule
-      services:
-        - name: api@internal
-          kind: TraefikService
-```
-
-Accessible with the url: http://traefik.localhost/dashboard/
+🛂 **Warning**: Helm v2 support was removed in the chart version 10.0.0.
 
 ## Upgrading
 


### PR DESCRIPTION
### What does this PR do?

Moves configuration example from the README and put it into EXAMPLES.

### Motivation

It's more coherent to have all the dashboard-related documentation in the same place. 
It also makes the README more readable.

