### PR TITLE
🐛 Don't fail when prometheus is disabled

### DIFF
--- a/traefik/templates/service-metrics.yaml
+++ b/traefik/templates/service-metrics.yaml
@@ -3,6 +3,8 @@
   {{- fail "ERROR: Cannot create a metrics service when name contains more than 50 characters" }}
 {{- end }}
 
+{{- if .Values.metrics.prometheus }}
+{{- if .Values.metrics.prometheus.service }}
 {{- if (and (.Values.metrics.prometheus.service).enabled (not .Values.hub.enabled)) -}}
 apiVersion: v1
 kind: Service
@@ -26,5 +28,6 @@ spec:
     {{- if .Values.ports.metrics.nodePort }}
     nodePort: {{ .Values.ports.metrics.nodePort }}
     {{- end }}
-{{- end -}}
-
+{{- end }}
+{{- end }}
+{{- end }}

--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -2,6 +2,13 @@ suite: Traefik Metrics configuration
 templates:
   - deployment.yaml
 tests:
+  - it: "should support to set prometheus: null"
+    set:
+      metrics:
+        prometheus: null
+    asserts:
+      - hasDocuments:
+          count: 1
   - it: should have prometheus enabled by default on metrics entrypoint
     asserts:
       - contains:

--- a/traefik/tests/service-metrics-config_test.yaml
+++ b/traefik/tests/service-metrics-config_test.yaml
@@ -2,6 +2,13 @@ suite: Metrics Service configuration
 templates:
   - service-metrics.yaml
 tests:
+  - it: "should support prometheus: null"
+    set:
+      metrics:
+        prometheus: null
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should not provide a dedicated metrics service by default
     asserts:
       - hasDocuments:


### PR DESCRIPTION
### What does this PR do?

Ensure Helm Chart does not fail when setting metrics.prometheus=null.

### Motivation

Fixes #755

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

