### PR TITLE
fix: allowExternalNameServices for kubernetes ingress when hub enabled

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -440,7 +440,7 @@
           {{- end }}
           {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
-          {{- if .Values.providers.kubernetesIngress.allowExternalNameServices }}
+          {{- if (or .Values.providers.kubernetesIngress.allowExternalNameServices .Values.hub.enabled) }}
           - "--providers.kubernetesingress.allowExternalNameServices=true"
           {{- end }}
           {{- if .Values.providers.kubernetesIngress.allowEmptyServices }}


### PR DESCRIPTION
### Description

This PR allows allowExternalNameServices for kubernterIngress provider when hub is enabled