### PR TITLE
fix: 🐛 update rbac for both traefik.io and containo.us apigroups

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -44,6 +44,7 @@ rules:
 {{- end -}}
 {{- if .Values.providers.kubernetesCRD.enabled }}
   - apiGroups:
+      - traefik.io
       - traefik.containo.us
     resources:
       - ingressroutes

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -37,6 +37,7 @@ rules:
 {{- end -}}
 {{- if .Values.providers.kubernetesCRD.enabled }}
   - apiGroups:
+      - traefik.io
       - traefik.containo.us
     resources:
       - ingressroutes

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -227,3 +227,53 @@ tests:
           path: subjects[0].namespace
           value: "traefik-ns-override"
         template: rbac/rolebinding.yaml
+  - it: cluster rbac should be on both traefik.io and containo.us API group
+    set:
+    asserts:
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - traefik.io
+              - traefik.containo.us
+            resources:
+              - ingressroutes
+              - ingressroutetcps
+              - ingressrouteudps
+              - middlewares
+              - middlewaretcps
+              - tlsoptions
+              - tlsstores
+              - traefikservices
+              - serverstransports
+            verbs:
+              - get
+              - list
+              - watch
+  - it: namespaced rbac should be on both traefik.io and containo.us API group
+    set:
+      rbac:
+        namespaced: true
+    asserts:
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - traefik.io
+              - traefik.containo.us
+            resources:
+              - ingressroutes
+              - ingressroutetcps
+              - ingressrouteudps
+              - middlewares
+              - middlewaretcps
+              - tlsoptions
+              - tlsstores
+              - traefikservices
+              - serverstransports
+            verbs:
+              - get
+              - list
+              - watch


### PR DESCRIPTION
### What does this PR do?

Update rbac to use both API Groups


### Motivation

It's needed by Traefik v2.10.
It should also fix #835.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

