### PR TITLE
:boom: Rename image.name => image.repository

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Create the chart image name.
 */}}
 
 {{- define "traefik.image-name" -}}
-{{- printf "%s:%s" .Values.image.name (.Values.image.tag | default .Chart.AppVersion) }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end -}}
 {{/*
 Create a default fully qualified app name.

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -17,10 +17,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: traefik:v2.0.0-beta1
-  - it: should change image when image.name value is specified
+  - it: should change image when image.repository value is specified
     set:
       image:
-        name: traefik/traefik
+        repository: traefik/traefik
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image:
-  name: traefik
+  repository: traefik
   # defaults to appVersion
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
### What does this PR do?

Rename helm value from `image.name` to `image.repository`
It's just a renaming, no change on the behaviour.

### Motivation

It's in fact a repository path and it's needed for Renovate compatibility.
See #625 & https://github.com/renovatebot/renovate/issues/7010

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

