### PR TITLE
feat: allow excluding entrypoints from internal service

### DIFF
--- a/traefik/templates/_service-internal.tpl
+++ b/traefik/templates/_service-internal.tpl
@@ -35,7 +35,7 @@
 
 {{- define "traefik.service-internal-ports" }}
   {{- range $name, $config := . }}
-  {{- if (or $config.expose $config.exposeInternal) }}
+  {{- if (and (or $config.expose $config.exposeInternal) (not $config.onlyExternal))  }}
   - port: {{ default $config.port $config.exposedPort }}
     name: {{ $name | quote }}
     targetPort: {{ default $name $config.targetPort }}

--- a/traefik/tests/service-internal-config_test.yaml
+++ b/traefik/tests/service-internal-config_test.yaml
@@ -203,3 +203,27 @@ tests:
             port: 3000
             protocol: TCP
             targetPort: internal
+  - it: should not expose ports that are exposed on default service only
+    set:
+      service:
+        internal:
+          enabled: true
+      ports:
+        web:
+          onlyExternal: true
+        websecure:
+          onlyExternal: true
+        internal:
+          expose: false
+          exposeInternal: true
+          port: 4000
+          exposedPort: 3000
+          protocol: TCP
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - name: internal
+              port: 3000
+              protocol: TCP
+              targetPort: internal

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -635,6 +635,10 @@ ports:
     # note that ports exposed on the default service are exposed on the internal
     # service by default as well.
     exposeInternal: false
+    # -- Defines whether the port should be exposed only on the default service;
+    # this can be useful if you want to define different entrypoints for external 
+    # and internal service but expose them on competing ports
+    onlyExternal: false
   web:
     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
     # asDefault: true
@@ -654,6 +658,10 @@ ports:
     # note that ports exposed on the default service are exposed on the internal
     # service by default as well.
     exposeInternal: false
+    # -- Defines whether the port should be exposed only on the default service;
+    # this can be useful if you want to define different entrypoints for external 
+    # and internal service but expose them on competing ports
+    onlyExternal: false
     # Port Redirections
     # Added in 2.2, you can make permanent redirects via entrypoints.
     # https://docs.traefik.io/routing/entrypoints/#redirection
@@ -688,6 +696,10 @@ ports:
     # note that ports exposed on the default service are exposed on the internal
     # service by default as well.
     exposeInternal: false
+    # -- Defines whether the port should be exposed only on the default service;
+    # this can be useful if you want to define different entrypoints for external 
+    # and internal service but expose them on competing ports
+    onlyExternal: false
     ## -- Specify an application protocol. This may be used as a hint for a Layer 7 load balancer.
     # appProtocol: https
     #


### PR DESCRIPTION
### What does this PR do?

This PR allows to specifically exclude some entrypoints from the default service. This can be useful if you want to expose different entrypoint on the same set of ports across the default and internal service.

### Motivation

This change was inspired from the following requirement:
- `web` configured with `redirectTo: websecure`, exposed on port 80
- `websecure` configured, exposed on port 443
- `webinsecure` not exposed

This above usecase allows to make sure that the default behavior of an ingress is to redirect to encrypted web traffic and this means, assuming that the default service uses a LoadBalancer or NodePort that all external traffic will be forced to be secured.

Now if you want to allow insecure traffic in the cluster, you will need to use a different port, say 8080, which is sub-optimal.

Thus this feature, hopefully non breaking, which allow to:

Externally:

- `web` configured with `redirectTo: websecure`, exposed on port 80
- `websecure` configured, exposed on port 443

Internally: 

- `webinsecure` configured, exposed on port 80
- `websecure` configured, exposed on port 443

using the following config:

```yaml
ports:
  web:
    onlyExternal: true
  webinsecure:
    port: 10080
    exposedPort: 80
    expose: false
    exposeInternal: true
```

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed
