### PR TITLE
🚨 Fail when enabling PSP on Kubernetes v1.25+

### DIFF
--- a/traefik/templates/rbac/podsecuritypolicy.yaml
+++ b/traefik/templates/rbac/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podSecurityPolicy.enabled }}
 {{- if semverCompare ">=1.25.0-0" .Capabilities.KubeVersion.Version }}
-  {{- fail "ERROR: PodSecurityPolicy has been deprecated on Kubernetes v1.25+" }}
+  {{- fail "ERROR: PodSecurityPolicy has been removed in Kubernetes v1.25+" }}
 {{- end }}
 ---
 apiVersion: policy/v1beta1

--- a/traefik/templates/rbac/podsecuritypolicy.yaml
+++ b/traefik/templates/rbac/podsecuritypolicy.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.podSecurityPolicy.enabled }}
+{{- if semverCompare ">=1.25.0-0" .Capabilities.KubeVersion.Version }}
+  {{- fail "ERROR: PodSecurityPolicy has been deprecated on Kubernetes v1.25+" }}
+{{- end }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/traefik/tests/podsecuritypolicy-config_test.yaml
+++ b/traefik/tests/podsecuritypolicy-config_test.yaml
@@ -2,11 +2,25 @@ suite: PodSecurityPolicy configuration
 templates:
   - rbac/podsecuritypolicy.yaml
   - rbac/clusterrole.yaml
+capabilities:
+  majorVersion: 1
+  minorVersion: 20
 tests:
   - it: should be disabled by default
     asserts:
       - hasDocuments:
           count: 0
+        template: rbac/podsecuritypolicy.yaml
+  - it: should throw an error when enabled on k8s >= v1.25
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    set:
+      podSecurityPolicy:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "PodSecurityPolicy has been deprecated on Kubernetes v1.25+"
         template: rbac/podsecuritypolicy.yaml
   - it: should have privileged set to false
     set:

--- a/traefik/tests/podsecuritypolicy-config_test.yaml
+++ b/traefik/tests/podsecuritypolicy-config_test.yaml
@@ -20,7 +20,7 @@ tests:
         enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "PodSecurityPolicy has been deprecated on Kubernetes v1.25+"
+          errorMessage: "PodSecurityPolicy has been removed in Kubernetes v1.25+"
         template: rbac/podsecuritypolicy.yaml
   - it: should have privileged set to false
     set:


### PR DESCRIPTION
### What does this PR do?

It produces an error when enabling PodSecurityPolicy on Kubernetes 1.25+.


### Motivation

It has been [removed](https://kubernetes.io/docs/concepts/security/pod-security-policy/) by Kubernetes.
Some users missed it and does not understand why it fails to install, see https://github.com/traefik/traefik-helm-chart/issues/800

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

