### PR TITLE
fix(service-metrics): invert prometheus svc & fullname length checking

### DIFF
--- a/traefik/templates/service-metrics.yaml
+++ b/traefik/templates/service-metrics.yaml
@@ -1,11 +1,11 @@
+{{- if .Values.metrics.prometheus }}
+{{- if .Values.metrics.prometheus.service }}
+{{- if (and (.Values.metrics.prometheus.service).enabled (not .Values.hub.enabled)) -}}
+
 {{- $fullname := include "traefik.fullname" . }}
 {{- if ge (len $fullname) 50 }}
   {{- fail "ERROR: Cannot create a metrics service when name contains more than 50 characters" }}
 {{- end }}
-
-{{- if .Values.metrics.prometheus }}
-{{- if .Values.metrics.prometheus.service }}
-{{- if (and (.Values.metrics.prometheus.service).enabled (not .Values.hub.enabled)) -}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Invert Prometheus metrics service creation check and the Traefik fullname length check.
Fix: https://github.com/traefik/traefik-helm-chart/issues/759


### Motivation

If we have a release name with more than 50 chars but we don't want to create a metrics service, then the Helm rendering will fail.

With this PR, it will not fail anymore.


### More

- [ ] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

