### PR TITLE
doc: fix invalid suggestion on TLSOption

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -761,7 +761,7 @@ ports:
 #     labels: {}
 #     sniStrict: true
 #     preferServerCipherSuites: true
-#   customOptions:
+#   custom-options:
 #     labels: {}
 #     curvePreferences:
 #       - CurveP521


### PR DESCRIPTION
### What does this PR do?

Fix suggestion.

### Motivation

It's an invalid `metadata.name`: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

