### PR TITLE
📝 Improve documentation on entrypoint options

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -580,7 +580,7 @@ ports:
     # hostPort: 8443
     expose: true
     exposedPort: 443
-    # The port protocol (TCP/UDP)
+    ## The port protocol (TCP/UDP)
     protocol: TCP
     # nodePort: 32443
     #
@@ -594,6 +594,16 @@ ports:
       enabled: false
     # advertisedPort: 4443
     #
+    ## Trust forwarded  headers information (X-Forwarded-*).
+    #forwardedHeaders:
+    #  trustedIPs: []
+    #  insecure: false
+    #
+    ## Enable the Proxy Protocol header parsing for the entry point
+    #proxyProtocol:
+    #  trustedIPs: []
+    #  insecure: false
+    #
     ## Set TLS at the entrypoint
     ## https://doc.traefik.io/traefik/routing/entrypoints/#tls
     tls:
@@ -606,16 +616,6 @@ ports:
       #   sans:
       #     - foo.example.com
       #     - bar.example.com
-    #
-    # Trust forwarded  headers information (X-Forwarded-*).
-    # forwardedHeaders:
-    #   trustedIPs: []
-    #   insecure: false
-    #
-    # Enable the Proxy Protocol header parsing for the entry point
-    # proxyProtocol:
-    #   trustedIPs: []
-    #   insecure: false
     #
     # One can apply Middlewares on an entrypoint
     # https://doc.traefik.io/traefik/middlewares/overview/


### PR DESCRIPTION
### What does this PR do?

1. It put documentation line with double ##.
2. It moves some entrypoint options before tls part 

### Motivation

Help users to avoid confusion between tls options and entrypoint options. See #767 

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

