### PR TITLE
Fix existing tag detection in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  tag_prefix: v
+
 jobs:
   test:
     uses: "traefik/traefik-helm-chart/.github/workflows/test.yml@master"
@@ -43,7 +46,7 @@ jobs:
         id: tag_exists
         run: |
           TAG_EXISTS=true
-          if ! [ $(git tag -l "${{ steps.chart_version.outputs.CHART_VERSION }}") ]; then
+          if ! [ $(git tag -l "${{ env.tag_prefix }}${{ steps.chart_version.outputs.CHART_VERSION }}") ]; then
               TAG_EXISTS=false
           fi
           echo TAG_EXISTS=$TAG_EXISTS >> $GITHUB_OUTPUT
@@ -54,6 +57,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.chart_version.outputs.CHART_VERSION }}
+          tag_prefix: ${{ env.tag_prefix }}
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Create release


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fix failing workflows for commits on `master` with existing tags.


### Motivation

Currently the step `Check if tag exists` on the `release` job fails to detect existing tags, because it does not account for the prefix `v` added (by default) by the `Tag release` action. This PR explicitly adds the prefix to both stages.

See also [`succesful example run on my fork`](https://github.com/jnoordsij/traefik-helm-chart/actions/runs/3874275347/jobs/6605281682) and [`currently failing run on master`](https://github.com/traefik/traefik-helm-chart/actions/runs/3828467971/jobs/6514093053).

### More

- [ ] ~~Yes, I updated the tests accordingly~~
- [ ] ~~Yes, I ran `make test` and all the tests passed~~

