### PR TITLE
:bug: Fix typo on bufferingSize for access logs

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -485,8 +485,8 @@
           {{- if .access.filePath }}
           - "--accesslog.filepath={{ .access.filePath }}"
           {{- end }}
-          {{- if .access.bufferingsize }}
-          - "--accesslog.bufferingsize={{ .access.bufferingsize }}"
+          {{- if .access.bufferingSize }}
+          - "--accesslog.bufferingsize={{ .access.bufferingSize }}"
           {{- end }}
           {{- if .access.filters }}
           {{- if .access.filters.statuscodes }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -392,6 +392,7 @@ tests:
           enabled: true
           format: json
           filePath: "/data/log"
+          bufferingSize: 100
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -402,3 +403,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.filepath=/data/log"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--accesslog.bufferingsize=100"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -222,7 +222,8 @@ logs:
     # By default, the logs use a text format (common), but you can
     # also ask for the json format in the format option
     # format: json
-    # By default, the level is set to ERROR. Alternative logging levels are DEBUG, PANIC, FATAL, ERROR, WARN, and INFO.
+    # By default, the level is set to ERROR.
+    # Alternative logging levels are DEBUG, PANIC, FATAL, ERROR, WARN, and INFO.
     level: ERROR
   access:
     # To enable access logs


### PR DESCRIPTION
### What does this PR do?

Fixes a typo on bufferingSize for access logs.

### Motivation

It was not functioning as documented in values.yaml.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

