### PR TITLE
feat: ✨ display release name and image full path in installation notes

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -1,6 +1,6 @@
 
 
-Traefik Proxy {{ .Values.image.tag | default .Chart.AppVersion }} has been deployed successfully on {{ template "traefik.namespace" . }} namespace !
+{{ .Release.Name }} with {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }} has been deployed successfully on {{ template "traefik.namespace" . }} namespace !
 
 {{- if .Values.persistence }}
 {{- if and .Values.persistence.enabled (empty .Values.deployment.initContainer)}}

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: |2
 
 
-            Traefik Proxy 2.3.0 has been deployed successfully on NAMESPACE namespace !
+            RELEASE-NAME with docker.io/traefik:2.3.0 has been deployed successfully on NAMESPACE namespace !
   - it: should use helm managed namespace in release notes output
     set:
       namespaceOverride: "traefik-ns-override"
@@ -25,7 +25,7 @@ tests:
           value: |2
 
 
-            Traefik Proxy 2.3.0 has been deployed successfully on traefik-ns-override namespace !
+            RELEASE-NAME with docker.io/traefik:2.3.0 has been deployed successfully on traefik-ns-override namespace !
   - it: should use tag version in release notes output if set
     set:
       image:
@@ -35,7 +35,7 @@ tests:
           value: |2
 
 
-            Traefik Proxy v3.0 has been deployed successfully on NAMESPACE namespace !
+            RELEASE-NAME with docker.io/traefik:v3.0 has been deployed successfully on NAMESPACE namespace !
   - it: should not display a warning when persistence and initContainer are enabled
     set:
       persistence:
@@ -53,7 +53,7 @@ tests:
           value: |2
 
 
-            Traefik Proxy 2.3.0 has been deployed successfully on NAMESPACE namespace !
+            RELEASE-NAME with docker.io/traefik:2.3.0 has been deployed successfully on NAMESPACE namespace !
   - it: should display warning when enabling persistence without initContainer
     set:
       persistence:
@@ -63,7 +63,7 @@ tests:
           value: |
 
 
-            Traefik Proxy 2.3.0 has been deployed successfully on NAMESPACE namespace !
+            RELEASE-NAME with docker.io/traefik:2.3.0 has been deployed successfully on NAMESPACE namespace !
 
             🚨 When enabling persistence for certificates, permissions on acme.json can be
             lost when Traefik restarts. You can ensure correct permissions with an
@@ -83,6 +83,6 @@ tests:
           value: |
 
 
-            Traefik Proxy 2.3.0 has been deployed successfully on NAMESPACE namespace !
+            RELEASE-NAME with docker.io/traefik:2.3.0 has been deployed successfully on NAMESPACE namespace !
             🚨 Resources populated with this chart don't match with labelSelector `not_here=CRD` applied on kubernetesCRD provider 🚨
             🚨 Resources populated with this chart don't match with labelSelector `not_here=Ingress` applied on kubernetesIngress provider 🚨


### PR DESCRIPTION
### What does this PR do?

Display release name and image full path in installation notes

### Motivation

@mmatur discovered it : it always display "Traefik Proxy has been installed", even when using an other image or version compatible with Traefik Proxy, like Traefik Hub.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

