### PR TITLE
fix: 🐛 ingressroute default name

### DIFF
--- a/traefik/templates/ingressroute.yaml
+++ b/traefik/templates/ingressroute.yaml
@@ -4,7 +4,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: {{ template "traefik.fullname" $ }}-$name
+  name: {{ $.Release.Name }}-{{ $name }}
   namespace: {{ template "traefik.namespace" $ }}
   annotations:
     {{- if and $.Values.ingressClass.enabled $.Values.providers.kubernetesCRD.enabled $.Values.providers.kubernetesCRD.ingressClass }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -14,11 +14,14 @@ tests:
   asserts:
   - hasDocuments:
       count: 0
-- it: should have the expected default route match rule
+- it: should have the expected default
   asserts:
   - equal:
       path: spec.routes[0].match
       value: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+  - equal:
+      path: metadata.name
+      value: RELEASE-NAME-dashboard
 - it: should support overwriting the route match rule
   set:
     ingressRoute:

--- a/traefik/tests/healthcheck-ingressroute_test.yaml
+++ b/traefik/tests/healthcheck-ingressroute_test.yaml
@@ -10,6 +10,9 @@ tests:
   asserts:
   - hasDocuments:
       count: 1
+  - equal:
+      path: metadata.name
+      value: RELEASE-NAME-healthcheck
 - it: should have the expected default route match rule
   set:
     ingressRoute:


### PR DESCRIPTION
### What does this PR do?

Set default name for templated ingressroute to {{ release name }}-{{ ingressroute name }}

### Motivation

1. Fix current issue on the unified template
2. Provide more readable default name 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

