### PR TITLE
⬆️Update Traefik to v2.9.5

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 20.5.2  ![AppVersion: v2.9.5](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.5&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2022-11-23
+
+* ⬆️i Update Traefik appVersion to 2.9.5
+* 🐛 Use static appVersion for testing container config
+
+
 ## 20.5.1  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2022-11-23

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 20.5.1
-appVersion: v2.9.4
+version: 20.5.2
+appVersion: v2.9.5
 keywords:
   - traefik
   - ingress
@@ -25,4 +25,5 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - 🐛 Fix namespaceSelector on ServiceMonitor
+    - ⬆️i Update Traefik appVersion to 2.9.5
+    - 🐛 Use static appVersion for testing container config

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -1,12 +1,14 @@
 suite: Main Container configuration
 templates:
   - deployment.yaml
+chart:
+  appVersion: v2.0.0
 tests:
   - it: should have the default Docker image when no value is specified
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik:v2.9.4
+          value: traefik:v2.0.0
   - it: should change image when image.tag value is specified
     set:
       image:
@@ -22,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: traefik/traefik:v2.9.4
+          value: traefik/traefik:v2.0.0
 
   - it: should have no resource limit by default
     asserts:
@@ -179,7 +181,7 @@ tests:
     asserts:
       - isSubset:
           path: spec.selector
-          content: 
+          content:
             matchLabels:
               app.kubernetes.io/name: traefik
               app.kubernetes.io/instance: RELEASE-NAME-NAMESPACE
@@ -189,7 +191,7 @@ tests:
     asserts:
       - isSubset:
           path: spec.selector
-          content: 
+          content:
             matchLabels:
               app.kubernetes.io/name: traefik
               app.kubernetes.io/instance: traefik


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Update Traefik to the [latest version (2.9.5)](https://github.com/traefik/traefik/releases/tag/v2.9.5).

Also use a static appVersion for testing container configuration, inspired by https://github.com/traefik/traefik-helm-chart/pull/734.
This removes the need to update this file on every Traefik update.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

