### PR TITLE
fix: 🐛 traefik or metrics port can be disabled

### DIFF
--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -4,21 +4,23 @@
 {{- $udpPorts := dict -}}
 {{- $exposedPorts := false -}}
 {{- range $name, $config := .Values.ports -}}
-  {{- if $config.http3 -}}
-  {{- if $config.http3.enabled -}}
-    {{- if (not $config.tls.enabled) -}}
-      {{- fail "ERROR: You cannot enable http3 without enabling tls" -}}
+  {{- if $config -}}
+    {{- if $config.http3 -}}
+    {{- if $config.http3.enabled -}}
+      {{- if (not $config.tls.enabled) -}}
+        {{- fail "ERROR: You cannot enable http3 without enabling tls" -}}
+      {{- end -}}
     {{- end -}}
-  {{- end -}}
-  {{- end -}}
-  {{- if eq (toString $config.protocol) "UDP" -}}
-    {{ $_ := set $udpPorts $name $config -}}
-  {{- end -}}
-  {{- if eq (toString (default "TCP" $config.protocol)) "TCP" -}}
-    {{ $_ := set $tcpPorts $name $config -}}
-  {{- end -}}
-  {{- if (eq $config.expose true) -}}
-    {{- $exposedPorts = true -}}
+    {{- end -}}
+    {{- if eq (toString $config.protocol) "UDP" -}}
+      {{ $_ := set $udpPorts $name $config -}}
+    {{- end -}}
+    {{- if eq (toString (default "TCP" $config.protocol)) "TCP" -}}
+      {{ $_ := set $tcpPorts $name $config -}}
+    {{- end -}}
+    {{- if (eq $config.expose true) -}}
+      {{- $exposedPorts = true -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -239,4 +239,25 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.web.address=:666/tcp"
         template: deployment.yaml
+  - it: should be possible to disable traefik & metrics port
+    set:
+      ports:
+        web:
+          port: 80
+        websecure:
+          port: 443
+          http3:
+            enabled: true
+            advertisedPort: 443
+        traefik: null
+        prometheus: null
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+        template: deployment.yaml
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+        template: service.yaml
 


### PR DESCRIPTION
### What does this PR do?

Solve error encountered when trying to disable `traefik` or `metrics` port.
/!\ Note that when you disable `traefik` ports, liveness probe will be directly on web port.

### Motivation

See #890.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

