### PR TITLE
Add `serverstransporttcps` to clusterrole for Traefik 3

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -56,6 +56,7 @@ rules:
       - tlsstores
       - traefikservices
       - serverstransports
+      - serverstransporttcps
     verbs:
       - get
       - list


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Traefik 3 added `serverstransporttcps` so clusterole should be update. This will fix `Failed to watch *v1alpha1.ServersTransportTCP: failed to list *v1alpha1.ServersTransportTCP: serverstransporttcps.traefik.io is forbidden: User "system:serviceaccount:traefik:traefik" cannot list resource "serverstransporttcps" in API group "traefik.io" at the cluster scope` error.

### Motivation

<!-- What inspired you to submit this pull request? -->
[#870](https://github.com/traefik/traefik-helm-chart/issues/870)

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

