### PR TITLE
fix(Traefik Hub): support new RBACs for upcoming traefik hub release

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -130,11 +130,15 @@ Renders a complete tree, even values that contains template.
 
 {{- define "imageVersion" -}}
 {{/*
-Traefik hub is based on v3.0 of traefik proxy, so this is a hack to avoid to much complexity in RBAC management which are
+Traefik hub is based on v3.1 (v3.0 before v3.3.1) of traefik proxy, so this is a hack to avoid to much complexity in RBAC management which are
 based on semverCompare
 */}}
 {{- if $.Values.hub.token -}}
+{{ if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $.Values.image.tag)) (semverCompare "<=v3.3.1-0" $.Values.image.tag) -}}
 v3.0
+{{- else -}}
+v3.1
+{{- end -}}
 {{- else -}}
 {{ (split "@" (default $.Chart.AppVersion $.Values.image.tag))._0 | replace "latest-" "" | replace "experimental-" "" }}
 {{- end -}}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -262,6 +262,7 @@ rules:
       - get
       - list
       - watch
+    {{- if (semverCompare "<v3.1.0-0" $version) }}
   - apiGroups:
       - ""
     resources:
@@ -269,6 +270,7 @@ rules:
     verbs:
       - list
       - watch
+    {{- end -}}
   {{- end -}}
 {{- end }}
 {{- end }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1161,9 +1161,9 @@ tests:
               - list
               - watch
   - it: should contain additional RBACS for hub API gateway
-    image:
-      tag: v3.1.0
     set:
+      image:
+        tag: v3.1.0
       hub:
         token: xxx
     asserts:
@@ -1196,9 +1196,9 @@ tests:
               - delete
 
   - it: should contain additional RBACS for hub API management
-    image:
-      tag: v3.1.0
     set:
+      image:
+        tag: v3.1.0
       hub:
         token: xxx
         apimanagement:
@@ -1321,6 +1321,27 @@ tests:
               - watch
       - template: rbac/clusterrole.yaml
         contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes
+            verbs:
+              - list
+              - watch
+
+  - it: should not contain additional RBACS for hub > 3.3.1 API management
+    set:
+      image:
+        tag: v3.3.2
+      hub:
+        token: xxx
+        apimanagement:
+          enabled: true
+    asserts:
+      - template: rbac/clusterrole.yaml
+        notContains:
           path: rules
           content:
             apiGroups:


### PR DESCRIPTION
### What does this PR do?

This PR modifies RBACs for upcoming Traefik Hub version which will be based on Traefik 3.1.


### Motivation

Support Traefik Hub > 3.3.1.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

