### PR TITLE
chore: remove label whitespace at TLSOption

### DIFF
--- a/traefik/templates/tlsoption.yaml
+++ b/traefik/templates/tlsoption.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "traefik.labels" $ | nindent 4 }}
     {{- with $config.labels }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}    
+    {{- end }}
 spec:
   {{- with $config.alpnProtocols }}
   alpnProtocols:


### PR DESCRIPTION
### What does this PR do?

There is some whitespace next to the labels section inside the Helm chart.

This PR just removes these spaces


### More

- [x] Yes, I updated the tests accordingly -> not required
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

