### PR TITLE
feat: ✨ update CRDs & RBAC for Traefik Proxy

### DIFF
--- a/traefik/crds/traefik.io_ingressroutes.yaml
+++ b/traefik/crds/traefik.io_ingressroutes.yaml
@@ -120,6 +120,13 @@ spec:
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
                             type: boolean
+                          nodePortLB:
+                            description: |-
+                              NodePortLB controls, when creating the load-balancer,
+                              whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                              It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                              By default, NodePortLB is false.
+                            type: boolean
                           passHostHeader:
                             description: |-
                               PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.

--- a/traefik/crds/traefik.io_ingressroutetcps.yaml
+++ b/traefik/crds/traefik.io_ingressroutetcps.yaml
@@ -103,6 +103,13 @@ spec:
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
                             type: boolean
+                          nodePortLB:
+                            description: |-
+                              NodePortLB controls, when creating the load-balancer,
+                              whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                              It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                              By default, NodePortLB is false.
+                            type: boolean
                           port:
                             anyOf:
                             - type: integer

--- a/traefik/crds/traefik.io_ingressrouteudps.yaml
+++ b/traefik/crds/traefik.io_ingressrouteudps.yaml
@@ -74,6 +74,13 @@ spec:
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
                             type: boolean
+                          nodePortLB:
+                            description: |-
+                              NodePortLB controls, when creating the load-balancer,
+                              whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                              It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                              By default, NodePortLB is false.
+                            type: boolean
                           port:
                             anyOf:
                             - type: integer

--- a/traefik/crds/traefik.io_middlewares.yaml
+++ b/traefik/crds/traefik.io_middlewares.yaml
@@ -172,6 +172,10 @@ spec:
                       breaker will try to recover (as soon as it is in recovering
                       state).
                     x-kubernetes-int-or-string: true
+                  responseCode:
+                    description: ResponseCode is the status code that the circuit
+                      breaker will return while it is in the open state.
+                    type: integer
                 type: object
               compress:
                 description: |-
@@ -273,6 +277,13 @@ spec:
                           whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                           The Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
+                        type: boolean
+                      nodePortLB:
+                        description: |-
+                          NodePortLB controls, when creating the load-balancer,
+                          whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                          It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                          By default, NodePortLB is false.
                         type: boolean
                       passHostHeader:
                         description: |-
@@ -661,7 +672,7 @@ spec:
               ipAllowList:
                 description: |-
                   IPAllowList holds the IP allowlist middleware configuration.
-                  This middleware accepts / refuses requests based on the client IP.
+                  This middleware limits allowed requests based on the client IP.
                   More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/ipallowlist/
                 properties:
                   ipStrategy:
@@ -715,7 +726,7 @@ spec:
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
-                      of allowed IPs by using CIDR notation).
+                      of allowed IPs by using CIDR notation). Required.
                     items:
                       type: string
                     type: array

--- a/traefik/crds/traefik.io_traefikservices.yaml
+++ b/traefik/crds/traefik.io_traefikservices.yaml
@@ -88,6 +88,13 @@ spec:
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
                           type: boolean
+                        nodePortLB:
+                          description: |-
+                            NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                            By default, NodePortLB is false.
+                          type: boolean
                         passHostHeader:
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
@@ -193,6 +200,13 @@ spec:
                       whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                       The Kubernetes Service itself does load-balance to the pods.
                       By default, NativeLB is false.
+                    type: boolean
+                  nodePortLB:
+                    description: |-
+                      NodePortLB controls, when creating the load-balancer,
+                      whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                      It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                      By default, NodePortLB is false.
                     type: boolean
                   passHostHeader:
                     description: |-
@@ -307,6 +321,13 @@ spec:
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          type: boolean
+                        nodePortLB:
+                          description: |-
+                            NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                            By default, NodePortLB is false.
                           type: boolean
                         passHostHeader:
                           description: |-

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -27,8 +27,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
       - endpoints
+      - nodes
+      - services
     verbs:
       - get
       - list

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -16,8 +16,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - services
       - endpoints
+      - nodes
+      - services
     verbs:
       - get
       - list

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -669,8 +669,9 @@ tests:
             apiGroups:
               - ""
             resources:
-              - services
               - endpoints
+              - nodes
+              - services
             verbs:
               - get
               - list
@@ -757,8 +758,9 @@ tests:
             apiGroups:
               - ""
             resources:
-              - services
               - endpoints
+              - nodes
+              - services
             verbs:
               - get
               - list


### PR DESCRIPTION
### What does this PR do?

Adds update on CRDs & RBAC needed by those upstream PRs:

- https://github.com/traefik/traefik/pull/10278/
- https://github.com/traefik/traefik/pull/10625

It won't be merged until there is an upstream release with those PR in it.

This PR can be used for testing, by using _experimental_ build of Traefik Proxy

### Motivation

Fixes #1064 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

