### PR TITLE
feat(workflow): add oci push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,16 @@ jobs:
           commit_username: traefiker
           commit_email: 30906710+traefiker@users.noreply.github.com
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
+
+      - name: Publish Helm chart to the ghcr.io registry
+        uses: appany/helm-oci-chart-releaser@v0.4.2
+        with:
+          name: traefik
+          repository:  traefik
+          tag: ${{ steps.chart_version.outputs.CHART_VERSION }}
+          path: ./traefik
+          registry: ghcr.io
+          registry_username: ${{ secrets.GHCR_USERNAME }}
+          registry_password: ${{ secrets.GHCR_PASSWORD }}
+          update_dependencies: 'true' # Defaults to false
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'


### PR DESCRIPTION
### What does this PR do?

This PR solves #962 by adding OCI push to the release workflow

### Motivation

Provide the ability to pull the chart from the OCI registry.


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

