### PR TITLE
fix: add rbac needed for Traefik v3 rc1

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -101,6 +101,7 @@ rules:
       - gatewayclasses
       - gateways
       - httproutes
+      - referencegrants
       - tcproutes
       - tlsroutes
     verbs:

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -92,5 +92,37 @@ rules:
     verbs:
       - use
 {{- end -}}
+{{- if $.Values.experimental.kubernetesGateway.enabled }}
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - referencegrants
+      - tcproutes
+      - tlsroutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses/status
+      - gateways/status
+      - httproutes/status
+      - tcproutes/status
+      - tlsroutes/status
+    verbs:
+      - update
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### What does this PR do?

Adds ReferenceGrants to ClusterRole for Get, List & Watch when using k8s Gateways via Traefik's experimental v3 features. 


### Motivation

Fixes #1007 error: 
```
W0220 15:39:46.262443       1 reflector.go:535] k8s.io/client-go@v0.28.4/tools/cache/reflector.go:229: failed to list *v1beta1.ReferenceGrant: referencegrants.gat
# eway.networking.k8s.io is forbidden: User "system:serviceaccount:ingress-system:traefik" cannot list resource "referencegrants" in API group "gateway.networking.k8s.io" at the cluster scope
```


### More

- [ ] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

Unit tests did not need updating for this change. 

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

