### PR TITLE
fix: semverCompare failing on some legitimate tags

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -129,7 +129,7 @@ Renders a complete tree, even values that contains template.
 {{- end -}}
 
 {{- define "imageVersion" -}}
-{{ (split "@" (default $.Chart.AppVersion $.Values.image.tag))._0 | replace "latest-" "" }}
+{{ (split "@" (default $.Chart.AppVersion $.Values.image.tag))._0 | replace "latest-" "" | replace "experimental-" "" }}
 {{- end -}}
 
 {{/* Generate/load self-signed certificate for admission webhooks */}}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,6 +1,7 @@
+{{- $version := include "imageVersion" $ }}
 {{- if .Values.rbac.enabled }}
 {{- if or
-       (semverCompare ">=v3.1.0-0" (.Values.image.tag | default .Chart.AppVersion))
+       (semverCompare ">=v3.1.0-0" $version)
        (not .Values.rbac.namespaced)
        (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.enabled (not .Values.providers.kubernetesIngress.disableIngressClassLookup))
 }}
@@ -15,7 +16,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
     {{- end }}
 rules:
-  {{- if semverCompare ">=v3.1.0-0" (.Values.image.tag | default .Chart.AppVersion) }}
+  {{- if semverCompare ">=v3.1.0-0" $version }}
   - apiGroups:
       - ""
     resources:
@@ -61,7 +62,7 @@ rules:
       - update
 {{- end }}
 {{- if not .Values.rbac.namespaced }}
-  {{- if (semverCompare "<v3.1.0-0" (.Values.image.tag | default .Chart.AppVersion)) }}
+  {{- if (semverCompare "<v3.1.0-0" $version) }}
   - apiGroups:
       - ""
     resources:
@@ -146,7 +147,7 @@ rules:
       - ""
     resources:
       - services
-{{- if (semverCompare "<v3.1.0-0" ($.Values.image.tag | default $.Chart.AppVersion)) }}
+{{- if (semverCompare "<v3.1.0-0" $version) }}
       - endpoints
 {{- end }}
       - secrets
@@ -154,7 +155,7 @@ rules:
       - get
       - list
       - watch
-{{- if (semverCompare ">=v3.1.0-0" ($.Values.image.tag | default $.Chart.AppVersion)) }}
+{{- if (semverCompare ">=v3.1.0-0" $version) }}
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -1,6 +1,7 @@
+{{- $version := include "imageVersion" $ }}
 {{- if .Values.rbac.enabled }}
 {{- if or
-       (semverCompare ">=v3.1.0-0" (.Values.image.tag | default .Chart.AppVersion))
+       (semverCompare ">=v3.1.0-0" $version)
        (not .Values.rbac.namespaced)
        (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.enabled (not .Values.providers.kubernetesIngress.disableIngressClassLookup))
 }}

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -1,3 +1,4 @@
+{{- $version := include "imageVersion" $ }}
 {{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
 {{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
 {{- $gatewayNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.kubernetesGateway).namespaces) -}}
@@ -14,7 +15,7 @@ metadata:
   labels:
     {{- include "traefik.labels" $ | nindent 4 }}
 rules:
-  {{- if (semverCompare "<v3.1.0-0" ($.Values.image.tag | default $.Chart.AppVersion)) }}
+  {{- if (semverCompare "<v3.1.0-0" $version) }}
   - apiGroups:
       - ""
     resources:
@@ -114,7 +115,7 @@ rules:
       - ""
     resources:
       - services
-{{- if (semverCompare "<v3.1.0-0" ($.Values.image.tag | default $.Chart.AppVersion)) }}
+{{- if (semverCompare "<v3.1.0-0" $version) }}
       - endpoints
 {{- end }}
       - secrets
@@ -122,7 +123,7 @@ rules:
       - get
       - list
       - watch
-{{- if (semverCompare ">=v3.1.0-0" ($.Values.image.tag | default $.Chart.AppVersion)) }}
+{{- if (semverCompare ">=v3.1.0-0" $version) }}
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1495,3 +1495,37 @@ tests:
               - get
               - list
               - watch
+  - it: should not provide nodes RBACS for version < v3.1 if rbac are namespaced (experimental tag)
+    set:
+      image:
+        tag: experimental-v3.0
+      rbac:
+        enabled: true
+        namespaced: true
+      providers:
+        kubernetesIngress:
+          disableIngressClassLookup: true
+    asserts:
+      - template: rbac/clusterrole.yaml
+        hasDocuments:
+          count: 0
+  - it: should provide nodes RBACS for version >= v3.1 even if rbac are namespaced (experimental tag)
+    set:
+      image:
+        tag: experimental-v3.1
+      rbac:
+        enabled: true
+        namespaced: true
+    asserts:
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes
+            verbs:
+              - get
+              - list
+              - watch


### PR DESCRIPTION
### What does this PR do?

This PR fixes issues for v29 when using such values:

```yaml
image:
  tag: experimental-v3.0
```

### Motivation

Fix this bug.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

