### PR TITLE
fix: disable default HTTPS listener for gateway

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -822,8 +822,6 @@ metrics:
 One can use the new stable kubernetes gateway API provider setting the following _values_:
 
 ```yaml
-image:
-  tag: v3.1.0-rc3
 providers:
   kubernetesGateway:
     enabled: true
@@ -906,6 +904,8 @@ gateway:
   listeners:
     websecure:
       hostname: whoami.docker.localhost
+      port: 8443
+      protocol: HTTPS
       certificateRefs:
         - name: whoami-tls
 ```

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -60,15 +60,10 @@ Kubernetes: `>=1.22.0-0`
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template)  In some cases, it can avoid the need for additional, extended or adhoc deployments. See #595 for more details and traefik/tests/values/extra.yaml for example. |
 | gateway.annotations | string | `nil` | Additional gateway annotations (e.g. for cert-manager.io/issuer) |
 | gateway.enabled | bool | `true` | When providers.kubernetesGateway.enabled, deploy a default gateway |
-| gateway.listeners | object | `{"web":{"hostname":null,"namespacePolicy":null,"port":8000,"protocol":"HTTP"},"websecure":{"certificateRefs":null,"hostname":null,"mode":null,"namespacePolicy":null,"port":8443,"protocol":"HTTPS"}}` | Define listeners |
+| gateway.listeners | object | `{"web":{"hostname":null,"namespacePolicy":null,"port":8000,"protocol":"HTTP"}}` | Define listeners |
 | gateway.listeners.web.hostname | string | `nil` | Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) |
 | gateway.listeners.web.namespacePolicy | string | `nil` | Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces |
 | gateway.listeners.web.port | int | `8000` | Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. The port must match a port declared in ports section. |
-| gateway.listeners.websecure.certificateRefs | string | `nil` | Add certificates for TLS or HTTPS protocols. See [GatewayTLSConfig](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayTLSConfig) |
-| gateway.listeners.websecure.hostname | string | `nil` | Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) |
-| gateway.listeners.websecure.mode | string | `nil` | TLS behavior for the TLS session initiated by the client. See [TLSModeType](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.TLSModeType). |
-| gateway.listeners.websecure.namespacePolicy | string | `nil` | Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces) |
-| gateway.listeners.websecure.port | int | `8443` | Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. The port must match a port declared in ports section. |
 | gateway.name | string | `nil` | Set a custom name to gateway |
 | gateway.namespace | string | `nil` | By default, Gateway is created in the same `Namespace` than Traefik. |
 | gatewayClass.enabled | bool | `true` | When providers.kubernetesGateway.enabled and gateway.enabled, deploy a default gatewayClass |

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -19,6 +19,9 @@ spec:
   listeners:
     {{- range $name, $config := .Values.gateway.listeners }}
     - name: {{ $name }}
+      {{ if not .port }}
+        {{- fail "ERROR: port needs to be specified" }}
+      {{- end -}}
       {{ $found := false }}
       {{- range $portName, $portConfig := $.Values.ports -}}
         {{- if eq $portConfig.port $config.port -}}
@@ -37,6 +40,9 @@ spec:
       allowedRoutes:
         namespaces:
           from: {{ . }}
+      {{- end }}
+      {{ if and (eq .protocol  "HTTPS") (not .certificateRefs) }}
+        {{- fail "ERROR: certificateRefs needs to be specified using HTTPS" }}
       {{- end }}
       {{ if or .certificateRefs .mode }}
       tls:

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -33,19 +33,6 @@ tests:
       - equal:
           path: spec.listeners[0].allowedRoutes.namespaces.from
           value: "All"
-  - it: should configure namespacePolicy and certificateRefs within websecure listener
-    set:
-      providers:
-        kubernetesGateway:
-          enabled: true
-      gateway:
-        listeners:
-          websecure:
-            namespacePolicy: All
-    asserts:
-      - equal:
-          path: spec.listeners[1].allowedRoutes.namespaces.from
-          value: "All"
   - it: should set expected apiVersion with v3 version
     set:
       image:
@@ -65,6 +52,7 @@ tests:
       gateway:
         listeners:
           websecure:
+            port: 8443
             certificateRefs:
               - name: "my-name"
                 group: "my-group"
@@ -173,6 +161,7 @@ tests:
       gateway:
         listeners:
           websecure:
+            port: 8443
             mode: Terminate
     asserts:
       - equal:
@@ -226,3 +215,40 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: port 8001 is not declared in ports"
+  - it: should provider listeners by default
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.listeners
+          value:
+            - name: web
+              port: 8000
+              protocol: HTTP
+  - it: should fail when no certificateRefs is specified with HTTPS
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+      gateway:
+        listeners:
+          websecure:
+            port: 8443
+            protocol: HTTPS
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: certificateRefs needs to be specified using HTTPS"
+  - it: should fail when no port is specified
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+      gateway:
+        listeners:
+          websecure:
+            protocol: HTTPS
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: port needs to be specified"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -150,20 +150,22 @@ gateway:
       protocol: HTTP
       # -- Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces
       namespacePolicy:
-    websecure:
-      # -- Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules.
-      # The port must match a port declared in ports section.
-      port: 8443
-      # -- Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname)
-      hostname:
-      # Specify expected protocol on this listener See [ProtocolType](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ProtocolType)
-      protocol: HTTPS
-      # -- Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces)
-      namespacePolicy:
-      # -- Add certificates for TLS or HTTPS protocols. See [GatewayTLSConfig](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayTLSConfig)
-      certificateRefs:
-      # -- TLS behavior for the TLS session initiated by the client. See [TLSModeType](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.TLSModeType).
-      mode:
+    # websecure listener is disabled by default because certificateRefs needs to be added,
+    # or you may specify TLS protocol with Passthrough mode and add "--providers.kubernetesGateway.experimentalChannel=true" in additionalArguments section.
+    # websecure:
+    #   # -- Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules.
+    #   # The port must match a port declared in ports section.
+    #   port: 8443
+    #   # -- Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname)
+    #   hostname:
+    #   # Specify expected protocol on this listener See [ProtocolType](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ProtocolType)
+    #   protocol: HTTPS
+    #   # -- Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces)
+    #   namespacePolicy:
+    #   # -- Add certificates for TLS or HTTPS protocols. See [GatewayTLSConfig](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayTLSConfig)
+    #   certificateRefs:
+    #   # -- TLS behavior for the TLS session initiated by the client. See [TLSModeType](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.TLSModeType).
+    #   mode:
 
 gatewayClass:
   # -- When providers.kubernetesGateway.enabled and gateway.enabled, deploy a default gatewayClass


### PR DESCRIPTION
### What does this PR do?

This PR disables default websecure listener for gateway.


### Motivation

Fixes https://github.com/traefik/traefik-helm-chart/issues/1147.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

