### PR TITLE
fix: 🐛 set runtimeClassName at pod level

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -49,13 +49,13 @@
       {{- if .Values.deployment.shareProcessNamespace }}
       shareProcessNamespace: true
       {{- end }}
+      {{- with .Values.deployment.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       containers:
       - image: {{ template "traefik.image-name" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ template "traefik.fullname" . }}
-        {{- with .Values.deployment.runtimeClassName }}
-        runtimeClassName: {{ . }}
-        {{- end }}        
         resources:
           {{- with .Values.resources }}
           {{- toYaml . | nindent 10 }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -626,7 +626,7 @@ tests:
         runtimeClassName: ArbitraryRuntimeClass
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].runtimeClassName
+          path: spec.template.spec.runtimeClassName
           value: ArbitraryRuntimeClass
   - it: should not set runtimeClassName when configured
     set:


### PR DESCRIPTION
### What does this PR do?

Move `runtimeClassName` at the expected level.

### Motivation

Fixes #991

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

