### PR TITLE
fix: can't set gateway name

### DIFF
--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: {{ default .Values.gateway.name "traefik-gateway" }}
+  name: {{ default "traefik-gateway" .Values.gateway.name }}
   namespace: {{ template "traefik.namespace" . }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -155,3 +155,15 @@ tests:
         equal:
           path: spec.gatewayClassName
           value: test
+  - it: should be possible to customize gateway name
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+      gateway:
+        name: test
+    asserts:
+      - template: gateway.yaml
+        equal:
+          path: metadata.name
+          value: test


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where we can't override gateway name.


### Motivation

Fixes https://github.com/traefik/traefik-helm-chart/issues/1124.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

