### PR TITLE
feat: ✨ add AllowACMEByPass and improve schema/doc on ports values

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -207,24 +207,41 @@ Kubernetes: `>=1.22.0-0`
 | ports.metrics.protocol | string | `"TCP"` | The port protocol (TCP/UDP) |
 | ports.traefik.expose | object | `{"default":false}` | You SHOULD NOT expose the traefik port on production deployments. If you want to access it from outside your cluster, use `kubectl port-forward` or create a secure ingress |
 | ports.traefik.exposedPort | int | `9000` | The exposed port for this service |
+| ports.traefik.hostIP | string | `nil` | Use hostIP if set. If not set, Kubernetes will default to 0.0.0.0, which means it's listening on all your interfaces and all your IPs. You may want to set this value if you need traefik to listen on specific interface only. |
+| ports.traefik.hostPort | string | `nil` | Use hostPort if set. |
 | ports.traefik.port | int | `9000` |  |
 | ports.traefik.protocol | string | `"TCP"` | The port protocol (TCP/UDP) |
 | ports.web.expose.default | bool | `true` |  |
 | ports.web.exposedPort | int | `80` |  |
+| ports.web.forwardedHeaders.insecure | bool | `false` |  |
+| ports.web.forwardedHeaders.trustedIPs | list | `[]` | Trust forwarded headers information (X-Forwarded-*). |
+| ports.web.nodePort | string | `nil` | See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |
 | ports.web.port | int | `8000` |  |
 | ports.web.protocol | string | `"TCP"` |  |
+| ports.web.proxyProtocol.insecure | bool | `false` |  |
+| ports.web.proxyProtocol.trustedIPs | list | `[]` | Enable the Proxy Protocol header parsing for the entry point |
+| ports.web.redirectTo | object | `{}` |  |
+| ports.web.targetPort | string | `nil` |  |
 | ports.web.transport | object | `{"keepAliveMaxRequests":null,"keepAliveMaxTime":null,"lifeCycle":{"graceTimeOut":null,"requestAcceptGraceTimeout":null},"respondingTimeouts":{"idleTimeout":null,"readTimeout":null,"writeTimeout":null}}` | Set transport settings for the entrypoint; see also https://doc.traefik.io/traefik/routing/entrypoints/#transport |
+| ports.websecure.allowACMEByPass | bool | `false` | See [upstream documentation](https://doc.traefik.io/traefik/routing/entrypoints/#allowacmebypass) |
+| ports.websecure.appProtocol | string | `nil` | See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) |
+| ports.websecure.containerPort | string | `nil` |  |
 | ports.websecure.expose.default | bool | `true` |  |
 | ports.websecure.exposedPort | int | `443` |  |
+| ports.websecure.forwardedHeaders.insecure | bool | `false` |  |
+| ports.websecure.forwardedHeaders.trustedIPs | list | `[]` | Trust forwarded headers information (X-Forwarded-*). |
+| ports.websecure.hostPort | string | `nil` |  |
+| ports.websecure.http3.advertisedPort | string | `nil` |  |
 | ports.websecure.http3.enabled | bool | `false` |  |
-| ports.websecure.middlewares | list | `[]` | /!\ It introduces here a link between your static configuration and your dynamic configuration /!\ It follows the provider naming convention: https://doc.traefik.io/traefik/providers/overview/#provider-namespace middlewares:   - namespace-name1@kubernetescrd   - namespace-name2@kubernetescrd |
+| ports.websecure.middlewares | list | `[]` | /!\ It introduces here a link between your static configuration and your dynamic configuration /!\ It follows the provider naming convention: https://doc.traefik.io/traefik/providers/overview/#provider-namespace   - namespace-name1@kubernetescrd   - namespace-name2@kubernetescrd |
+| ports.websecure.nodePort | string | `nil` | See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |
 | ports.websecure.port | int | `8443` |  |
 | ports.websecure.protocol | string | `"TCP"` |  |
-| ports.websecure.tls.certResolver | string | `""` |  |
-| ports.websecure.tls.domains | list | `[]` |  |
-| ports.websecure.tls.enabled | bool | `true` |  |
-| ports.websecure.tls.options | string | `""` |  |
-| ports.websecure.transport | object | `{"keepAliveMaxRequests":null,"keepAliveMaxTime":null,"lifeCycle":{"graceTimeOut":null,"requestAcceptGraceTimeout":null},"respondingTimeouts":{"idleTimeout":null,"readTimeout":null,"writeTimeout":null}}` | Set transport settings for the entrypoint; see also https://doc.traefik.io/traefik/routing/entrypoints/#transport |
+| ports.websecure.proxyProtocol.insecure | bool | `false` |  |
+| ports.websecure.proxyProtocol.trustedIPs | list | `[]` | Enable the Proxy Protocol header parsing for the entry point |
+| ports.websecure.targetPort | string | `nil` |  |
+| ports.websecure.tls | object | `{"certResolver":"","domains":[],"enabled":true,"options":""}` | See [upstream documentation](https://doc.traefik.io/traefik/routing/entrypoints/#tls) |
+| ports.websecure.transport | object | `{"keepAliveMaxRequests":null,"keepAliveMaxTime":null,"lifeCycle":{"graceTimeOut":null,"requestAcceptGraceTimeout":null},"respondingTimeouts":{"idleTimeout":null,"readTimeout":null,"writeTimeout":null}}` | See [upstream documentation](https://doc.traefik.io/traefik/routing/entrypoints/#transport) |
 | priorityClassName | string | `""` | [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) |
 | providers.file.content | string | `""` | File content (YAML format, go template supported) (see https://doc.traefik.io/traefik/providers/file/) |
 | providers.file.enabled | bool | `false` | Create a file provider |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -538,9 +538,6 @@
           {{- range $entrypoint, $config := $.Values.ports }}
           {{- if $config }}
             {{- if $config.redirectTo }}
-             {{- if eq (typeOf $config.redirectTo) "string" }}
-               {{- fail "ERROR: Syntax of `ports.web.redirectTo` has changed to `ports.web.redirectTo.port`. Details in PR #934." }}
-             {{- end }}
              {{- $toPort := index $.Values.ports $config.redirectTo.port }}
           - "--entryPoints.{{ $entrypoint }}.http.redirections.entryPoint.to=:{{ $toPort.exposedPort }}"
           - "--entryPoints.{{ $entrypoint }}.http.redirections.entryPoint.scheme=https"
@@ -582,6 +579,9 @@
                   {{- end }}
                 {{- end }}
               {{- end }}
+            {{- end }}
+            {{- if $config.allowACMEByPass }}
+          - "--entryPoints.name.allowACMEByPass=true"
             {{- end }}
             {{- if $config.forwardedHeaders }}
               {{- if $config.forwardedHeaders.trustedIPs }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -180,7 +180,7 @@ tests:
           exposedPort: 443
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: Syntax of `ports.web.redirectTo` has changed to `ports.web.redirectTo.port`. Details in PR #934."
+          errorPattern: "redirectTo"
   - it: should have http redirections enabled, when enabled with redirectTo
     set:
       ports:

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -445,11 +445,9 @@ tests:
       ports:
         websecure:
           forwardedHeaders:
-            insecure: True
-              - 127.0.0.1/32
-              - 192.168.1.7
+            insecure: true
           proxyProtocol:
-            insecure: True
+            insecure: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -631,3 +629,12 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesgateway.labelselector=app=traefik"
+  - it: should be possible to allow ACME bypass
+    set:
+      ports:
+        websecure:
+          allowACMEByPass: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.name.allowACMEByPass=true"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -980,6 +980,19 @@
                         "exposedPort": {
                             "type": "integer"
                         },
+                        "hostIP": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "hostPort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
                         "port": {
                             "type": "integer"
                         },
@@ -1002,11 +1015,51 @@
                         "exposedPort": {
                             "type": "integer"
                         },
+                        "forwardedHeaders": {
+                            "properties": {
+                                "insecure": {
+                                    "type": "boolean"
+                                },
+                                "trustedIPs": {
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "nodePort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
                         "port": {
                             "type": "integer"
                         },
                         "protocol": {
                             "type": "string"
+                        },
+                        "proxyProtocol": {
+                            "properties": {
+                                "insecure": {
+                                    "type": "boolean"
+                                },
+                                "trustedIPs": {
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "redirectTo": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "targetPort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
                         },
                         "transport": {
                             "properties": {
@@ -1077,6 +1130,22 @@
                 },
                 "websecure": {
                     "properties": {
+                        "allowACMEByPass": {
+                            "type": "boolean"
+                        },
+                        "appProtocol": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "containerPort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
                         "expose": {
                             "properties": {
                                 "default": {
@@ -1088,8 +1157,33 @@
                         "exposedPort": {
                             "type": "integer"
                         },
+                        "forwardedHeaders": {
+                            "properties": {
+                                "insecure": {
+                                    "type": "boolean"
+                                },
+                                "trustedIPs": {
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "hostPort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
                         "http3": {
                             "properties": {
+                                "advertisedPort": {
+                                    "minimum": 0,
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
                                 "enabled": {
                                     "type": "boolean"
                                 }
@@ -1099,11 +1193,36 @@
                         "middlewares": {
                             "type": "array"
                         },
+                        "nodePort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
                         "port": {
                             "type": "integer"
                         },
                         "protocol": {
                             "type": "string"
+                        },
+                        "proxyProtocol": {
+                            "properties": {
+                                "insecure": {
+                                    "type": "boolean"
+                                },
+                                "trustedIPs": {
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "targetPort": {
+                            "minimum": 0,
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
                         },
                         "tls": {
                             "properties": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -585,13 +585,12 @@ ports:
   traefik:
     port: 9000
     # -- Use hostPort if set.
-    # hostPort: 9000
-    #
+    hostPort:  # @schema type:[integer, null]; minimum:0
     # -- Use hostIP if set. If not set, Kubernetes will default to 0.0.0.0, which
     # means it's listening on all your interfaces and all your IPs. You may want
     # to set this value if you need traefik to listen on specific interface
     # only.
-    # hostIP: 192.168.100.10
+    hostIP:  # @schema type:[string, null]
 
     # Defines whether the port is exposed if service.type is LoadBalancer or
     # NodePort.
@@ -615,31 +614,23 @@ ports:
       default: true
     exposedPort: 80
     ## -- Different target traefik port on the cluster, useful for IP type LB
-    # targetPort: 80
+    targetPort: # @schema type:[integer, null]; minimum:0
     # The port protocol (TCP/UDP)
     protocol: TCP
-    # -- Use nodeport if set. This is useful if you have configured Traefik in a
-    # LoadBalancer.
-    # nodePort: 32080
+    # -- See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
+    nodePort:  # @schema type:[integer, null]; minimum:0
     # Port Redirections
     # Added in 2.2, you can make permanent redirects via entrypoints.
     # https://docs.traefik.io/routing/entrypoints/#redirection
-    # redirectTo:
-    #   port: websecure
-    #   (Optional)
-    #   priority: 10
-    #   permanent: true
-    #
-    # -- Trust forwarded headers information (X-Forwarded-*).
-    # forwardedHeaders:
-    #   trustedIPs: []
-    #   insecure: false
-    #
-    # -- Enable the Proxy Protocol header parsing for the entry point
-    # proxyProtocol:
-    #   trustedIPs: []
-    #   insecure: false
-    #
+    redirectTo: {}
+    forwardedHeaders:
+      # -- Trust forwarded headers information (X-Forwarded-*).
+      trustedIPs: []
+      insecure: false
+    proxyProtocol:
+      # -- Enable the Proxy Protocol header parsing for the entry point
+      trustedIPs: []
+      insecure: false
     # -- Set transport settings for the entrypoint; see also
     # https://doc.traefik.io/traefik/routing/entrypoints/#transport
     transport:
@@ -656,41 +647,39 @@ ports:
     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
     # asDefault: true
     port: 8443
-    # hostPort: 8443
-    # containerPort: 8443
+    hostPort:  # @schema type:[integer, null]; minimum:0
+    containerPort:  # @schema type:[integer, null]; minimum:0
     expose:
       default: true
     exposedPort: 443
     ## -- Different target traefik port on the cluster, useful for IP type LB
-    # targetPort: 80
+    targetPort:  # @schema type:[integer, null]; minimum:0
     ## -- The port protocol (TCP/UDP)
     protocol: TCP
-    # nodePort: 32443
-    ## -- Specify an application protocol. This may be used as a hint for a Layer 7 load balancer.
-    # appProtocol: https
-    #
-    ## -- Enable HTTP/3 on the entrypoint
-    ## Enabling it will also enable http3 experimental feature
-    ## https://doc.traefik.io/traefik/routing/entrypoints/#http3
-    ## There are known limitations when trying to listen on same ports for
-    ## TCP & UDP (Http3). There is a workaround in this chart using dual Service.
-    ## https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741
+    # -- See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
+    nodePort: # @schema type:[integer, null]; minimum:0
+    # -- See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)
+    appProtocol: # @schema type:[string, null]
+    # -- See [upstream documentation](https://doc.traefik.io/traefik/routing/entrypoints/#allowacmebypass)
+    allowACMEByPass: false
     http3:
+      ## -- Enable HTTP/3 on the entrypoint
+      ## Enabling it will also enable http3 experimental feature
+      ## https://doc.traefik.io/traefik/routing/entrypoints/#http3
+      ## There are known limitations when trying to listen on same ports for
+      ## TCP & UDP (Http3). There is a workaround in this chart using dual Service.
+      ## https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741
       enabled: false
-    # advertisedPort: 4443
-    #
-    # -- Trust forwarded headers information (X-Forwarded-*).
-    # forwardedHeaders:
-    #   trustedIPs: []
-    #   insecure: false
-    #
-    # -- Enable the Proxy Protocol header parsing for the entry point
-    # proxyProtocol:
-    #   trustedIPs: []
-    #   insecure: false
-    #
-    # -- Set transport settings for the entrypoint; see also
-    # https://doc.traefik.io/traefik/routing/entrypoints/#transport
+      advertisedPort:  # @schema type:[integer, null]; minimum:0
+    forwardedHeaders:
+        # -- Trust forwarded headers information (X-Forwarded-*).
+      trustedIPs: []
+      insecure: false
+    proxyProtocol:
+      # -- Enable the Proxy Protocol header parsing for the entry point
+      trustedIPs: []
+      insecure: false
+    # -- See [upstream documentation](https://doc.traefik.io/traefik/routing/entrypoints/#transport)
     transport:
       respondingTimeouts:
         readTimeout:   # @schema type:[string, integer, null]
@@ -701,26 +690,17 @@ ports:
         graceTimeOut:               # @schema type:[string, integer, null]
       keepAliveMaxRequests:         # @schema type:[integer, null]; minimum:0
       keepAliveMaxTime:             # @schema type:[string, integer, null]
-    #
-    ## Set TLS at the entrypoint
-    ## https://doc.traefik.io/traefik/routing/entrypoints/#tls
+    # --  See [upstream documentation](https://doc.traefik.io/traefik/routing/entrypoints/#tls)
     tls:
       enabled: true
-      # this is the name of a TLSOption definition
       options: ""
       certResolver: ""
       domains: []
-      # - main: example.com
-      #   sans:
-      #     - foo.example.com
-      #     - bar.example.com
-    #
     # -- One can apply Middlewares on an entrypoint
     # https://doc.traefik.io/traefik/middlewares/overview/
     # https://doc.traefik.io/traefik/routing/entrypoints/#middlewares
     # -- /!\ It introduces here a link between your static configuration and your dynamic configuration /!\
     # It follows the provider naming convention: https://doc.traefik.io/traefik/providers/overview/#provider-namespace
-    # middlewares:
     #   - namespace-name1@kubernetescrd
     #   - namespace-name2@kubernetescrd
     middlewares: []
@@ -728,10 +708,6 @@ ports:
     # -- When using hostNetwork, use another port to avoid conflict with node exporter:
     # https://github.com/prometheus/prometheus/wiki/Default-port-allocations
     port: 9100
-    # hostPort: 9100
-    # Defines whether the port is exposed if service.type is LoadBalancer or
-    # NodePort.
-    #
     # -- You may not want to expose the metrics port on production deployments.
     # If you want to access it from outside your cluster,
     # use `kubectl port-forward` or create a secure ingress


### PR DESCRIPTION
### What does this PR do?

It adds the new entryPoints setting [allowACMEByPass](https://doc.traefik.io/traefik/routing/entrypoints/#allowacmebypass) introduced in v3.1.3 and v2.11.9

It also improve documentation & schema of the `ports` section

### Motivation

1. Support latest Traefik Proxy feature
2. Improve documentation & schema

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

