### PR TITLE
fix: http redirections breaking cert-manager challenges

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -566,6 +566,7 @@
             {{- $toPort := index $.Values.ports $config.redirectTo }}
           - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.to=:{{ $toPort.exposedPort }}"
           - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.scheme=https"
+          - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.priority=10"
             {{- end }}
             {{- if $config.middlewares }}
           - "--entrypoints.{{ $entrypoint }}.http.middlewares={{ join "," $config.middlewares }}"

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -164,3 +164,20 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.websecure.http3.advertisedPort=443"
+  - it: should have http redirections enabled, when enabled with redirectTo
+    set: 
+      ports:
+        web:
+          redirectTo: websecure
+        websecure:
+          exposedPort: 443
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.web.http.redirections.entryPoint.to=:443"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.web.http.redirections.entryPoint.priority=10"


### PR DESCRIPTION
### What does this PR do?

We found that when using the HTTP redirections feature (to force usage of HTTPS) all cert-manager challenges to issue new certificates were failing, this PR adds a new priority parameter that actually enables Traefik to work with cert-manager even if using HTTP redirections.

This helm chart does not have any tests on enabling this feature either so I added it.
 
### Motivation

The solution was found here:
https://community.traefik.io/t/solved-http-to-https-redirect-ends-in-an-https-url-with-8443-appended/10136/5

(Thanks to [matthiasbaldi](https://community.traefik.io/u/matthiasbaldi))

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

