### PR TITLE
fix: don't add unsupported otlp tracing options

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -320,7 +320,6 @@
            {{- end }}
            {{- with .http }}
             {{- if .enabled }}
-          - "--metrics.otlp.http=true"
              {{- with .endpoint }}
           - "--metrics.otlp.http.endpoint={{ . }}"
              {{- end }}
@@ -345,7 +344,6 @@
            {{- end }}
            {{- with .grpc }}
             {{- if .enabled }}
-          - "--metrics.otlp.grpc=true"
              {{- with .endpoint }}
           - "--metrics.otlp.grpc.endpoint={{ . }}"
              {{- end }}

--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -367,9 +367,6 @@ tests:
           content: "--metrics.otlp.pushInterval=10s"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--metrics.otlp.http=true"
-      - contains:
-          path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.http.endpoint=http://localhost:4318/v1/metrics"
       - contains:
           path: spec.template.spec.containers[0].args
@@ -389,9 +386,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.http.tls.insecureSkipVerify=true"
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--metrics.otlp.grpc=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.grpc.endpoint=http://localhost:4318/v1/metrics"


### PR DESCRIPTION
The options `--tracing.otlp.http=true` and `--tracing.oltp.grpc=true` [are not supported][1] (albeit documented). Before this change, setting the values `tracing.otlp.http.enabled` or `tracing.otlp.grpc.enabled` to `true` resulted in the prod crashing.

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

[1]: https://github.com/traefik/traefik/issues/10721