### PR TITLE
Fix v3 CRDs. Docs to v3 and some issues on changed Middleware properties like `ipAllowList`

### DIFF
--- a/traefik/crds/traefik.io_ingressroutes.yaml
+++ b/traefik/crds/traefik.io_ingressroutes.yaml
@@ -39,7 +39,7 @@ spec:
               entryPoints:
                 description: 'EntryPoints defines the list of entry point names to
                   bind to. Entry points have to be configured in the static configuration.
-                  More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/
+                  More info: https://doc.traefik.io/traefik/v3.0/routing/entrypoints/
                   Default: all.'
                 items:
                   type: string
@@ -56,11 +56,11 @@ spec:
                       - Rule
                       type: string
                     match:
-                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#rule'
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v3.0/routing/routers/#rule'
                       type: string
                     middlewares:
                       description: 'Middlewares defines the list of references to
-                        Middleware resources. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-middleware'
+                        Middleware resources. More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#kind-middleware'
                       items:
                         description: MiddlewareRef is a reference to a Middleware
                           resource.
@@ -79,7 +79,7 @@ spec:
                       type: array
                     priority:
                       description: 'Priority defines the router''s priority. More
-                        info: https://doc.traefik.io/traefik/v2.10/routing/routers/#priority'
+                        info: https://doc.traefik.io/traefik/v3.0/routing/routers/#priority'
                       type: integer
                     services:
                       description: Services defines the list of Service. It can contain
@@ -152,7 +152,7 @@ spec:
                             type: string
                           sticky:
                             description: 'Sticky defines the sticky sessions configuration.
-                              More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions'
+                              More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions'
                             properties:
                               cookie:
                                 description: Cookie defines the sticky cookie configuration.
@@ -197,16 +197,16 @@ spec:
                   type: object
                 type: array
               tls:
-                description: 'TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#tls'
+                description: 'TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v3.0/routing/routers/#tls'
                 properties:
                   certResolver:
                     description: 'CertResolver defines the name of the certificate
                       resolver to use. Cert resolvers have to be configured in the
-                      static configuration. More info: https://doc.traefik.io/traefik/v2.10/https/acme/#certificate-resolvers'
+                      static configuration. More info: https://doc.traefik.io/traefik/v3.0/https/acme/#certificate-resolvers'
                     type: string
                   domains:
                     description: 'Domains defines the list of domains that will be
-                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#domains'
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v3.0/routing/routers/#domains'
                     items:
                       description: Domain holds a domain name with SANs.
                       properties:
@@ -224,15 +224,15 @@ spec:
                   options:
                     description: 'Options defines the reference to a TLSOption, that
                       specifies the parameters of the TLS connection. If not defined,
-                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options'
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v3.0/https/tls/#tls-options'
                     properties:
                       name:
                         description: 'Name defines the name of the referenced TLSOption.
-                          More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsoption'
+                          More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#kind-tlsoption'
                         type: string
                       namespace:
                         description: 'Namespace defines the namespace of the referenced
-                          TLSOption. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsoption'
+                          TLSOption. More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#kind-tlsoption'
                         type: string
                     required:
                     - name
@@ -248,11 +248,11 @@ spec:
                     properties:
                       name:
                         description: 'Name defines the name of the referenced TLSStore.
-                          More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsstore'
+                          More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#kind-tlsstore'
                         type: string
                       namespace:
                         description: 'Namespace defines the namespace of the referenced
-                          TLSStore. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsstore'
+                          TLSStore. More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#kind-tlsstore'
                         type: string
                     required:
                     - name

--- a/traefik/crds/traefik.io_ingressroutetcps.yaml
+++ b/traefik/crds/traefik.io_ingressroutetcps.yaml
@@ -39,7 +39,7 @@ spec:
               entryPoints:
                 description: 'EntryPoints defines the list of entry point names to
                   bind to. Entry points have to be configured in the static configuration.
-                  More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/
+                  More info: https://doc.traefik.io/traefik/v3.0/routing/entrypoints/
                   Default: all.'
                 items:
                   type: string
@@ -50,7 +50,7 @@ spec:
                   description: RouteTCP holds the TCP route configuration.
                   properties:
                     match:
-                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#rule_1'
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v3.0/routing/routers/#rule_1'
                       type: string
                     middlewares:
                       description: Middlewares defines the list of references to MiddlewareTCP
@@ -73,7 +73,7 @@ spec:
                       type: array
                     priority:
                       description: 'Priority defines the router''s priority. More
-                        info: https://doc.traefik.io/traefik/v2.10/routing/routers/#priority_1'
+                        info: https://doc.traefik.io/traefik/v3.0/routing/routers/#priority_1'
                       type: integer
                     services:
                       description: Services defines the list of TCP services.
@@ -105,7 +105,7 @@ spec:
                             x-kubernetes-int-or-string: true
                           proxyProtocol:
                             description: 'ProxyProtocol defines the PROXY protocol
-                              configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#proxy-protocol'
+                              configuration. More info: https://doc.traefik.io/traefik/v3.0/routing/services/#proxy-protocol'
                             properties:
                               version:
                                 description: Version defines the PROXY Protocol version
@@ -136,16 +136,16 @@ spec:
                 type: array
               tls:
                 description: 'TLS defines the TLS configuration on a layer 4 / TCP
-                  Route. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#tls_1'
+                  Route. More info: https://doc.traefik.io/traefik/v3.0/routing/routers/#tls_1'
                 properties:
                   certResolver:
                     description: 'CertResolver defines the name of the certificate
                       resolver to use. Cert resolvers have to be configured in the
-                      static configuration. More info: https://doc.traefik.io/traefik/v2.10/https/acme/#certificate-resolvers'
+                      static configuration. More info: https://doc.traefik.io/traefik/v3.0/https/acme/#certificate-resolvers'
                     type: string
                   domains:
                     description: 'Domains defines the list of domains that will be
-                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#domains'
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v3.0/routing/routers/#domains'
                     items:
                       description: Domain holds a domain name with SANs.
                       properties:
@@ -163,7 +163,7 @@ spec:
                   options:
                     description: 'Options defines the reference to a TLSOption, that
                       specifies the parameters of the TLS connection. If not defined,
-                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options'
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v3.0/https/tls/#tls-options'
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik

--- a/traefik/crds/traefik.io_ingressrouteudps.yaml
+++ b/traefik/crds/traefik.io_ingressrouteudps.yaml
@@ -39,7 +39,7 @@ spec:
               entryPoints:
                 description: 'EntryPoints defines the list of entry point names to
                   bind to. Entry points have to be configured in the static configuration.
-                  More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/
+                  More info: https://doc.traefik.io/traefik/v3.0/routing/entrypoints/
                   Default: all.'
                 items:
                   type: string

--- a/traefik/crds/traefik.io_middlewares.yaml
+++ b/traefik/crds/traefik.io_middlewares.yaml
@@ -20,7 +20,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: 'Middleware is the CRD implementation of a Traefik Middleware.
-          More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/overview/'
+          More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/overview/'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -40,7 +40,7 @@ spec:
               addPrefix:
                 description: 'AddPrefix holds the add prefix middleware configuration.
                   This middleware updates the path of a request before forwarding
-                  it. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/addprefix/'
+                  it. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/addprefix/'
                 properties:
                   prefix:
                     description: Prefix is the string to add before the current path
@@ -50,11 +50,11 @@ spec:
               basicAuth:
                 description: 'BasicAuth holds the basic auth middleware configuration.
                   This middleware restricts access to your services to known users.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/basicauth/'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/basicauth/'
                 properties:
                   headerField:
                     description: 'HeaderField defines a header field to store the
-                      authenticated user. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/basicauth/#headerfield'
+                      authenticated user. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/basicauth/#headerfield'
                     type: string
                   realm:
                     description: 'Realm allows the protected resources on a server
@@ -74,7 +74,7 @@ spec:
               buffering:
                 description: 'Buffering holds the buffering middleware configuration.
                   This middleware retries or limits the size of requests that can
-                  be forwarded to backends. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/buffering/#maxrequestbodybytes'
+                  be forwarded to backends. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/buffering/#maxrequestbodybytes'
                 properties:
                   maxRequestBodyBytes:
                     description: 'MaxRequestBodyBytes defines the maximum allowed
@@ -107,13 +107,13 @@ spec:
                   retryExpression:
                     description: 'RetryExpression defines the retry conditions. It
                       is a logical combination of functions with operators AND (&&)
-                      and OR (||). More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/buffering/#retryexpression'
+                      and OR (||). More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/buffering/#retryexpression'
                     type: string
                 type: object
               chain:
                 description: 'Chain holds the configuration of the chain middleware.
                   This middleware enables to define reusable combinations of other
-                  pieces of middleware. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/chain/'
+                  pieces of middleware. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/chain/'
                 properties:
                   middlewares:
                     description: Middlewares is the list of MiddlewareRef which composes
@@ -167,12 +167,13 @@ spec:
               compress:
                 description: 'Compress holds the compress middleware configuration.
                   This middleware compresses responses before sending them to the
-                  client, using gzip compression. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/compress/'
+                  client, using gzip compression. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/compress/'
                 properties:
                   excludedContentTypes:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
-                      and responses before compressing.
+                      and responses before compressing. `application/grpc` is always
+                      excluded.
                     items:
                       type: string
                     type: array
@@ -184,28 +185,18 @@ spec:
                 type: object
               contentType:
                 description: ContentType holds the content-type middleware configuration.
-                  This middleware exists to enable the correct behavior until at least
-                  the default one can be changed in a future version.
-                properties:
-                  autoDetect:
-                    description: AutoDetect specifies whether to let the `Content-Type`
-                      header, if it has not been set by the backend, be automatically
-                      set to a value derived from the contents of the response. As
-                      a proxy, the default behavior should be to leave the header
-                      alone, regardless of what the backend did with it. However,
-                      the historic default was to always auto-detect and set the header
-                      if it was nil, and it is going to be kept that way in order
-                      to support users currently relying on it.
-                    type: boolean
+                  This middleware sets the `Content-Type` header value to the media
+                  type detected from the response content, when it is not set by the
+                  backend.
                 type: object
               digestAuth:
                 description: 'DigestAuth holds the digest auth middleware configuration.
                   This middleware restricts access to your services to known users.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/digestauth/'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/digestauth/'
                 properties:
                   headerField:
                     description: 'HeaderField defines a header field to store the
-                      authenticated user. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/basicauth/#headerfield'
+                      authenticated user. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/basicauth/#headerfield'
                     type: string
                   realm:
                     description: 'Realm allows the protected resources on a server
@@ -224,7 +215,7 @@ spec:
               errors:
                 description: 'ErrorPage holds the custom error middleware configuration.
                   This middleware returns a custom page in lieu of the default, according
-                  to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/errorpages/'
+                  to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/errorpages/'
                 properties:
                   query:
                     description: Query defines the URL for the error page (hosted
@@ -233,7 +224,7 @@ spec:
                     type: string
                   service:
                     description: 'Service defines the reference to a Kubernetes Service
-                      that will serve the error page. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/errorpages/#service'
+                      that will serve the error page. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/errorpages/#service'
                     properties:
                       kind:
                         description: Kind defines the kind of the Service.
@@ -297,7 +288,7 @@ spec:
                         type: string
                       sticky:
                         description: 'Sticky defines the sticky sessions configuration.
-                          More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions'
+                          More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions'
                         properties:
                           cookie:
                             description: Cookie defines the sticky cookie configuration.
@@ -346,7 +337,7 @@ spec:
               forwardAuth:
                 description: 'ForwardAuth holds the forward auth middleware configuration.
                   This middleware delegates the request authentication to a Service.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/forwardauth/'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/'
                 properties:
                   address:
                     description: Address defines the authentication server address.
@@ -369,14 +360,12 @@ spec:
                     description: 'AuthResponseHeadersRegex defines the regex to match
                       headers to copy from the authentication server response and
                       set on forwarded request, after stripping all headers that match
-                      the regex. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/forwardauth/#authresponseheadersregex'
+                      the regex. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#authresponseheadersregex'
                     type: string
                   tls:
                     description: TLS defines the configuration used to secure the
                       connection to the authentication server.
                     properties:
-                      caOptional:
-                        type: boolean
                       caSecret:
                         description: CASecret is the name of the referenced Kubernetes
                           Secret containing the CA to validate the server certificate.
@@ -397,10 +386,21 @@ spec:
                       forward) all X-Forwarded-* headers.'
                     type: boolean
                 type: object
+              grpcWeb:
+                description: GrpcWeb holds the gRPC web middleware configuration.
+                  This middleware converts a gRPC web request to an HTTP/2 gRPC request.
+                properties:
+                  allowOrigins:
+                    description: AllowOrigins is a list of allowable origins. Can
+                      also be a wildcard origin "*".
+                    items:
+                      type: string
+                    type: array
+                type: object
               headers:
                 description: 'Headers holds the headers middleware configuration.
                   This middleware manages the requests and responses headers. More
-                  info: https://doc.traefik.io/traefik/v2.10/middlewares/http/headers/#customrequestheaders'
+                  info: https://doc.traefik.io/traefik/v3.0/middlewares/http/headers/#customrequestheaders'
                 properties:
                   accessControlAllowCredentials:
                     description: AccessControlAllowCredentials defines whether the
@@ -484,9 +484,6 @@ spec:
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
                     type: object
-                  featurePolicy:
-                    description: 'Deprecated: use PermissionsPolicy instead.'
-                    type: string
                   forceSTSHeader:
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
@@ -522,12 +519,6 @@ spec:
                       value. This allows sites to control whether browsers forward
                       the Referer header to other sites.
                     type: string
-                  sslForceHost:
-                    description: 'Deprecated: use RedirectRegex instead.'
-                    type: boolean
-                  sslHost:
-                    description: 'Deprecated: use RedirectRegex instead.'
-                    type: string
                   sslProxyHeaders:
                     additionalProperties:
                       type: string
@@ -536,14 +527,6 @@ spec:
                       useful when using other proxies (example: "X-Forwarded-Proto":
                       "https").'
                     type: object
-                  sslRedirect:
-                    description: 'Deprecated: use EntryPoint redirection or RedirectScheme
-                      instead.'
-                    type: boolean
-                  sslTemporaryRedirect:
-                    description: 'Deprecated: use EntryPoint redirection or RedirectScheme
-                      instead.'
-                    type: boolean
                   stsIncludeSubdomains:
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
@@ -561,7 +544,7 @@ spec:
               inFlightReq:
                 description: 'InFlightReq holds the in-flight request middleware configuration.
                   This middleware limits the number of requests being processed and
-                  served concurrently. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/inflightreq/'
+                  served concurrently. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/inflightreq/'
                 properties:
                   amount:
                     description: Amount defines the maximum amount of allowed simultaneous
@@ -575,11 +558,11 @@ spec:
                       group requests as originating from a common source. If several
                       strategies are defined at the same time, an error will be raised.
                       If none are set, the default is to use the requestHost. More
-                      info: https://doc.traefik.io/traefik/v2.10/middlewares/http/inflightreq/#sourcecriterion'
+                      info: https://doc.traefik.io/traefik/v3.0/middlewares/http/inflightreq/#sourcecriterion'
                     properties:
                       ipStrategy:
                         description: 'IPStrategy holds the IP strategy configuration
-                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/#ipstrategy'
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/ipallowlist/#ipstrategy'
                         properties:
                           depth:
                             description: Depth tells Traefik to use the X-Forwarded-For
@@ -604,14 +587,14 @@ spec:
                         type: boolean
                     type: object
                 type: object
-              ipWhiteList:
-                description: 'IPWhiteList holds the IP whitelist middleware configuration.
+              ipAllowList:
+                description: 'IPAllowList holds the IP allowlist middleware configuration.
                   This middleware accepts / refuses requests based on the client IP.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/ipallowlist/'
                 properties:
                   ipStrategy:
                     description: 'IPStrategy holds the IP strategy configuration used
-                      by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/#ipstrategy'
+                      by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/ipallowlist/#ipstrategy'
                     properties:
                       depth:
                         description: Depth tells Traefik to use the X-Forwarded-For
@@ -635,7 +618,7 @@ spec:
               passTLSClientCert:
                 description: 'PassTLSClientCert holds the pass TLS client cert middleware
                   configuration. This middleware adds the selected data from the passed
-                  client TLS certificate to a header. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/passtlsclientcert/'
+                  client TLS certificate to a header. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/passtlsclientcert/'
                 properties:
                   info:
                     description: Info selects the specific client certificate details
@@ -742,7 +725,7 @@ spec:
               rateLimit:
                 description: 'RateLimit holds the rate limit configuration. This middleware
                   ensures that services will receive a fair amount of requests, and
-                  allows one to define what fair is. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ratelimit/'
+                  allows one to define what fair is. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/ratelimit/'
                 properties:
                   average:
                     description: Average is the maximum rate, by default in requests/s,
@@ -775,7 +758,7 @@ spec:
                     properties:
                       ipStrategy:
                         description: 'IPStrategy holds the IP strategy configuration
-                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/#ipstrategy'
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/ipallowlist/#ipstrategy'
                         properties:
                           depth:
                             description: Depth tells Traefik to use the X-Forwarded-For
@@ -803,7 +786,7 @@ spec:
               redirectRegex:
                 description: 'RedirectRegex holds the redirect regex middleware configuration.
                   This middleware redirects a request using regex matching and replacement.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/redirectregex/#regex'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/redirectregex/#regex'
                 properties:
                   permanent:
                     description: Permanent defines whether the redirection is permanent
@@ -821,7 +804,7 @@ spec:
               redirectScheme:
                 description: 'RedirectScheme holds the redirect scheme middleware
                   configuration. This middleware redirects requests from a scheme/port
-                  to another. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/redirectscheme/'
+                  to another. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/redirectscheme/'
                 properties:
                   permanent:
                     description: Permanent defines whether the redirection is permanent
@@ -837,7 +820,7 @@ spec:
               replacePath:
                 description: 'ReplacePath holds the replace path middleware configuration.
                   This middleware replaces the path of the request URL and store the
-                  original path in an X-Replaced-Path header. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/replacepath/'
+                  original path in an X-Replaced-Path header. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/replacepath/'
                 properties:
                   path:
                     description: Path defines the path to use as replacement in the
@@ -847,7 +830,7 @@ spec:
               replacePathRegex:
                 description: 'ReplacePathRegex holds the replace path regex middleware
                   configuration. This middleware replaces the path of a URL using
-                  regex matching and replacement. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/replacepathregex/'
+                  regex matching and replacement. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/replacepathregex/'
                 properties:
                   regex:
                     description: Regex defines the regular expression used to match
@@ -863,7 +846,7 @@ spec:
                   middleware reissues requests a given number of times to a backend
                   server if that server does not reply. As soon as the server answers,
                   the middleware stops retrying, regardless of the response status.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/retry/'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/retry/'
                 properties:
                   attempts:
                     description: Attempts defines how many times the request should
@@ -883,13 +866,8 @@ spec:
               stripPrefix:
                 description: 'StripPrefix holds the strip prefix middleware configuration.
                   This middleware removes the specified prefixes from the URL path.
-                  More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/stripprefix/'
+                  More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/stripprefix/'
                 properties:
-                  forceSlash:
-                    description: 'ForceSlash ensures that the resulting stripped path
-                      is not the empty string, by replacing it with / when necessary.
-                      Default: true.'
-                    type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
@@ -900,7 +878,7 @@ spec:
               stripPrefixRegex:
                 description: 'StripPrefixRegex holds the strip prefix regex middleware
                   configuration. This middleware removes the matching prefixes from
-                  the URL path. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/stripprefixregex/'
+                  the URL path. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/stripprefixregex/'
                 properties:
                   regex:
                     description: Regex defines the regular expression to match the

--- a/traefik/crds/traefik.io_middlewaretcps.yaml
+++ b/traefik/crds/traefik.io_middlewaretcps.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -20,7 +19,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: 'MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.
-          More info: https://doc.traefik.io/traefik/v2.10/middlewares/overview/'
+          More info: https://doc.traefik.io/traefik/v3.0/middlewares/overview/'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -47,8 +46,8 @@ spec:
                     format: int64
                     type: integer
                 type: object
-              ipWhiteList:
-                description: IPWhiteList defines the IPWhiteList middleware configuration.
+              ipAllowList:
+                description: IPAllowList defines the IPAllowList middleware configuration.
                 properties:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of

--- a/traefik/crds/traefik.io_serverstransports.yaml
+++ b/traefik/crds/traefik.io_serverstransports.yaml
@@ -22,7 +22,7 @@ spec:
         description: 'ServersTransport is the CRD implementation of a ServersTransport.
           If no serversTransport is specified, the default@internal will be used.
           The default@internal serversTransport is created from the static configuration.
-          More info: https://doc.traefik.io/traefik/v2.10/routing/services/#serverstransport_1'
+          More info: https://doc.traefik.io/traefik/v3.0/routing/services/#serverstransport_1'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/traefik/crds/traefik.io_tlsoptions.yaml
+++ b/traefik/crds/traefik.io_tlsoptions.yaml
@@ -21,7 +21,7 @@ spec:
       openAPIV3Schema:
         description: 'TLSOption is the CRD implementation of a Traefik TLS Option,
           allowing to configure some parameters of the TLS connection. More info:
-          https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options'
+          https://doc.traefik.io/traefik/v3.0/https/tls/#tls-options'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -41,13 +41,13 @@ spec:
               alpnProtocols:
                 description: 'ALPNProtocols defines the list of supported application
                   level protocols for the TLS handshake, in order of preference. More
-                  info: https://doc.traefik.io/traefik/v2.10/https/tls/#alpn-protocols'
+                  info: https://doc.traefik.io/traefik/v3.0/https/tls/#alpn-protocols'
                 items:
                   type: string
                 type: array
               cipherSuites:
                 description: 'CipherSuites defines the list of supported cipher suites
-                  for TLS versions up to TLS 1.2. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#cipher-suites'
+                  for TLS versions up to TLS 1.2. More info: https://doc.traefik.io/traefik/v3.0/https/tls/#cipher-suites'
                 items:
                   type: string
                 type: array
@@ -74,7 +74,7 @@ spec:
                 type: object
               curvePreferences:
                 description: 'CurvePreferences defines the preferred elliptic curves
-                  in a specific order. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#curve-preferences'
+                  in a specific order. More info: https://doc.traefik.io/traefik/v3.0/https/tls/#curve-preferences'
                 items:
                   type: string
                 type: array

--- a/traefik/crds/traefik.io_tlsstores.yaml
+++ b/traefik/crds/traefik.io_tlsstores.yaml
@@ -22,7 +22,7 @@ spec:
         description: 'TLSStore is the CRD implementation of a Traefik TLS Store. For
           the time being, only the TLSStore named default is supported. This means
           that you cannot have two stores that are named default in different Kubernetes
-          namespaces. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#certificates-stores'
+          namespaces. More info: https://doc.traefik.io/traefik/v3.0/https/tls/#certificates-stores'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/traefik/crds/traefik.io_traefikservices.yaml
+++ b/traefik/crds/traefik.io_traefikservices.yaml
@@ -21,7 +21,7 @@ spec:
       openAPIV3Schema:
         description: 'TraefikService is the CRD implementation of a Traefik Service.
           TraefikService object allows to: - Apply weight to Services on load-balancing
-          - Mirror traffic on services More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-traefikservice'
+          - Mirror traffic on services More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#kind-traefikservice'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -127,7 +127,7 @@ spec:
                           type: string
                         sticky:
                           description: 'Sticky defines the sticky sessions configuration.
-                            More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions'
+                            More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions'
                           properties:
                             cookie:
                               description: Cookie defines the sticky cookie configuration.
@@ -218,7 +218,7 @@ spec:
                     type: string
                   sticky:
                     description: 'Sticky defines the sticky sessions configuration.
-                      More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions'
+                      More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions'
                     properties:
                       cookie:
                         description: Cookie defines the sticky cookie configuration.
@@ -325,7 +325,7 @@ spec:
                           type: string
                         sticky:
                           description: 'Sticky defines the sticky sessions configuration.
-                            More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions'
+                            More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions'
                           properties:
                             cookie:
                               description: Cookie defines the sticky cookie configuration.
@@ -364,7 +364,7 @@ spec:
                     type: array
                   sticky:
                     description: 'Sticky defines whether sticky sessions are enabled.
-                      More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#stickiness-and-load-balancing'
+                      More info: https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/#stickiness-and-load-balancing'
                     properties:
                       cookie:
                         description: Cookie defines the sticky cookie configuration.


### PR DESCRIPTION
### What does this PR do?

Updates CRDs linkd to documentation on ApiVersion traefik.io/v1 related CRDs.
Fixes some Middleware issues, for example `ipAllowList` not being allowed in current CRD which prevents migration from `ipWhiteList` to `ipAllowList`.

This is basically a less aggressive version of #766  done by copying CRDs from https://github.com/traefik/traefik/blob/v3.0/integration/fixtures/k8s/01-traefik-crd.yml

### Motivation

I've started this to address this issue with `ipAllowList` not be valid in the CRDs but Traefik V3 not supporting depreacted `ipWhiteList`

This was also addressed by #766 but that PR was done prior to recent CRDs api version deduplication by #944 so I am just let's say merging both of them because we need CRDs to match V3 config params schema, being waiting for this more than 3 months already....

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed\

