### PR TITLE
Fix Node API permissions in RBAC

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.rbac.enabled (or .Values.providers.kubernetesIngress.enabled (not .Values.rbac.namespaced)) }}
-{{- if not (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.disableIngressClassLookup) }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -11,6 +10,17 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
     {{- end }}
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+{{- if not .Values.rbac.namespaced }}
+      - services
+{{- end }}
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - extensions
       - networking.k8s.io
@@ -35,15 +45,6 @@ rules:
       - list
       - watch
   {{- else }}
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - services
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -220,6 +221,5 @@ rules:
       - get
       - list
       - watch
-{{- end }}
 {{- end }}
 {{- end }}

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -27,7 +27,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - nodes
       - services
     verbs:
       - get

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -796,7 +796,6 @@ tests:
             apiGroups:
               - ""
             resources:
-              - nodes
               - services
             verbs:
               - get
@@ -1147,4 +1146,3 @@ tests:
               - list
               - get
               - watch
-


### PR DESCRIPTION
### What does this PR do?

Move the Node API permissions from `Role` to `ClusterRole`, as Node is not a namespaced object and therefore cannot be accessed using namespaced `Role`.


### Motivation

When testing the latest chart version (local checkout) + latest RC locally to check for potential upgrade issues, new pods failed to function properly, as it had no access to nodes (rejected by K8S RBAC). This is due to the fact that namespaced `Role` cannot assign permissions for non-namespaced APIs.


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

