### PR TITLE
fix: 🐛 improve confusing suggested value on openTelemetry.grpc

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -515,7 +515,7 @@ metrics:
 # -- https://doc.traefik.io/traefik/observability/tracing/overview/
 tracing: {}
 #  openTelemetry: # traefik v3+ only
-#    grpc: {}
+#    grpc: true
 #    insecure: true
 #    address: localhost:4317
 # instana:


### PR DESCRIPTION
### What does this PR do?

Set correct suggested value on `tracing.openTelemetry.grpc` for Traefik v3


### Motivation

Fixes #963 

