### PR TITLE
Release namespace for Prometheus Operator resources

### DIFF
--- a/traefik/templates/prometheusrules.yaml
+++ b/traefik/templates/prometheusrules.yaml
@@ -11,6 +11,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   {{- if .Values.metrics.prometheus.prometheusRule.namespace }}
   namespace: {{ .Values.metrics.prometheus.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ template "traefik.namespace" . }}
   {{- end }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -9,8 +9,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "traefik.fullname" . }}
-  {{- with .Values.metrics.prometheus.serviceMonitor.namespace }}
+  {{- if .Values.metrics.prometheus.serviceMonitor.namespace }}
   namespace: {{ . }}
+  {{- else }}
+  namespace: {{ template "traefik.namespace" . }}
   {{- end }}
   labels:
     {{- if (.Values.metrics.prometheus.service).enabled }}


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Set namespace for `ServiceMonitor` and `PrometheusRule` resources to the release namespace if no namespace is setted into the values file, like all others resources

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

