### PR TITLE
add additional labels to tlsoption

### DIFF
--- a/traefik/templates/tlsoption.yaml
+++ b/traefik/templates/tlsoption.yaml
@@ -6,7 +6,37 @@ metadata:
   namespace: {{ template "traefik.namespace" $ }}
   labels:
     {{- include "traefik.labels" $ | nindent 4 }}
+    {{- with $config.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}    
 spec:
-  {{- toYaml $config | nindent 2 }}
+  {{- with $config.alpnProtocols }}
+  alpnProtocols:
+  {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with $config.cipherSuites }}
+  cipherSuites:
+  {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with $config.clientAuth }}
+  clientAuth:
+  {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with $config.curvePreferences }}
+  curvePreferences:
+  {{- toYaml . | nindent 6 }}
+  {{- end }}  
+  {{- if $config.maxVersion }}
+  maxVersion: {{ $config.maxVersion }}
+  {{- end }}
+  {{- if $config.minVersion }}
+  minVersion: {{ $config.minVersion }}
+  {{- end }}
+  {{- if $config.preferServerCipherSuites }}
+  preferServerCipherSuites: {{ $config.preferServerCipherSuites }}
+  {{- end }}
+  {{- if $config.sniStrict }}
+  sniStrict: {{ $config.sniStrict }}
+  {{- end }}
 ---
 {{- end -}}

--- a/traefik/tests/tlsoption_test.yaml
+++ b/traefik/tests/tlsoption_test.yaml
@@ -1,0 +1,139 @@
+suite: TlsOption configuration
+templates:
+  - tlsoption.yaml
+tests:
+  - it: should use helm managed namespace as default behavior
+    set:
+      tlsOptions:
+        default:
+          labels:
+            foo: bar
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+  - it: should set tlsoption name
+    set:
+      tlsOptions:
+        default:
+          labels:
+            foo: bar
+    asserts:
+      - equal:
+          path: metadata.name
+          value: default
+  - it: should set additional labels
+    set:
+      tlsOptions:
+        default:
+          labels:
+            label: label
+    asserts:
+      - equal:
+          path: metadata.labels.label
+          value: label
+  - it: should set cipherSuites
+    set:
+      tlsOptions:
+        default:
+          labels:
+          cipherSuites:
+            - cipherSuite
+    asserts:
+      - equal:
+          path: spec.cipherSuites[0]
+          value: cipherSuite
+  - it: should set alpnProtocols
+    set:
+      tlsOptions:
+        default:
+          labels:
+          alpnProtocols:
+            - alpnProtocol
+    asserts:
+      - equal:
+          path: spec.alpnProtocols[0]
+          value: alpnProtocol
+  - it: should set clientAuthConfig
+    set:
+      tlsOptions:
+        default:
+          labels:
+          clientAuth:
+            clientAuthType: clientAuthType
+    asserts:
+      - equal:
+          path: spec.clientAuth
+          value:
+            clientAuthType: clientAuthType
+  - it: should set curvePreferences
+    set:
+      tlsOptions:
+        default:
+          labels:
+          curvePreferences:
+            - curvePreference
+    asserts:
+      - equal:
+          path: spec.curvePreferences[0]
+          value: curvePreference
+  - it: should set minVersion
+    set:
+      tlsOptions:
+        default:
+          labels:
+          minVersion: minVersion
+    asserts:
+      - equal:
+          path: spec.minVersion
+          value: minVersion
+  - it: should set maxVersion
+    set:
+      tlsOptions:
+        default:
+          labels:
+          maxVersion: maxVersion
+    asserts:
+      - equal:
+          path: spec.maxVersion
+          value: maxVersion
+  - it: should set preferServerCipherSuites
+    set:
+      tlsOptions:
+        default:
+          labels:
+          preferServerCipherSuites: true
+    asserts:
+      - equal:
+          path: spec.preferServerCipherSuites
+          value: true
+  - it: should set sniStrict
+    set:
+      tlsOptions:
+        default:
+          labels:
+          sniStrict: true
+    asserts:
+      - equal:
+          path: spec.sniStrict
+          value: true
+  - it: should render config without labels
+    set:
+      tlsOptions:
+        default:
+          minVersion: minVersion
+    asserts:
+      - equal:
+          path: metadata
+          value:
+            name: default
+            namespace: NAMESPACE
+            labels:
+              app.kubernetes.io/instance: RELEASE-NAME-NAMESPACE
+              app.kubernetes.io/managed-by: Helm
+              app.kubernetes.io/name: traefik
+              helm.sh/chart: traefik-22.0.0
+      - equal:
+          path: spec
+          value:
+            minVersion: minVersion

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -654,12 +654,15 @@ ports:
 
 # TLS Options are created as TLSOption CRDs
 # https://doc.traefik.io/traefik/https/tls/#tls-options
+# You can add additional labels to a tlsOption
 # Example:
 # tlsOptions:
 #   default:
+#     labels: {}
 #     sniStrict: true
 #     preferServerCipherSuites: true
-#   foobar:
+#   customOptions:
+#     labels: {}
 #     curvePreferences:
 #       - CurveP521
 #       - CurveP384


### PR DESCRIPTION
### What does this PR do?
When using custom TLSOptions together with labelSelectors, the helm chart was unable to generate a matching label when using tlsOption key.
This PR enables users to add custom labels to any custom TLSOption defined so that you have fine grained control over which TLSOption a traefik intance should pick up.

### Motivation
A possible workaround was to use extraObject, however it seems a little bit unintuitive for me as a user tries to use built in TLSOption first.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

[x] HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

