### PR TITLE
add: add internal-service ingress

### DIFF
--- a/traefik/templates/_service-internal-ingress.tpl
+++ b/traefik/templates/_service-internal-ingress.tpl
@@ -1,0 +1,41 @@
+{{- define "traefik.service-internal-ingress-metadata" }}
+  labels:
+  {{- include "traefik.labels" . | nindent 4 -}}
+  {{- with .Values.service.internal.ingress.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{- define "traefik.service-internal-ingress-tls" }}
+  - hosts:
+    {{- range $host := .Values.service.internal.ingress.tls.hosts }}
+    - {{ $host }}
+    {{- end }}
+    secretName: {{ .Values.service.internal.ingress.tls.secretName }}
+{{- end }}
+
+{{- define "traefik.service-internal-ingress-rules" }}
+  {{- $serviceName := printf "%s-internal" (include "traefik.fullname" .)}}
+  {{- range $name, $config := .Values.service.internal.ports }}
+  {{- if $config.host  }}
+  - host: {{ $config.host }}
+    http:
+  {{- else }}
+  - http:
+  {{- end }}
+      paths:
+      - path: {{ default "/" $config.path }}
+        pathType: {{ default "Prefix" $config.prefix }}
+        backend:
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ default $config.port $config.exposedPort }}
+  {{- end }}
+{{- end }}
+
+{{- define "traefik.service-internal-ingress-spec" -}}
+  {{- with .Values.service.internal.ingress.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/traefik/templates/ingress.yaml
+++ b/traefik/templates/ingress.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.service.internal -}}
+{{- if .Values.service.internal.ingress.enable -}}
+
+{{- $fullname := include "traefik.fullname" . }}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ template "traefik.namespace" . }}
+  {{- template "traefik.service-internal-ingress-metadata" . }}
+  annotations:
+  {{- with .Values.service.internal.ingress.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- template "traefik.service-internal-ingress-spec" . }}
+  {{- if .Values.service.internal.ingress.tls.enable }}
+  tls:
+  {{- template "traefik.service-internal-ingress-tls" . }}
+  {{- end }}
+  rules:
+  {{- template "traefik.service-internal-ingress-rules" . }}
+{{- end -}}
+{{- end -}}

--- a/traefik/templates/service-internal.yaml
+++ b/traefik/templates/service-internal.yaml
@@ -8,7 +8,7 @@
 {{- $tcpPorts := dict -}}
 {{- $udpPorts := dict -}}
 {{- $exposedPorts := false -}}
-{{- range $name, $config := .Values.ports -}}
+{{- range $name, $config := .Values.service.internal.ports -}}
   {{- if eq (toString $config.protocol) "UDP" -}}
     {{ $_ := set $udpPorts $name $config -}}
   {{- end -}}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -768,7 +768,7 @@ service:
   #     enable: true
   #     annotations: {}
   #     tls:
-  #       enable: true
+  #       enable: false
   #       hosts: []
   #       secretName: ""
   #     # -- Additional entries here will be added to the ingress spec.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -750,12 +750,30 @@ service:
   ## Same parameters as external Service
   # internal:
   #   type: ClusterIP
+  #   ports:
+  #     traefik:
+  #       host: ""
+  #       path: /
+  #       port: 9000
+  #       expose: true
+  #       exposedPort: 9000
+  #       protocol: TCP
   #   # labels: {}
   #   # annotations: {}
   #   # spec: {}
   #   # loadBalancerSourceRanges: []
   #   # externalIPs: []
   #   # ipFamilies: [ "IPv4","IPv6" ]
+  #   ingress:
+  #     enable: true
+  #     annotations: {}
+  #     tls:
+  #       enable: true
+  #       hosts: []
+  #       secretName: ""
+  #     # -- Additional entries here will be added to the ingress spec.
+  #     # -- Cannot contain tls, rules entries.
+  #     spec: {}
 
 autoscaling:
   # -- Create HorizontalPodAutoscaler object.


### PR DESCRIPTION
### What does this PR do?
PR to route internal services to another Ingress controller. By exposing only the dashboard service as an internal service and routing the service to an another Ingress controller (e.g. nginx) equipped with a private load balancer, each service can be used separately without service port forwarding.

```yaml
# Example
# values.yaml#749L
  ## -- An additionnal and optional internal Service.
  ## Same parameters as external Service
  internal:
    type: ClusterIP
    ports:
      traefik:
        host: dashboard.traefik.com
        path: /
        port: 9000
        expose: true
        exposedPort: 9000
        protocol: TCP
    # labels: {}
    # annotations: {}
    # spec: {}
    # loadBalancerSourceRanges: []
    # externalIPs: []
    # ipFamilies: [ "IPv4","IPv6" ]
    ingress:
      enable: true
      annotations:
        # The nginx ingress controller in the example is an internal(private) load balancer.
        kubernetes.io/ingress.class: nginx
        cert-manager.io/cluster-issuer: letsencrypt-prod
      tls:
        enable: true
        hosts:
        - dashboard.traefik.com
        secretName: dashboard.traefik.com
      # -- Additional entries here will be added to the ingress spec.
      # -- Cannot contain tls, rules entries.
      spec: {}
```

### Motivation
I modified the chart for my own use, but I thought it would be helpful to those who want to configure the same environment as me.


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

> This is my first time seeing the test grammar, so I think it will take some time to write it. If anyone can help, I'd appreciate it, but if not, I'll take the time to commit more.

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

