### PR TITLE
Add Prometheus scraping annotations only if serviceMonitor not created

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -5,7 +5,7 @@
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.metrics }}
-      {{- if and (.Values.metrics.prometheus) (not Values.metrics.prometheus.serviceMonitor) }}
+      {{- if and (.Values.metrics.prometheus) (not .Values.metrics.prometheus.serviceMonitor) }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ quote (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -5,7 +5,7 @@
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.metrics }}
-      {{- if .Values.metrics.prometheus }}
+      {{- if and (.Values.metrics.prometheus) (not Values.metrics.prometheus.serviceMonitor) }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ quote (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -620,6 +620,5 @@ tests:
           serviceMonitor:
             jobLabel: traefik
     asserts:
-      - notContains:
-          path: spec.template.annotations
-          value: "prometheus.io/scrape: "true""
+      - isNull:
+          path: spec.template.metadata.annotations.prometheus.io/scrape

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -613,3 +613,13 @@ tests:
       - equal:
           path: spec.template.spec.dnsConfig.options[1].name
           value: "edns0"
+  - it: should not have prometheus annotations
+    set:
+      metrics:
+        prometheus:
+          serviceMonitor:
+            jobLabel: traefik
+    asserts:
+      - notContains:
+          path: spec.template.annotations
+          value: "prometheus.io/scrape: "true""


### PR DESCRIPTION
### What does this PR do?

There are two ways to enable Prometheus scraping :

- If using Prometheus Operator, you have to create ServiceMonitors or PodMonitors crds.
- If using Prometheus without Operator, you have to define scraping configuration in pods (or service) annotation.

This PR intend to add Prometheus scraping Annotations only if 'metrics.prometheus' exists but 'metrics.prometheus.serviceMonitor' does not..


### Motivation

Adding scraping annotations **and** ServiceMonitor (or podMonitor) for the same pod can result to get metrics being collected twice by Prometheus.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed


