### PR TITLE
fix: 🐛 updateStrategy behavior

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -309,7 +309,7 @@ Kubernetes: `>=1.22.0-0`
 | tracing.otlp.http.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
 | updateStrategy.rollingUpdate.maxSurge | int | `1` |  |
 | updateStrategy.rollingUpdate.maxUnavailable | int | `0` |  |
-| updateStrategy.type | string | `"RollingUpdate"` | Customize updateStrategy: RollingUpdate or OnDelete |
+| updateStrategy.type | string | `"RollingUpdate"` | Customize updateStrategy of Deployment or DaemonSet |
 | volumes | list | `[]` | Add volumes to the traefik pod. The volume name will be passed to tpl. This can be used to mount a cert pair or a configmap that holds a config.toml file. After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg: `additionalArguments: - "--providers.file.filename=/config/dynamic.toml" - "--ping" - "--ping.entrypoint=web"` |
 
 ----------------------------------------------

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -10,7 +10,7 @@
     {{- fail "\n\n ERROR: latest tag should not be used" }}
   {{- end }}
   {{- with .Values.updateStrategy }}
-    {{- if eq (.type) "RollingUpdate" }}
+    {{- if and (eq (.type) "RollingUpdate") (.rollingUpdate) }}
       {{- if not (contains "%" (toString .rollingUpdate.maxUnavailable)) }}
         {{- if and ($.Values.hostNetwork) (lt (float64 .rollingUpdate.maxUnavailable) 1.0) }}
           {{- fail "maxUnavailable should be greater than 1 when using hostNetwork." }}
@@ -41,7 +41,15 @@ spec:
   selector:
     matchLabels:
       {{- include "traefik.labelselector" . | nindent 6 }}
-  updateStrategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    type: {{ .type }}
+    {{- if (eq .type "RollingUpdate") }}
+    rollingUpdate:
+      maxUnavailable: {{ .rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .rollingUpdate.maxSurge }}
+    {{- end }}
+  {{- end }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
   {{- if .Values.deployment.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -44,7 +44,15 @@ spec:
   selector:
     matchLabels:
       {{- include "traefik.labelselector" . | nindent 6 }}
-  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    type: {{ .type }}
+    {{- if (eq .type "RollingUpdate") }}
+    rollingUpdate:
+      maxUnavailable: {{ .rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .rollingUpdate.maxSurge }}
+    {{- end }}
+  {{- end }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
   template: {{ template "traefik.podTemplate" . }}
 {{- end -}}

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -150,6 +150,8 @@ tests:
       - equal:
           path: spec.updateStrategy.type
           value: OnDelete
+      - notExists:
+          path: spec.updateStrategy.rollingUpdate
   - it: should use helm managed namespace as default behavior
     set:
       deployment:

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -43,7 +43,6 @@ tests:
       updateStrategy:
         rollingUpdate:
           maxUnavailable: 4
-          vegetaForce: 9000
     asserts:
       - equal:
           path: spec.strategy.type
@@ -54,9 +53,6 @@ tests:
       - equal:
           path: spec.strategy.rollingUpdate.maxSurge
           value: 1
-      - equal:
-          path: spec.strategy.rollingUpdate.vegetaForce
-          value: 9000
   - it: should have annotations with specified values
     set:
       deployment:
@@ -156,14 +152,16 @@ tests:
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
           value: kubernetes.io/hostname
-  - it: should have an OnDelete strategy when set
+  - it: should have Recreate strategy when set
     set:
       updateStrategy:
-        type: OnDelete
+        type: Recreate
     asserts:
       - equal:
           path: spec.strategy.type
-          value: OnDelete
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
   - it: should accept overridden namespace
     set:
       namespaceOverride: "traefik-ns-override"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -219,11 +219,13 @@ ingressRoute:
     tls: {}
 
 updateStrategy:  # @schema additionalProperties: false
-  # -- Customize updateStrategy: RollingUpdate or OnDelete
+  # -- Customize updateStrategy of Deployment or DaemonSet
   type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 0  # @schema type:[integer, string, null]
     maxSurge: 1        # @schema type:[integer, string, null]
+
+
 
 readinessProbe:  # @schema additionalProperties: false
   # -- The number of consecutive failures allowed before considering the probe as failed.


### PR DESCRIPTION
### What does this PR do?

Map exactly expected fields from Kubernetes instead of calling `toYaml`.

### Motivation

Fixes #1193

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

