### PR TITLE
Allow readOnly to be specified on volume mounts

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -123,7 +123,7 @@
           {{- range .Values.volumes }}
           - name: {{ tpl (.name) $root | replace "." "-" }}
             mountPath: {{ .mountPath }}
-            readOnly: true
+            readOnly: {{ .readOnly }}
           {{- end }}
           {{- if .Values.experimental.plugins.enabled }}
           - name: plugins


### PR DESCRIPTION
### What does this PR do?

Passes through the `readOnly` flag from the `volumes[]` section. The current value is hardcoded to `true`.

### Motivation

TLDR: I want to provide my own volume and have letsencrypt manage an `acme.json` in it.

I've spent a fair chunk of time weeding through file-system permissions issues. Seems like others have been [struggling too](https://github.com/traefik/traefik-helm-chart/issues/165). The `persistence` configuration option didn't work for me and I've forgotten why (sorry!).

It seems reasonable that volume mounts shouldn't only be `readOnly`, but perhaps there are other ideas how one should approach this. If that's the case, maybe a troubleshooting readme section would suffice.
