### PR TITLE
chore(release): publish v27.0.2

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -6,7 +6,6 @@
 
 * feat: ✨ update Traefik Proxy to v2.11.2
 
-
 ## 27.0.1  ![AppVersion: v2.11.1](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.1&color=success&logo=) ![Kubernetes: >=1.16.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.16.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2024-04-10

--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 27.0.2  ![AppVersion: v2.11.1](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.1&color=success&logo=) ![Kubernetes: >=1.16.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.16.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2024-04-11
+
+* feat: ✨ update Traefik Proxy to v2.11.2
+
+
 ## 27.0.1  ![AppVersion: v2.11.1](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.1&color=success&logo=) ![Kubernetes: >=1.16.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.16.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2024-04-10

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 27.0.1
+version: 27.0.2
 # renovate: image=traefik
-appVersion: v2.11.1
+appVersion: v2.11.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - traefik
@@ -25,4 +25,4 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - "feat: ✨ update Traefik Proxy to v2.11.1"
+    - "feat: ✨ update Traefik Proxy to v2.11.2"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 27.0.1](https://img.shields.io/badge/Version-27.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.1](https://img.shields.io/badge/AppVersion-v2.11.1-informational?style=flat-square)
+![Version: 27.0.2](https://img.shields.io/badge/Version-27.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.2](https://img.shields.io/badge/AppVersion-v2.11.2-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Publish a new release with Traefik Proxy to v2.11.2

### Motivation

It comes with an important bugfix introduced in v2.11.1, see upstream [release notes](https://github.com/traefik/traefik/releases/tag/v2.11.2).

