### PR TITLE
Replace `CLF` with `common` in `values.yaml`

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -345,7 +345,7 @@ logs:
     # -- To enable access logs
     enabled: false
     # -- Set [access log format](https://doc.traefik.io/traefik/observability/access-logs/#format)
-    format:  # @schema enum:["CLF", "json", null]; type:[string, null]; default: "CLF"
+    format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
     # filePath: "/var/log/traefik/access.log
     # -- Set [bufferingSize](https://doc.traefik.io/traefik/observability/access-logs/#bufferingsize)
     bufferingSize:  # @schema type:[integer, null]


### PR DESCRIPTION
I tried using `CLF` as the docs suggested for the access log format, but I received the following error:

```
2024-09-26T21:36:25Z ERR github.com/traefik/traefik/v3/pkg/middlewares/accesslog/logger.go:98 > Unsupported access log format: "CLF", defaulting to common format instead.
```
