### PR TITLE
Release namespace for Prometheus Operator resources

### DIFF
--- a/traefik/templates/prometheusrules.yaml
+++ b/traefik/templates/prometheusrules.yaml
@@ -11,6 +11,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   {{- if .Values.metrics.prometheus.prometheusRule.namespace }}
   namespace: {{ .Values.metrics.prometheus.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ template "traefik.namespace" . }}
   {{- end }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -9,8 +9,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "traefik.fullname" . }}
-  {{- with .Values.metrics.prometheus.serviceMonitor.namespace }}
+  {{- if .Values.metrics.prometheus.serviceMonitor.namespace }}
   namespace: {{ . }}
+  {{- else }}
+  namespace: {{ template "traefik.namespace" . }}
   {{- end }}
   labels:
     {{- if (.Values.metrics.prometheus.service).enabled }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "traefik.fullname" . }}
-  {{- if .Values.metrics.prometheus.serviceMonitor.namespace }}
+  {{- with .Values.metrics.prometheus.serviceMonitor.namespace }}
   namespace: {{ . }}
   {{- else }}
   namespace: {{ template "traefik.namespace" . }}

--- a/traefik/tests/servicemonitor-config_test.yaml
+++ b/traefik/tests/servicemonitor-config_test.yaml
@@ -83,3 +83,36 @@ tests:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/component"]
           value: metrics
+  - it: should use the release namespace by default if metrics.prometheus.serviceMonitor.namespace is not set
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    values:
+      - ./values/servicemonitor.yaml
+    release:
+      namespace: release-namespace
+    set:
+      metrics:
+        prometheus:
+          serviceMonitor:
+            namespace: ""
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: release-namespace
+  - it: should use the release namespace if specified
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    values:
+      - ./values/servicemonitor.yaml
+    release:
+      namespace: release-namespace
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: another-namespace


### PR DESCRIPTION
### What does this PR do?

Set namespace for ServiceMonitor and PrometheusRule resources to the release namespace if no namespace is setted into the values file, like all others resources

### Motivation

Closes https://github.com/traefik/traefik-helm-chart/pull/948 which seems to be stale

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

