### PR TITLE
Update service.yaml

### DIFF
--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: {{ template "traefik.namespace" . }}
   {{- template "traefik.service-metadata" . }}
   annotations:
-  {{- with (merge .Values.service.annotationsTCP .Values.service.annotations) }}
+  {{- with (merge dict .Values.service.annotationsTCP .Values.service.annotations) }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
Relates to https://github.com/helm/helm/issues/11891 .

Merge mutates its first parameter and this is not isolated between multiple aliased subcharts.

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

I have this Chart.yaml
```yaml
apiVersion: v2
name: inf-traefik
description: A Helm chart for Kubernetes
type: application
version: 0.1.0
dependencies:
  - name: traefik
    version: ">0"
    repository: https://helm.traefik.io/traefik
    alias: traefik-external
  - name: traefik
    version: ">0"
    repository: https://helm.traefik.io/traefik
    alias: traefik-internal
```
And this values.yaml
```yaml
traefik-external:
  ingressRoute:
    dashboard:
      annotations:
        kubernetes.io/ingress.class: traefik-ext

  service:
    annotations:
      external-dns.alpha.kubernetes.io/hostname: "*.lb-ext.alpha.example.com"


traefik-internal:
  ingressRoute:
    dashboard:
      annotations:
        kubernetes.io/ingress.class: traefik-int

  service:
    name: traefik-int
    annotations:
      external-dns.alpha.kubernetes.io/hostname: "*.lb-int.alpha.example.com"
```

When running template I would expect that each aliased subchart receives only its specific values. But rendering the template, I get both services with same value.

```
❯ helm template . | grep hostname:
    external-dns.alpha.kubernetes.io/hostname: '*.lb-int.alpha.example.com'
    external-dns.alpha.kubernetes.io/hostname: '*.lb-int.alpha.example.com'
```
Where I'd expect to have
```
❯ helm3 template . | grep hostname:
    external-dns.alpha.kubernetes.io/hostname: '*.lb-ext.alpha.example.com' # not an actual result
    external-dns.alpha.kubernetes.io/hostname: '*.lb-int.alpha.example.com'
```



### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

