### PR TITLE
Add IngressClass annotation to dashboard IngressRoute per default if …

### DIFF
--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- if and .Values.ingressClass.enabled (or .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesIngress.enabled) }}
     kubernetes.io/ingress.class: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
     {{- end }}
-    {{- toYaml .Values.ingressRoute.dashboard.annotations | nindent 4 }}
+    {{- with .Values.ingressRoute.dashboard.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
     {{- with .Values.ingressRoute.dashboard.labels }}

--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -4,10 +4,11 @@ kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   namespace: {{ template "traefik.namespace" . }}
-{{- with .Values.ingressRoute.dashboard.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- if and .Values.ingressClass.enabled (or .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesIngress.enabled) }}
+    kubernetes.io/ingress.class: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+    {{- end }}
+    {{- toYaml .Values.ingressRoute.dashboard.annotations | nindent 4 }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
     {{- with .Values.ingressRoute.dashboard.labels }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -1,110 +1,125 @@
 suite: Dashboard IngressRoute configuration
 templates:
-- dashboard-ingressroute.yaml
+  - dashboard-ingressroute.yaml
 tests:
-- it: should allow disabling dashboard exposure using ingressRoute
-  set:
-    ingressRoute:
-      dashboard:
-        enabled: false
-  asserts:
-  - hasDocuments:
-      count: 0
-- it: should have the expected default route match rule
-  asserts:
-  - equal:
-      path: spec.routes[0].match
-      value: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
-- it: should support overwriting the route match rule
-  set:
-    ingressRoute:
-      dashboard:
-        matchRule: Host(`traefik.example.com`)
-  asserts:
-  - equal:
-      path: spec.routes[0].match
-      value: Host(`traefik.example.com`)
-- it: should have traefik as default entryPoints
-  asserts:
-  - equal:
-      path: spec.entryPoints
-      value: ["traefik"]
-- it: should support setting websecure as entryPoint
-  set:
-    ingressRoute:
-      dashboard:
-        entryPoints: ["websecure"]
-  asserts:
-  - equal:
-      path: spec.entryPoints
-      value: ["websecure"]
-- it: should support adding specific label on IngressRoute
-  set:
-    ingressRoute:
-      dashboard:
-        labels:
-          foo: bar
-  asserts:
-  - equal:
-      path: metadata.labels.foo
-      value: bar
-- it: should not have middlewares by default
-  asserts:
-  - isNull:
-      path: spec.routes[0].middlewares
-- it: should support adding middlewares
-  set:
-    ingressRoute:
-      dashboard:
-        middlewares:
-        - name: traefik-dashboard-auth
-          namespace: default
-  asserts:
-  - equal:
-      path: spec.routes[0].middlewares
-      value:
-      - name: traefik-dashboard-auth
-        namespace: default
-- it: should not have tls options by default
-  asserts:
-  - isNull:
-      path: spec.tls
-- it: should support adding tls options
-  set:
-    ingressRoute:
-      dashboard:
-        tls:
-          secretName: traefik-dashboard-auth
-          options:
-            name: tls-options
-            namespace: default
-  asserts:
-  - equal:
-      path: spec.tls
-      value:
-        secretName: traefik-dashboard-auth
-        options:
-          name: tls-options
-          namespace: default
-- it: should not allow to create null annotations
-  set:
-    ingressRoute:
-      dashboard:
-        enabled: true
-  asserts:
-  - isNull:
-      path: metadata.annotations
-- it: should insert annotations correctly
-  set:
-    ingressRoute:
-      dashboard:
-        enabled: true
-        annotations:
-          foo: bar
-          fis: fas
-  asserts:
-  - equal:
-      path: metadata.annotations
-      value:
-        foo: bar
-        fis: fas
+  - it: should allow disabling dashboard exposure using ingressRoute
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should have the expected default route match rule
+    asserts:
+      - equal:
+          path: spec.routes[0].match
+          value: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+  - it: should support overwriting the route match rule
+    set:
+      ingressRoute:
+        dashboard:
+          matchRule: Host(`traefik.example.com`)
+    asserts:
+      - equal:
+          path: spec.routes[0].match
+          value: Host(`traefik.example.com`)
+  - it: should have traefik as default entryPoints
+    asserts:
+      - equal:
+          path: spec.entryPoints
+          value: ["traefik"]
+  - it: should support setting websecure as entryPoint
+    set:
+      ingressRoute:
+        dashboard:
+          entryPoints: ["websecure"]
+    asserts:
+      - equal:
+          path: spec.entryPoints
+          value: ["websecure"]
+  - it: should support adding specific label on IngressRoute
+    set:
+      ingressRoute:
+        dashboard:
+          labels:
+            foo: bar
+    asserts:
+      - equal:
+          path: metadata.labels.foo
+          value: bar
+  - it: should not have middlewares by default
+    asserts:
+      - isNull:
+          path: spec.routes[0].middlewares
+  - it: should support adding middlewares
+    set:
+      ingressRoute:
+        dashboard:
+          middlewares:
+            - name: traefik-dashboard-auth
+              namespace: default
+    asserts:
+      - equal:
+          path: spec.routes[0].middlewares
+          value:
+            - name: traefik-dashboard-auth
+              namespace: default
+  - it: should not have tls options by default
+    asserts:
+      - isNull:
+          path: spec.tls
+  - it: should support adding tls options
+    set:
+      ingressRoute:
+        dashboard:
+          tls:
+            secretName: traefik-dashboard-auth
+            options:
+              name: tls-options
+              namespace: default
+    asserts:
+      - equal:
+          path: spec.tls
+          value:
+            secretName: traefik-dashboard-auth
+            options:
+              name: tls-options
+              namespace: default
+  - it: should use the release name as the default ingress class annotation
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            kubernetes.io/ingress.class: RELEASE-NAME-traefik
+  - it: should use the ingress class name for the annotation
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: true
+      ingressClass:
+        name: test-class
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            kubernetes.io/ingress.class: test-class
+  - it: should insert annotations correctly
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: true
+          annotations:
+            foo: bar
+            fis: fas
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            kubernetes.io/ingress.class: RELEASE-NAME-traefik
+            foo: bar
+            fis: fas


### PR DESCRIPTION
…necessary

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds the annotation for the IngressClass to the IngressRoute of the dashboard, if necessary.


### Motivation

<!-- What inspired you to submit this pull request? -->
When deployed with an IngressClass filter on the IngressRoute or Ingress providers, Traefik does not see it's own IngressRoute for the dashboard.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

One test had to be removed since per default the `.metadata.annotations` object will not be null on the dashboard IngressRoute

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

