### PR TITLE
Fix: tracing.opentelemetry.tls is optional for all values

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -374,6 +374,7 @@
           {{- if .Values.tracing.openTelemetry.path }}
           - "--tracing.openTelemetry.path={{ .Values.tracing.openTelemetry.path }}"
           {{- end }}
+          {{- if .Values.tracing.openTelemetry.tls }}
           {{- if .Values.tracing.openTelemetry.tls.ca }}
           - "--tracing.openTelemetry.tls.ca={{ .Values.tracing.openTelemetry.tls.ca }}"
           {{- end }}
@@ -385,6 +386,7 @@
           {{- end }}
           {{- if .Values.tracing.openTelemetry.tls.insecureSkipVerify }}
           - "--tracing.openTelemetry.tls.insecureSkipVerify={{ .Values.tracing.openTelemetry.tls.insecureSkipVerify }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.tracing.openTelemetry.grpc }}
           - "--tracing.openTelemetry.grpc=true"


### PR DESCRIPTION
tracing.opentelemetry.tls is optional for all values, but tls itself it not

### What does this PR do?
min config from 
```
  tracing:
    openTelemetry:
      address: somewhere
      tls: {}
```
to
```
  tracing:
    openTelemetry:
      address: somewhere
```

### More

As we have seen I suck at making helm tests 👎 