### PR TITLE
:bug: Add missing scheme in help on Traefik Hub integration

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -10,7 +10,7 @@ Traefik Hub integration is enabled ! With your specific parameters,
 `metricsURL`, `tunnelHost` and `tunnelPort` needs to be set accordingly
 on hub-agent Helm Chart. Based on this Chart, it should be:
 
-  --set controllerDeployment.traefik.metricsURL=traefik-hub.{{ template "traefik.namespace" . }}.svc.cluster.local:{{ .Values.ports.metrics.port }}/metrics
+  --set controllerDeployment.traefik.metricsURL=http://traefik-hub.{{ template "traefik.namespace" . }}.svc.cluster.local:{{ .Values.ports.metrics.port }}/metrics
   --set tunnelDeployment.traefik.tunnelHost=traefik-hub.{{ template "traefik.namespace" . }}.svc.cluster.local
   --set tunnelDeployment.traefik.tunnelPort={{ default 9901 .Values.hub.tunnelPort }}
 

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -45,7 +45,7 @@ tests:
             `metricsURL`, `tunnelHost` and `tunnelPort` needs to be set accordingly
             on hub-agent Helm Chart. Based on this Chart, it should be:
 
-              --set controllerDeployment.traefik.metricsURL=traefik-hub.NAMESPACE.svc.cluster.local:9100/metrics
+              --set controllerDeployment.traefik.metricsURL=http://traefik-hub.NAMESPACE.svc.cluster.local:9100/metrics
               --set tunnelDeployment.traefik.tunnelHost=traefik-hub.NAMESPACE.svc.cluster.local
               --set tunnelDeployment.traefik.tunnelPort=9901
 


### PR DESCRIPTION
### What does this PR do?

Add missing `http` in NOTES.txt

### Motivation

The scheme is mandatory on hub-agent for this setting. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

