### PR TITLE
fix: traefik image name for renovate

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 21.0.0
-# renovate: image=traefik/traefik
+# renovate: image=traefik
 appVersion: v2.9.6
 kubeVersion: ">=1.16.0-0"
 keywords:


### PR DESCRIPTION
### What does this PR do?

This PR fix the image name for renovate. 

Traefik is built as an official image.


