### PR TITLE
feat: ✨ fail gracefully when required port number is not set

### DIFF
--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -52,7 +52,11 @@
 {{- define "traefik.service-ports" }}
   {{- range $name, $config := .ports }}
   {{- if (index (default dict $config.expose) $.serviceName) }}
-  - port: {{ default $config.port $config.exposedPort }}
+  {{- $port := default $config.port $config.exposedPort }}
+  {{- if empty $port }}
+    {{- fail (print "ERROR: Cannot create " (trim $name) " port on Service without .port or .exposedPort") }}
+  {{- end }}
+  - port: {{ $port }}
     name: {{ $name | quote }}
     targetPort: {{ default $name $config.targetPort }}
     protocol: {{ default "TCP" $config.protocol }}

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -348,3 +348,13 @@ tests:
       - failedTemplate:
           errorMessage: "ERROR: When disabling traefik port, you need to specify `deployment.healthchecksPort`"
         template: deployment.yaml
+  - it: should failed when no port nor exposed port are defined
+    set:
+      ports:
+        ssh:
+          expose:
+            default: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Cannot create ssh port on Service without .port or .exposedPort"
+


### PR DESCRIPTION
### What does this PR do?

Display an error message when `Service` cannot be created

### Motivation

Some users are confused by last breaking change on `Service`, see #1036 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed