### PR TITLE
Multi namespace RBAC manifests

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -108,10 +108,10 @@ Users can provide an override for an explicit service they want bound via `.Valu
 Construct a comma-separated list of whitelisted namespaces
 */}}
 {{- define "providers.kubernetesIngress.namespaces" -}}
-{{- default .Release.Namespace (join "," .Values.providers.kubernetesIngress.namespaces) }}
+{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngress.namespaces) }}
 {{- end -}}
 {{- define "providers.kubernetesCRD.namespaces" -}}
-{{- default .Release.Namespace (join "," .Values.providers.kubernetesCRD.namespaces) }}
+{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesCRD.namespaces) }}
 {{- end -}}
 
 {{/*

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -1,11 +1,17 @@
-{{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
+{{- $ingressNamespaces := default (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
+{{- $CRDNamespaces := default (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
+{{- $allNamespaces := uniq (concat $ingressNamespaces $CRDNamespaces) -}}
+
+{{- if and .Values.rbac.enabled .Values.rbac.namespaced -}}
+{{- range $allNamespaces }}
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
-  namespace: {{ template "traefik.namespace" . }}
+  name: {{ template "traefik.fullname" $ }}
+  namespace: {{ . }}
   labels:
-    {{- include "traefik.labels" . | nindent 4 }}
+    {{- include "traefik.labels" $ | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -17,7 +23,7 @@ rules:
       - get
       - list
       - watch
-{{- if .Values.providers.kubernetesIngress.enabled }}
+{{- if (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) }}
   - apiGroups:
       - extensions
       - networking.k8s.io
@@ -35,7 +41,7 @@ rules:
     verbs:
       - update
 {{- end -}}
-{{- if .Values.providers.kubernetesCRD.enabled }}
+{{- if (and (has . $CRDNamespaces) $.Values.providers.kubernetesCRD.enabled) }}
   - apiGroups:
       - traefik.io
       {{- if semverCompare "<3.0.0-0" (default $.Chart.AppVersion $.Values.image.tag)  }}
@@ -59,14 +65,15 @@ rules:
       - list
       - watch
 {{- end -}}
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if $.Values.podSecurityPolicy.enabled }}
   - apiGroups:
       - extensions
     resourceNames:
-      - {{ template "traefik.fullname" . }}
+      - {{ template "traefik.fullname" $ }}
     resources:
       - podsecuritypolicies
     verbs:
       - use
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -1,17 +1,24 @@
+{{- $ingressNamespaces := default (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
+{{- $CRDNamespaces := default (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
+{{- $allNamespaces := uniq (concat $ingressNamespaces $CRDNamespaces) -}}
+
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
+{{- range $allNamespaces }}
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
-  namespace: {{ template "traefik.namespace" . }}
+  name: {{ template "traefik.fullname" $ }}
+  namespace: {{ . }}
   labels:
-    {{- include "traefik.labels" . | nindent 4 }}
+    {{- include "traefik.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.fullname" $ }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "traefik.serviceAccountName" . }}
-    namespace: {{ template "traefik.namespace" . }}
+    name: {{ include "traefik.serviceAccountName" $ }}
+    namespace: {{ template "traefik.namespace" $ }}
+{{- end -}}
 {{- end -}}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -175,6 +175,56 @@ tests:
           path: metadata.namespace
           value: NAMESPACE
         template: rbac/serviceaccount.yaml
+  - it: should use multiple namespaces if provided
+    set:
+      providers:
+        kubernetesCRD:
+          namespaces:
+            - default
+            - foo
+        kubernetesIngress:
+          namespaces:
+            - default
+            - bar
+      rbac:
+        namespaced: true
+    asserts:
+      - hasDocuments:
+          count: 3
+        template: rbac/role.yaml
+      - hasDocuments:
+          count: 3
+        template: rbac/rolebinding.yaml
+      - equal:
+          path: metadata.namespace
+          value: default
+        template: rbac/role.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: bar
+        template: rbac/role.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: foo
+        template: rbac/role.yaml
+        documentIndex: 2
+      - equal:
+          path: metadata.namespace
+          value: default
+        template: rbac/rolebinding.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: bar
+        template: rbac/rolebinding.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: foo
+        template: rbac/rolebinding.yaml
+        documentIndex: 2
   - it: should accept overridden namespace
     set:
       namespaceOverride: "traefik-ns-override"


### PR DESCRIPTION
### What does this PR do?

When adding multiple namespaces to watch by the Traefik and using namespaced RBAC, this PR ensures Roles and RoleBindings are added for all relevant namespaces.


### Motivation

Currently, only a Role + RoleBinding is added for the chart namespaces. When watching more namespaces, manual adding (and maintaining) of additional resources is required, as by default the ServiceAccount has no access to the resources.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

