### PR TITLE
feat: add option to opt-out API credential automounting.

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -149,7 +149,7 @@ Kubernetes: `>=1.16.0-0`
 | service.single | bool | `true` |  |
 | service.spec | object | `{}` | Cannot contain type, selector or ports entries. |
 | service.type | string | `"LoadBalancer"` |  |
-| serviceAccount | object | `{"name":""}` | The service account the pods will use to interact with the Kubernetes API |
+| serviceAccount | object | `{"automountServiceAccountToken":true,"name":""}` | The service account the pods will use to interact with the Kubernetes API |
 | serviceAccountAnnotations | object | `{}` | Additional serviceAccount annotations (e.g. for oidc authentication) |
 | tlsOptions | object | `{}` | TLS Options are created as TLSOption CRDs https://doc.traefik.io/traefik/https/tls/#tls-options When using `labelSelector`, you'll need to set labels on tlsOption accordingly. Example: tlsOptions:   default:     labels: {}     sniStrict: true     preferServerCipherSuites: true   customOptions:     labels: {}     curvePreferences:       - CurveP521       - CurveP384 |
 | tlsStore | object | `{}` | TLS Store are created as TLSStore CRDs. This is useful if you want to set a default certificate https://doc.traefik.io/traefik/https/tls/#default-certificate Example: tlsStore:   default:     defaultCertificate:       secretName: tls-cert |

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
   {{- with .Values.serviceAccountAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -29,6 +29,10 @@ tests:
           value: RELEASE-NAME-traefik
         template: rbac/serviceaccount.yaml
       - equal:
+          path: automountServiceAccountToken
+          value: true
+        template: rbac/serviceaccount.yaml
+      - equal:
           path: spec.template.spec.serviceAccountName
           value: RELEASE-NAME-traefik
         template: deployment.yaml

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -834,6 +834,8 @@ serviceAccount:
   # If set, an existing service account is used
   # If not set, a service account is created automatically using the fullname template
   name: ""
+  # Allows auto mount of ServiceAccountToken on the serviceAccount created
+  automountServiceAccountToken: true
 
 # -- Additional serviceAccount annotations (e.g. for oidc authentication)
 serviceAccountAnnotations: {}


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to opt-out API credential automounting. The default behaviour stays the same.

See [kubernetes - opt-out-of-api-credential-automounting](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting)


### Motivation

This opt-out option would help us to meet our kubernetes security policies.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed


