### PR TITLE
Remove email from apiToken solver as it is no longer valid.

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -413,7 +413,6 @@ spec:
     solvers:
       - dns01:
           cloudflare:
-            email: email@example.com
             apiTokenSecretRef:
               name: cloudflare
               key: api-token


### PR DESCRIPTION
### What does this PR do?

This PR removes the email from the cloudflare solver example, as it no longer valid. Cloudflare no longer requires an email for apiToken challenges.

https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/#api-tokens


### Motivation

I have been configuring a cluster in relation to work, and was not able to make the cloudflare challenge work due having added the email. It fails silently with a message of it not being able to find the certificate it needs to complete the challenge. Removing the email property made everything work.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

