### PR TITLE
🐛 Fix template issue with obsolete helm version + add helm version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If needed, one may use [extraObjects](./traefik/tests/values/extra.yaml) or exte
 
 ### Prerequisites
 
-1. [x] Helm **v3** [installed](https://helm.sh/docs/using_helm/#installing-helm): `helm version`
+1. [x] Helm **v3 > 3.9.0** [installed](https://helm.sh/docs/using_helm/#installing-helm): `helm version`
 2. [x] Traefik's chart repository: `helm repo add traefik https://traefik.github.io/charts`
 
 ### Kubernetes Version Support

--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,11 +1,17 @@
 # Change Log
 
+## 20.5.3  ![AppVersion: v2.9.5](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.5&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2022-11-25
+
+* 🐛 Fix template issue with obsolete helm version + add helm version requirement (#743)
+
+
 ## 20.5.2  ![AppVersion: v2.9.5](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.5&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-**Release date:** 2022-11-23
+**Release date:** 2022-11-24
 
-* ⬆️i Update Traefik appVersion to 2.9.5
-* 🐛 Use static appVersion for testing container config
+* ⬆️Update Traefik to v2.9.5 (#740)
 
 
 ## 20.5.1  ![AppVersion: v2.9.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.9.4&color=success&logo=) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 20.5.2
+version: 20.5.3
 appVersion: v2.9.5
 keywords:
   - traefik
@@ -25,5 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - ⬆️i Update Traefik appVersion to 2.9.5
-    - 🐛 Use static appVersion for testing container config
+    - 🐛 Fix template issue with obsolete helm version + add helm version requirement

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -136,10 +136,10 @@
           {{- if .addRoutersLabels}}
           - "--metrics.datadog.addRoutersLabels=true"
           {{- end }}
-          {{- if eq .addEntryPointsLabels false }}
+          {{- if eq (.addEntryPointsLabels | toString) "false" }}
           - "--metrics.datadog.addEntryPointsLabels=false"
           {{- end }}
-          {{- if eq .addServicesLabels false }}
+          {{- if eq (.addServicesLabels | toString) "false" }}
           - "--metrics.datadog.addServicesLabels=false"
           {{- end }}
           {{- end }}
@@ -168,10 +168,10 @@
           {{- if .addRoutersLabels}}
           - "--metrics.influxdb.addRoutersLabels=true"
           {{- end }}
-          {{- if eq .addEntryPointsLabels false }}
+          {{- if eq (.addEntryPointsLabels | toString) "false" }}
           - "--metrics.influxdb.addEntryPointsLabels=false"
           {{- end }}
-          {{- if eq .addServicesLabels false }}
+          {{- if eq (.addServicesLabels | toString) "false" }}
           - "--metrics.influxdb.addServicesLabels=false"
           {{- end }}
           {{- end }}
@@ -190,23 +190,24 @@
           {{- if .addRoutersLabels}}
           - "--metrics.influxdb2.addRoutersLabels=true"
           {{- end }}
-          {{- if eq .addEntryPointsLabels false }}
+          {{- if eq (.addEntryPointsLabels | toString) "false" }}
           - "--metrics.influxdb2.addEntryPointsLabels=false"
           {{- end }}
-          {{- if eq .addServicesLabels false }}
+          {{- if eq (.addServicesLabels | toString) "false" }}
           - "--metrics.influxdb2.addServicesLabels=false"
           {{- end }}
           {{- end }}
           {{- if (or .Values.metrics.prometheus .Values.hub.enabled) }}
           - "--metrics.prometheus=true"
           - "--metrics.prometheus.entrypoint={{ .Values.metrics.prometheus.entryPoint }}"
-          {{- if (or .Values.metrics.prometheus.addRoutersLabels .Values.hub.enabled) }}
+          {{- if (or (eq (.Values.metrics.prometheus.addRoutersLabels | toString) "true") .Values.hub.enabled) }}
           - "--metrics.prometheus.addRoutersLabels=true"
           {{- end }}
-          {{- if eq .Values.metrics.prometheus.addEntryPointsLabels false }}
+          {{- if eq (.Values.metrics.prometheus.addEntryPointsLabels | toString) "false" }}
+
           - "--metrics.prometheus.addEntryPointsLabels=false"
           {{- end }}
-          {{- if eq .Values.metrics.prometheus.addServicesLabels false }}
+          {{- if eq (.Values.metrics.prometheus.addServicesLabels| toString) "false" }}
           - "--metrics.prometheus.addServicesLabels=false"
           {{- end }}
           {{- if .Values.metrics.prometheus.buckets }}
@@ -228,10 +229,10 @@
           {{- if .addRoutersLabels}}
           - "--metrics.statsd.addRoutersLabels=true"
           {{- end }}
-          {{- if eq .addEntryPointsLabels false }}
+          {{- if eq (.addEntryPointsLabels | toString) "false" }}
           - "--metrics.statsd.addEntryPointsLabels=false"
           {{- end }}
-          {{- if eq .addServicesLabels false }}
+          {{- if eq (.addServicesLabels | toString) "false" }}
           - "--metrics.statsd.addServicesLabels=false"
           {{- end }}
           {{- end }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{/* check helm version */}}
+{{- if (semverCompare "<v3.9.0" (.Capabilities.HelmVersion.Version | default "v3.0.0")) -}}
+    {{- fail "ERROR: Helm >= 3.9.0 is required" -}}
+{{- end -}}
+
 {{- if and .Values.deployment.enabled (eq .Values.deployment.kind "Deployment") -}}
   {{- if gt (int .Values.deployment.replicas) 1 -}}
     {{- with .Values.additionalArguments -}}


### PR DESCRIPTION
### What does this PR do?

This PR makes pod template work with all helm v3 versions and also adds a version requirement from helm, set to 3.9.0.
[3.8.0](https://github.com/helm/helm/commit/3841af9a963b1070267ed4880f064ec8b5f624f7) fixes https://github.com/traefik/traefik-helm-chart/issues/741 but helm version retrieval is working only since 3.9.0.


### Motivation

Helm template installation doesn't raise any error.
Fixes: https://github.com/traefik/traefik-helm-chart/issues/741


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

