### PR TITLE
:bug: Disabling dashboard ingressroute should delete it

### DIFF
--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -5,9 +5,6 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   namespace: {{ template "traefik.namespace" . }}
   annotations:
-    helm.sh/hook: "post-install,post-upgrade"
-    meta.helm.sh/release-name: {{ .Release.Name }}
-    meta.helm.sh/release-namespace: {{ template "traefik.namespace" . }}
     {{- with .Values.ingressRoute.dashboard.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -1,6 +1,6 @@
 suite: Dashboard IngressRoute configuration
 templates:
-  - dashboard-hook-ingressroute.yaml
+  - dashboard-ingressroute.yaml
 tests:
   - it: should allow disabling dashboard exposure using ingressRoute
     set:


### PR DESCRIPTION
### What does this PR do?

Set dashboard `IngressRoute` as a regular helm resource instead of a hook.
Forced to make a new PR from #668 : I was unable to update it. 

### Motivation

It's not needed anymore to install it with a hook. 
Fixes #115

If you see during upgrade this message
```bash
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. 
Unable to continue with update: IngressRoute "traefik-dashboard" in namespace "default" exists and cannot be imported into the current release: invalid ownership metadata;
annotation validation error: missing key "meta.helm.sh/release-name": must be set to "traefik"; 
annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "default"
```

That means you were on Traefik Helm Chart in version < 15.2.1 and tried to upgrade directly to latest version. 
You'll need to upgrade to at least v15.2.1 before upgrading to latest version. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed
- [x] Is there a way to avoid break during upgrade between hook version and regular version ? 

