### PR TITLE
chore(release): 🚀 publish v28.1.0-beta.2

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,43 @@
 # Change Log
 
+## 28.1.0-beta.2  ![AppVersion: v3.0.0](https://img.shields.io/static/v1?label=AppVersion&message=v3.0.0&color=success&logo=) ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2024-05-02
+
+* fix: 🐛 refine Traefik Hub support
+* chore(release): 🚀 publish v28.1.0-beta.2
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index ce0a7a3..70297f6 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -1015,13 +1015,15 @@ hub:
+   # Name of Secret with key 'token' set to a valid license token.
+   # It enables API Gateway.
+   token:
+-  admission:
+-    # -- WebHook admission server listen address. Default: "0.0.0.0:9943".
+-    listenAddr:
+-    # -- Certificate of the WebHook admission server. Default: "hub-agent-cert".
+-    secretName:
+-  # -- Set to true in order to enable API Management. Requires a valid license token.
+   apimanagement:
++    # -- Set to true in order to enable API Management. Requires a valid license token.
++    enabled:
++    admission:
++      # -- WebHook admission server listen address. Default: "0.0.0.0:9943".
++      listenAddr:
++      # -- Certificate of the WebHook admission server. Default: "hub-agent-cert".
++      secretName:
++
+   metrics:
+     opentelemetry:
+       # -- Set to true to enable OpenTelemetry metrics exporter of Traefik Hub.
+```
+
 ## 28.1.0-beta.1  ![AppVersion: v3.0.0](https://img.shields.io/static/v1?label=AppVersion&message=v3.0.0&color=success&logo=) ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2024-04-30

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 28.1.0-beta.1
+version: 28.1.0-beta.2
 # renovate: image=traefik
 appVersion: v3.0.0
 kubeVersion: ">=1.22.0-0"
@@ -25,5 +25,5 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - "feat: :rocket: add initial support for traefik-hub api gateway"
-    - "chore(release): 🚀 v28.1.0-beta.1"
+    - "fix: 🐛 refine Traefik Hub support"
+    - "chore(release): 🚀 publish v28.1.0-beta.2"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 28.1.0-beta.1](https://img.shields.io/badge/Version-28.1.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
+![Version: 28.1.0-beta.2](https://img.shields.io/badge/Version-28.1.0--beta.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 
@@ -59,10 +59,10 @@ Kubernetes: `>=1.22.0-0`
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template)  In some cases, it can avoid the need for additional, extended or adhoc deployments. See #595 for more details and traefik/tests/values/extra.yaml for example. |
 | globalArguments | list | `["--global.checknewversion","--global.sendanonymoususage"]` | Global command arguments to be passed to all traefik's pods |
 | hostNetwork | bool | `false` | If hostNetwork is true, runs traefik in the host network namespace To prevent unschedulabel pods due to port collisions, if hostNetwork=true and replicas>1, a pod anti-affinity is recommended and will be set if the affinity is left as default. |
-| hub | object | `{"admission":{"listenAddr":null,"secretName":null},"apimanagement":null,"metrics":{"opentelemetry":{"address":null,"enabled":null,"explicitBoundaries":null,"grpc":null,"headers":null,"insecure":null,"path":null,"pushInterval":null,"tls":{"ca":null,"cert":null,"insecureSkipVerify":null,"key":null}}},"ratelimit":{"redis":{"cluster":null,"database":null,"endpoints":null,"password":null,"sentinel":{"masterset":null,"password":null,"username":null},"timeout":null,"tls":{"ca":null,"cert":null,"insecureSkipVerify":null,"key":null},"username":null}},"sendlogs":null,"token":null}` | Traefik Hub configuration. See https://doc.traefik.io/traefik-hub/ |
-| hub.admission.listenAddr | string | `nil` | WebHook admission server listen address. Default: "0.0.0.0:9943". |
-| hub.admission.secretName | string | `nil` | Certificate of the WebHook admission server. Default: "hub-agent-cert". |
-| hub.apimanagement | string | `nil` | Set to true in order to enable API Management. Requires a valid license token. |
+| hub | object | `{"apimanagement":{"admission":{"listenAddr":null,"secretName":null},"enabled":null},"metrics":{"opentelemetry":{"address":null,"enabled":null,"explicitBoundaries":null,"grpc":null,"headers":null,"insecure":null,"path":null,"pushInterval":null,"tls":{"ca":null,"cert":null,"insecureSkipVerify":null,"key":null}}},"ratelimit":{"redis":{"cluster":null,"database":null,"endpoints":null,"password":null,"sentinel":{"masterset":null,"password":null,"username":null},"timeout":null,"tls":{"ca":null,"cert":null,"insecureSkipVerify":null,"key":null},"username":null}},"sendlogs":null,"token":null}` | Traefik Hub configuration. See https://doc.traefik.io/traefik-hub/ |
+| hub.apimanagement.admission.listenAddr | string | `nil` | WebHook admission server listen address. Default: "0.0.0.0:9943". |
+| hub.apimanagement.admission.secretName | string | `nil` | Certificate of the WebHook admission server. Default: "hub-agent-cert". |
+| hub.apimanagement.enabled | string | `nil` | Set to true in order to enable API Management. Requires a valid license token. |
 | hub.metrics.opentelemetry.address | string | `nil` | Address (host:port) of the collector endpoint. Default: "localhost:4318". |
 | hub.metrics.opentelemetry.enabled | string | `nil` | Set to true to enable OpenTelemetry metrics exporter of Traefik Hub. |
 | hub.metrics.opentelemetry.explicitBoundaries | string | `nil` | Boundaries of latency metrics. Default: " 0.005000, 0.010000, 0.025000, 0.050000, 0.100000, 0.250000, 0.500000, 1.000000, 2.500000, 5.000000, 10.000000 " |


### PR DESCRIPTION
### What does this PR do?

Publish v28.1.0-beta.2

### Motivation

Capacity to test new features coming with support of Traefik Hub API Gateway & Traefik Hub API Management