### PR TITLE
chore: 🔧 update release on v27 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - master
+      - v27
 
 env:
   tag_prefix: v


### PR DESCRIPTION
### What does this PR do?

Update _release_ GH action on `v27` branch.


### Motivation

Being able to publish new version of v27, supporting Traefik Proxy v2.