### PR TITLE
fix: http3 support broken when advertisedPort set

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -595,13 +595,12 @@
           - "--experimental.http3=true"
                     {{- end }}
                     {{- if semverCompare ">=2.6.0-0" (default $.Chart.AppVersion $.Values.image.tag)}}
-                      {{- if $config.http3.advertisedPort }}
-          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.advertisedPort }}"
-                      {{- else }}
           - "--entrypoints.{{ $entrypoint }}.http3"
-                      {{- end }}
                     {{- else }}
           - "--entrypoints.{{ $entrypoint }}.enableHTTP3=true"
+                    {{- end }}
+                    {{- if $config.http3.advertisedPort }}
+          - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.advertisedPort }}"
                     {{- end }}
                   {{- end }}
                 {{- end }}


### PR DESCRIPTION
### What does this PR do?

when http3 enabled and http3.advertisedPort set, it would not actually set the argument to enable http3

### Motivation

I broke it

