### PR TITLE
fix(dashboard): Only set ingressClass annotation when kubernetesCRD provider is listening for it

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -369,6 +369,22 @@ extraObjects:
       client-secret: "{{ azure_dns_challenge_application_secret }}"
 ```
 
+# Use an IngressClass
+
+Default install comes with an `IngressClass` resource that can be enabled on providers.
+
+Here's how one can enable it on CRD & Ingress Kubernetes provider:
+
+```yaml
+ingressClass:
+  name: traefik
+providers:
+  kubernetesCRD:
+    ingressClass: traefik
+  kubernetesIngress:
+    ingressClass: traefik
+```
+
 # Use HTTP3
 
 By default, it will use a Load balancers with mixed protocols on `websecure`

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -17,10 +17,10 @@ Create chart name and version as used by the chart label.
 {{/*
 Create the chart image name.
 */}}
-
 {{- define "traefik.image-name" -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   namespace: {{ template "traefik.namespace" . }}
   annotations:
-    {{- if and .Values.ingressClass.enabled (or .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesIngress.enabled) }}
-    kubernetes.io/ingress.class: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+    {{- if and .Values.ingressClass.enabled .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesCRD.ingressClass }}
+    kubernetes.io/ingress.class: {{ .Values.providers.kubernetesCRD.ingressClass }}
     {{- end }}
     {{- with .Values.ingressRoute.dashboard.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/traefik/templates/healthcheck-ingressroute.yaml
+++ b/traefik/templates/healthcheck-ingressroute.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}-healthcheck
   namespace: {{ template "traefik.namespace" . }}
   annotations:
-    {{- if and .Values.ingressClass.enabled (or .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesIngress.enabled) }}
-    kubernetes.io/ingress.class: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+    {{- if and .Values.ingressClass.enabled .Values.providers.kubernetesCRD.enabled .Values.providers.kubernetesCRD.ingressClass }}
+    kubernetes.io/ingress.class: {{ .Values.providers.kubernetesCRD.ingressClass }}
     {{- end }}
     {{- with .Values.ingressRoute.healthcheck.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -86,7 +86,7 @@ tests:
         options:
           name: tls-options
           namespace: default
-- it: should use the release name as the default ingress class annotation
+- it: should not set default ingress class annotation
   set:
     ingressRoute:
       dashboard:
@@ -94,15 +94,15 @@ tests:
   asserts:
   - equal:
       path: metadata.annotations
-      value:
-        kubernetes.io/ingress.class: RELEASE-NAME-traefik
+      value: null
 - it: should use the ingress class name for the annotation
   set:
     ingressRoute:
       dashboard:
         enabled: true
-    ingressClass:
-      name: test-class
+    providers:
+      kubernetesCRD:
+        ingressClass: test-class
   asserts:
   - equal:
       path: metadata.annotations
@@ -120,6 +120,5 @@ tests:
   - equal:
       path: metadata.annotations
       value:
-        kubernetes.io/ingress.class: RELEASE-NAME-traefik
         foo: bar
         fis: fas

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -220,7 +220,8 @@ providers:
     allowExternalNameServices: false
     # -- Allows to return 503 when there is no endpoints available
     allowEmptyServices: false
-    # ingressClass: traefik-internal
+    # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
+    ingressClass:
     # labelSelector: environment=production,method=traefik
     # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces.
     namespaces: []
@@ -233,7 +234,8 @@ providers:
     allowExternalNameServices: false
     # -- Allows to return 503 when there is no endpoints available
     allowEmptyServices: false
-    # ingressClass: traefik-internal
+    # -- When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed.
+    ingressClass:
     # labelSelector: environment=production,method=traefik
     # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces.
     namespaces: []


### PR DESCRIPTION
### What does this PR do?

Align `ingressClass` annotation with provider configuration.
Supersede #1098.

### Motivation

Fixes #1096. 
Clarify how it works. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

