### PR TITLE
fix(dashboard): Only set ingressClass annotation when kubernetesCRD provider is listening for it.

### DIFF
--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   namespace: {{ template "traefik.namespace" . }}
   annotations:
-    {{- if and .Values.ingressClass.enabled (or .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesIngress.enabled) }}
-    kubernetes.io/ingress.class: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+    {{- if and .Values.ingressClass.enabled .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesCRD.ingressClass }}
+    kubernetes.io/ingress.class: {{ .Values.providers.kubernetesCRD.ingressClass }}
     {{- end }}
     {{- with .Values.ingressRoute.dashboard.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/traefik/templates/healthcheck-ingressroute.yaml
+++ b/traefik/templates/healthcheck-ingressroute.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}-healthcheck
   namespace: {{ template "traefik.namespace" . }}
   annotations:
-    {{- if and .Values.ingressClass.enabled (or .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesIngress.enabled) }}
-    kubernetes.io/ingress.class: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+    {{- if and .Values.ingressClass.enabled .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesCRD.ingressClass }}
+    kubernetes.io/ingress.class: {{ .Values.providers.kubernetesCRD.ingressClass }}
     {{- end }}
     {{- with .Values.ingressRoute.healthcheck.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -86,7 +86,7 @@ tests:
         options:
           name: tls-options
           namespace: default
-- it: should use the release name as the default ingress class annotation
+- it: should not set default ingress class annotation
   set:
     ingressRoute:
       dashboard:
@@ -94,15 +94,15 @@ tests:
   asserts:
   - equal:
       path: metadata.annotations
-      value:
-        kubernetes.io/ingress.class: RELEASE-NAME-traefik
+      value: null
 - it: should use the ingress class name for the annotation
   set:
     ingressRoute:
       dashboard:
         enabled: true
-    ingressClass:
-      name: test-class
+    providers:
+      kubernetesCRD:
+        ingressClass: test-class
   asserts:
   - equal:
       path: metadata.annotations
@@ -120,6 +120,5 @@ tests:
   - equal:
       path: metadata.annotations
       value:
-        kubernetes.io/ingress.class: RELEASE-NAME-traefik
         foo: bar
         fis: fas


### PR DESCRIPTION
### What does this PR do?

fixes #1096

### Motivation

The included dashboard ingressRoute is broken when the release name is not Traefik.

This is one of the possible fixes for it. But honestly it made me doubt if the implementation of custom ingressClass names are implemented correctly in this chart...

I split the changes into 2 commits to make reviewing easier.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed
