### PR TITLE
feat: allow to set hostAliases for traefik pod

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -40,6 +40,7 @@ Kubernetes: `>=1.22.0-0`
 | deployment.annotations | object | `{}` | Additional deployment annotations (e.g. for jaeger-operator sidecar injection) |
 | deployment.dnsConfig | object | `{}` | Custom pod DNS policy. Apply if `hostNetwork: true` dnsPolicy: ClusterFirstWithHostNet |
 | deployment.enabled | bool | `true` | Enable deployment |
+| deployment.hostAliases | list | `[]` | Custom [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) |
 | deployment.imagePullSecrets | list | `[]` | Additional imagePullSecrets |
 | deployment.initContainers | list | `[]` | Additional initContainers (e.g. for setting file permission as shown below) |
 | deployment.kind | string | `"Deployment"` | Deployment or DaemonSet |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -43,6 +43,10 @@
           {{- toYaml .options | nindent 10 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.deployment.hostAliases }}
+      hostAliases:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.deployment.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -91,6 +91,12 @@ deployment:
   #   - name: ndots
   #     value: "2"
   #   - name: edns0
+  # -- Custom [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)
+  hostAliases: []
+  #  - ip: "127.0.0.1" # this is an example
+  #    hostnames:
+  #    - "foo.local"
+  #    - "bar.local"
   # -- Additional imagePullSecrets
   imagePullSecrets: []
   # - name: myRegistryKeySecretName


### PR DESCRIPTION
### What does this PR do?

Allows to set host aliases in the traefik pod.

### More

- [+] Yes, I ran `make test` and all the tests passed


