### PR TITLE
WIP Expose all ports for internal service

### DIFF
--- a/traefik/templates/_service-internal.tpl
+++ b/traefik/templates/_service-internal.tpl
@@ -35,14 +35,12 @@
 
 {{- define "traefik.service-internal-ports" }}
   {{- range $name, $config := . }}
-  {{- if $config.expose }}
   - port: {{ default $config.port $config.exposedPort }}
     name: {{ $name | quote }}
     targetPort: {{ default $name $config.targetPort }}
     protocol: {{ default "TCP" $config.protocol }}
     {{- if $config.nodePort }}
     nodePort: {{ $config.nodePort }}
-    {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix https://github.com/traefik/traefik-helm-chart/issues/966 

### What does this PR do?

expose all ports for internal-service


### Motivation

internal-service should expose traefik internal port (aka 9000).


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed


