### PR TITLE
fix: 🐛 namespaced rbac with kubernetesIngress provider disabled

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.rbac.enabled (or .Values.providers.kubernetesIngress.enabled (not .Values.rbac.namespaced)) -}}
-{{- if not (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.disableIngressClassLookup) -}}
+{{- if and .Values.rbac.enabled (or .Values.providers.kubernetesIngress.enabled (not .Values.rbac.namespaced)) }}
+{{- if not (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.disableIngressClassLookup) }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -115,8 +115,6 @@ rules:
       - update
 {{- end -}}
 {{- end -}}
-{{- end -}}
-{{- end -}}
 {{- if .Values.hub.token }}
   - apiGroups:
       - hub.traefik.io
@@ -208,4 +206,6 @@ rules:
       - get
       - list
       - watch
-{{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -906,3 +906,128 @@ tests:
               - get
               - list
               - watch
+  - it: should provide namespace'd RBACS for hub
+    set:
+      hub:
+        token: xxx
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngress:
+          enabled: false
+    asserts:
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - hub.traefik.io
+            resources:
+              - accesscontrolpolicies
+              - apiaccesses
+              - apiportals
+              - apiratelimits
+              - apis
+              - apiversions
+            verbs:
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+              - get
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - namespaces
+              - pods
+              - nodes
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - events
+            verbs:
+              - create
+              - patch
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - list
+              - get
+              - watch
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - secrets
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - create
+              - delete
+              - deletecollection
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - replicasets
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+            verbs:
+              - get
+              - list
+              - watch


### PR DESCRIPTION
### What does this PR do?

Fix template logic in `clusterrole`.

### Motivation

This case should be supported.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

