### PR TITLE
feat(Traefik Proxy): update rbac following v3.2 migration guide

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -149,8 +149,10 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - backendtlspolicies
       - gatewayclasses
       - gateways
+      - grpcroutes
       - httproutes
       - referencegrants
       - tcproutes
@@ -162,8 +164,10 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - backendtlspolicies/status
       - gatewayclasses/status
       - gateways/status
+      - grpcroutes/status
       - httproutes/status
       - tcproutes/status
       - tlsroutes/status

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -601,8 +601,10 @@ tests:
             apiGroups:
               - gateway.networking.k8s.io
             resources:
+              - backendtlspolicies/status
               - gatewayclasses/status
               - gateways/status
+              - grpcroutes/status
               - httproutes/status
               - tcproutes/status
               - tlsroutes/status
@@ -615,8 +617,10 @@ tests:
             apiGroups:
               - gateway.networking.k8s.io
             resources:
+              - backendtlspolicies
               - gatewayclasses
               - gateways
+              - grpcroutes
               - httproutes
               - referencegrants
               - tcproutes
@@ -655,8 +659,10 @@ tests:
             apiGroups:
               - gateway.networking.k8s.io
             resources:
+              - backendtlspolicies/status
               - gatewayclasses/status
               - gateways/status
+              - grpcroutes/status
               - httproutes/status
               - tcproutes/status
               - tlsroutes/status
@@ -669,8 +675,10 @@ tests:
             apiGroups:
               - gateway.networking.k8s.io
             resources:
+              - backendtlspolicies
               - gatewayclasses
               - gateways
+              - grpcroutes
               - httproutes
               - referencegrants
               - tcproutes


### PR DESCRIPTION
### What does this PR do?

It update RBAC following [v3.2 migration guide](https://doc.traefik.io/traefik/v3.2/migration/v3/#v31-to-v32), required for latest features on Gateway API.

### Motivation

Support Traefik Proxy v3.2.0-rc1

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

