### PR TITLE
fix: 🐛 missing quote on experimental plugin args

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -521,8 +521,8 @@
           {{- if or (ne (typeOf $plugin) "map[string]interface {}") (not (hasKey $plugin "moduleName")) (not (hasKey $plugin "version")) }}
             {{- fail  (printf "ERROR: plugin %s is missing moduleName/version keys !" $pluginName) }}
           {{- end }}
-          - --experimental.plugins.{{ $pluginName }}.moduleName={{ $plugin.moduleName }}
-          - --experimental.plugins.{{ $pluginName }}.version={{ $plugin.version }}
+          - "--experimental.plugins.{{ $pluginName }}.moduleName={{ $plugin.moduleName }}"
+          - "--experimental.plugins.{{ $pluginName }}.version={{ $plugin.version }}"
           {{- end }}
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"


### PR DESCRIPTION
### What does this PR do?

Add missing quotes on experimental plugin args

### Motivation

Fixes #986 

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed