### PR TITLE
fix: RBACs missing for hub PAI gateway ClusterRole

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -195,7 +195,33 @@ rules:
       - update
 {{- end -}}
 {{- end -}}
-{{- if and .Values.hub.token .Values.hub.apimanagement.enabled }}
+{{- if .Values.hub.token }}
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - get
+  {{- if .Values.hub.apimanagement.enabled }}
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
   - apiGroups:
       - hub.traefik.io
     resources:
@@ -218,13 +244,6 @@ rules:
     resources:
       - namespaces
       - pods
-    verbs:
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-      - pods
       - nodes
     verbs:
       - get
@@ -237,18 +256,6 @@ rules:
     verbs:
       - create
       - patch
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
   - apiGroups:
       - ""
     resources:
@@ -278,6 +285,7 @@ rules:
       - get
       - list
       - watch
+  {{- end -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1160,8 +1160,42 @@ tests:
               - get
               - list
               - watch
+  - it: should contain additional RBACS for hub API gateway
+    image:
+      tag: v3.1.0
+    set:
+      hub:
+        token: xxx
+    asserts:
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - namespaces
+            verbs:
+              - list
+              - get
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
 
-  - it: should contain additional RBACS for hub
+  - it: should contain additional RBACS for hub API management
     image:
       tag: v3.1.0
     set:
@@ -1199,6 +1233,16 @@ tests:
               - ""
             resources:
               - namespaces
+            verbs:
+              - list
+              - get
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
               - pods
             verbs:
               - list


### PR DESCRIPTION
### What does this PR do?

This PR fixes hub API gateway RBACs when installing with non-namespaced RBACs.


### Motivation

Make API gateway working :-)


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

