### PR TITLE
Update topology spread constraints comments

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -860,7 +860,7 @@ topologySpreadConstraints: []
 # on nodes where no other traefik pods are scheduled.
 #  - labelSelector:
 #      matchLabels:
-#        app: '{{ template "traefik.name" . }}'
+#        app.kubernetes.io/name: '{{ template "traefik.name" . }}'
 #    maxSkew: 1
 #    topologyKey: kubernetes.io/hostname
 #    whenUnsatisfiable: DoNotSchedule


### PR DESCRIPTION
### What does this PR do?

This PR updates it to use the `app.kubernetes.io/name` label which is a default label in `traefik.labelselector`.

### Motivation

The help text for the topology spread constraints in the values file was misleading since the `app` label is not a default.

### More

- [ ]Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

I don't think any apply.