### PR TITLE
fix: Allow annotation templates for services that need them #1181

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -3,7 +3,13 @@
     metadata:
       annotations:
       {{- if .Values.deployment.podAnnotations }}
-        {{- tpl (toYaml .Values.deployment.podAnnotations) . | nindent 8 }}
+        {{- if .Values.deployment.templateAnnotations }}
+          {{- tpl (toYaml .Values.deployment.podAnnotations) . | nindent 8 }}
+        {{- else }}
+          {{- with .Values.deployment.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
       {{- end }}
       {{- if .Values.metrics }}
       {{- if and (.Values.metrics.prometheus) (not (.Values.metrics.prometheus.serviceMonitor).enabled) }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -93,6 +93,33 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.traefik/type
           value: 'internal'
+  - it: should error when annotations themselves contain a template
+    set:
+      deployment:
+        podAnnotations:
+          vault.hashicorp.com/agent-inject-template-test: |
+            {{- with secret 'kv/data/path/to/secret' -}}
+            {{ index .Data.data "secret" }}
+            {{- end }}
+    asserts:
+      - failedTemplate:
+          errorPattern: "[cannot parse template]+"
+  - it: should not error when templated annotations have templating disabled
+    set:
+      deployment:
+        podAnnotations:
+          vault.hashicorp.com/agent-inject-template-test: |
+            {{- with secret 'kv/data/path/to/secret' -}}
+            {{ index .Data.data "secret" }}
+            {{- end }}
+        templateAnnotations: false
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["vault.hashicorp.com/agent-inject-template-test"]
+          value: |
+            {{- with secret 'kv/data/path/to/secret' -}}
+            {{ index .Data.data "secret" }}
+            {{- end }}
   - it: should have labels with specified values
     set:
       deployment:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -52,6 +52,8 @@ deployment:
   # It supports templating. One can set it with values like traefik/name: '{{ template "traefik.name" . }}'
   podAnnotations: {}
   # -- Additional Pod labels (e.g. for filtering Pod by custom labels)
+  templateAnnotations: true
+  # -- Additional Pod labels (e.g. for filtering Pod by custom labels)
   podLabels: {}
   # -- Additional containers (e.g. for metric offloading sidecars)
   additionalContainers: []


### PR DESCRIPTION
### What does this PR do?
This fixes #1181 by doing the following:
- Adds a  `templateAnnotations` value to default values file and keeps it as `true` to keep existing behavior 
- Updates deployment template to leverage the new boolean
- Add true/false test cases

### Motivation
This should help avoid issues with Hashicorp Vault and agent injection and any other service which uses templates as a part of its annotations.

### More
- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

