### PR TITLE
feat: enable support for update Listener's allowedRoute inside Gateway

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 24.0.1
+version: 24.0.0
 # renovate: image=traefik
 appVersion: v2.10.4
 kubeVersion: ">=1.16.0-0"

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 24.0.0
+version: 24.0.1
 # renovate: image=traefik
 appVersion: v2.10.4
 kubeVersion: ">=1.16.0-0"

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -18,7 +18,11 @@ spec:
     - name: web
       port: {{ .Values.ports.web.port }}
       protocol: HTTP
-
+      {{- if .Values.experimental.kubernetesGateway.namespacePolicy }}
+      allowedRoutes:
+        namespaces:
+          from: {{ .Values.experimental.kubernetesGateway.namespacePolicy }}
+      {{- end }}
     {{- if .Values.experimental.kubernetesGateway.certificate }}
     - name: websecure
       port: {{ $.Values.ports.websecure.port }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -126,6 +126,7 @@ experimental:
   kubernetesGateway:
     # -- Enable traefik experimental GatewayClass CRD
     enabled: false
+    namespacePolicy: All
     gateway:
       # -- Enable traefik regular kubernetes gateway
       enabled: true

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -126,7 +126,7 @@ experimental:
   kubernetesGateway:
     # -- Enable traefik experimental GatewayClass CRD
     enabled: false
-    namespacePolicy: All
+#   namespacePolicy: All
     gateway:
       # -- Enable traefik regular kubernetes gateway
       enabled: true


### PR DESCRIPTION
### What does this PR do?

Enable support for configuring allowedRoutes within a gateway Listener

### Motivation

When using this helm chart and integrating with kubeVela we found that It's not working properly (was breaking http-route traits) because the default policy is hardcoded as "Same" and the helm chart does not have the option to configure it as convenience so I've added this option.

### More

- [ ] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

