### PR TITLE
Fix Let's Encrypt example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -315,6 +315,9 @@ deployment:
     - name: volume-permissions
       image: busybox:latest
       command: ["sh", "-c", "touch /data/acme.json; chmod -v 600 /data/acme.json"]
+      volumeMounts:
+      - mountPath: /data
+        name: data
 ```
 
 This example needs a CloudFlare token in a Kubernetes `Secret` and a working `StorageClass`.


### PR DESCRIPTION
Without the `volumeMount` the init fails, because `/data` doesn't exists.

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

