### PR TITLE
Separate UDP hostPort for HTTP/3

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -76,6 +76,15 @@
           hostIP: {{ $config.hostIP }}
           {{- end }}
           protocol: {{ default "TCP" $config.protocol | quote }}
+        {{- if $config.http3 }}
+        {{- if and $config.http3.enabled $config.hostPort }}
+        {{- $http3Port := default $config.exposedPort $config.http3.advertisedPort }}
+        - name: "{{ $name }}-http3"
+          containerPort: {{ $config.port }}
+          hostPort: {{ $config.hostPort }}
+          protocol: UDP
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.hub.enabled }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -464,3 +464,42 @@ tests:
           of: Deployment
       - isAPIVersion:
           of: apps/v1
+  - it: should have only one http3 port when not using hostport
+    set:
+      ports:
+        websecure:
+          http3:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          any: true
+          count: 1
+          content:
+            containerPort: 8443
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: websecure-http3
+  - it: should have two separate http3 port when using hostport
+    set:
+      ports:
+        websecure:
+          hostPort: 443
+          http3:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8443
+            hostPort: 443
+            name: websecure
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8443
+            hostPort: 443
+            name: websecure-http3
+            protocol: UDP


### PR DESCRIPTION
<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Changed the podSpec to have 2 separate ports for HTTP/3 when using hostPort

### Motivation

<!-- What inspired you to submit this pull request? -->

The Kubernetes Service provides multiple port specs for HTTP/3, with one for TCP and one for UDP. But when using hostPort, the host bypasses the Service and goes straight for the container. Because of this, the duplicate ports spec needs to be specified both in the Service (for inter-pod usage) and inside the podSpec (for hostPort usage).

My setup needs this, because I don't want to pay 10$ more per month to my cloud provider just because I need to use a LoadBalancer Service, especially since I only have a small single-node cluster.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

