### PR TITLE
fix(Traefik Hub): missing RBACs for Traefik Hub

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -134,7 +134,7 @@ Traefik hub is based on v3.1 (v3.0 before v3.3.1) of traefik proxy, so this is a
 based on semverCompare
 */}}
 {{- if $.Values.hub.token -}}
-{{ if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $.Values.image.tag)) (semverCompare "<=v3.3.1-0" $.Values.image.tag) -}}
+{{ if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $.Values.image.tag)) (semverCompare "<v3.3.2-0" $.Values.image.tag) -}}
 v3.0
 {{- else -}}
 v3.1

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -216,6 +216,15 @@ rules:
 {{- /* not .Values.rbac.namespace */}}
 {{- end }}
 {{- if .Values.hub.token }}
+   {{- if or (semverCompare ">=v3.1.0-0" $version) .Values.hub.apimanagement.enabled }}
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - list
+      - watch
+   {{- end }}
   - apiGroups:
       - ""
     resources:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1330,6 +1330,17 @@ tests:
             verbs:
               - list
               - watch
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - endpoints
+            verbs:
+              - list
+              - watch
 
   - it: should not contain additional RBACS for hub > 3.3.1 API management
     set:
@@ -1348,6 +1359,36 @@ tests:
               - ""
             resources:
               - nodes
+            verbs:
+              - list
+              - watch
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - endpoints
+            verbs:
+              - list
+              - watch
+
+  - it: should not contain additional RBACS for hub <= 3.3.1 API gateway
+    set:
+      image:
+        tag: v3.3.1
+      hub:
+        token: xxx
+    asserts:
+      - template: rbac/clusterrole.yaml
+        notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - endpoints
             verbs:
               - list
               - watch


### PR DESCRIPTION
### What does this PR do?

Some RBACs were still missing for Hub.


### Motivation

Make it work for all Hub versions.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

