### PR TITLE
chore: 🔧 update Traefik Hub CRD to v1.3.2

### DIFF
--- a/traefik/crds/hub.traefik.io_apiportals.yaml
+++ b/traefik/crds/hub.traefik.io_apiportals.yaml
@@ -45,14 +45,17 @@ spec:
               title:
                 description: Title is the public facing name of the APIPortal.
                 type: string
-              trustedDomains:
-                description: TrustedDomains are the domains that are trusted by the
-                  OAuth 2.0 authorization server.
+              trustedUrls:
+                description: TrustedURLs are the urls that are trusted by the OAuth
+                  2.0 authorization server.
                 items:
                   type: string
-                maxItems: 20
+                maxItems: 1
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: must be a valid URLs
+                  rule: self.all(x, isURL(x))
               ui:
                 description: UI holds the UI customization options.
                 properties:
@@ -61,7 +64,7 @@ spec:
                     type: string
                 type: object
             required:
-            - trustedDomains
+            - trustedUrls
             type: object
           status:
             description: The current status of this APIPortal.


### PR DESCRIPTION
### What does this PR do?

Update Traefik Hub CRD to v1.3.2

### Motivation

See https://github.com/traefik/hub-crds/pull/22