### PR TITLE
feat: add new webhooks and removes unnecessary ones

### DIFF
--- a/traefik/templates/hub-admission-controller.yaml
+++ b/traefik/templates/hub-admission-controller.yaml
@@ -18,37 +18,6 @@ data:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: hub-edge-ingress
-  labels:
-  {{- include "traefik.labels" . | nindent 4 }}
-webhooks:
-  - name: admission.traefik.svc
-    clientConfig:
-      service:
-        name: admission
-        namespace: {{ template "traefik.namespace" . }}
-        path: /edge-ingress
-      caBundle: {{ $cert.Cert }}
-    sideEffects: None
-    admissionReviewVersions:
-      - v1
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-          - DELETE
-        apiGroups:
-          - hub.traefik.io
-        apiVersions:
-          - v1alpha1
-        resources:
-          - edgeingresses
-        scope: Namespaced
-
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
   name: hub-acp
   labels:
   {{- include "traefik.labels" . | nindent 4 }}
@@ -104,27 +73,6 @@ webhooks:
           - v1alpha1
         resources:
           - apiportals
-  - name: hub-agent.traefik.gateway
-    clientConfig:
-      service:
-        name: admission
-        namespace: {{ template "traefik.namespace" . }}
-        path: /api-gateway
-      caBundle: {{ $cert.Cert }}
-    sideEffects: None
-    admissionReviewVersions:
-      - v1
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-          - DELETE
-        apiGroups:
-          - hub.traefik.io
-        apiVersions:
-          - v1alpha1
-        resources:
-          - apigateways
   - name: hub-agent.traefik.api
     clientConfig:
       service:
@@ -146,27 +94,6 @@ webhooks:
           - v1alpha1
         resources:
           - apis
-  - name: hub-agent.traefik.collection
-    clientConfig:
-      service:
-        name: admission
-        namespace: {{ template "traefik.namespace" . }}
-        path: /api-collection
-      caBundle: {{ $cert.Cert }}
-    sideEffects: None
-    admissionReviewVersions:
-      - v1
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-          - DELETE
-        apiGroups:
-          - hub.traefik.io
-        apiVersions:
-          - v1alpha1
-        resources:
-          - apicollections
   - name: hub-agent.traefik.access
     clientConfig:
       service:
@@ -188,12 +115,12 @@ webhooks:
           - v1alpha1
         resources:
           - apiaccesses
-  - name: hub-agent.traefik.rate-limit
+  - name: hub-agent.traefik.plan
     clientConfig:
       service:
         name: admission
         namespace: {{ template "traefik.namespace" . }}
-        path: /api-rate-limit
+        path: /api-plan
       caBundle: {{ $cert.Cert }}
     sideEffects: None
     admissionReviewVersions:
@@ -208,7 +135,28 @@ webhooks:
         apiVersions:
           - v1alpha1
         resources:
-          - apiratelimits
+          - apiplans
+  - name: hub-agent.traefik.bundle
+    clientConfig:
+      service:
+        name: admission
+        namespace: { { template "traefik.namespace" . } }
+        path: /api-bundle
+      caBundle: { { $cert.Cert } }
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - hub.traefik.io
+        apiVersions:
+          - v1alpha1
+        resources:
+          - apibundles
   - name: hub-agent.traefik.version
     clientConfig:
       service:

--- a/traefik/tests/hub-admission-controler_test.yaml
+++ b/traefik/tests/hub-admission-controler_test.yaml
@@ -17,7 +17,7 @@ tests:
   - it: should not deploy anything when hub is not enabled
     asserts:
       - hasDocuments:
-          count: 5
+          count: 4
   - it: should not deploy anything when api management is disabled
     set:
       hub:
@@ -34,16 +34,8 @@ tests:
       - equal:
           path: metadata.name
           value: hub-agent-cert
-  - it: should render hub-edge-ingress webhook
-    documentIndex: 1
-    asserts:
-      - isKind:
-          of: MutatingWebhookConfiguration
-      - equal:
-          path: metadata.name
-          value: hub-edge-ingress
   - it: should render hub-acp webhook
-    documentIndex: 2
+    documentIndex: 1
     asserts:
       - isKind:
           of: MutatingWebhookConfiguration
@@ -51,7 +43,7 @@ tests:
           path: metadata.name
           value: hub-acp
   - it: should render hub-api webhook
-    documentIndex: 3
+    documentIndex: 2
     asserts:
       - isKind:
           of: MutatingWebhookConfiguration
@@ -59,7 +51,7 @@ tests:
           path: metadata.name
           value: hub-api
   - it: should render admission service
-    documentIndex: 4
+    documentIndex: 3
     asserts:
       - isKind:
           of: Service
@@ -84,14 +76,8 @@ tests:
       - matchRegex:
           path: webhooks[0].clientConfig.caBundle
           pattern: .*==
-  - it: should issue a webhook with a certificate
-    documentIndex: 3
-    asserts:
-      - matchRegex:
-          path: webhooks[0].clientConfig.caBundle
-          pattern: .*==
   - it: should issue a service with good selectors
-    documentIndex: 4
+    documentIndex: 3
     asserts:
       - equal:
           path: spec.selector


### PR DESCRIPTION
### What does this PR do?

This PR removes these webhooks as they reference old CRDs:
- Edge Ingresses
- API Gateways
- API Collections

It also adds new webhooks for upcoming features:
- API Bundles
- API Plans

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

