### PR TITLE
fix(certificateResolvers)\!: :boom: use same syntax in Chart and in Traefik

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -331,14 +331,15 @@ Here is a more complete example, using also native Let's encrypt feature of Trae
 persistence:
   enabled: true
   size: 128Mi
-certResolvers:
+certificatesResolvers:
   letsencrypt:
-    email: "{{ letsencrypt_email }}"
-    #caServer: https://acme-v02.api.letsencrypt.org/directory # Production server
-    caServer: https://acme-staging-v02.api.letsencrypt.org/directory # Staging server
-    dnsChallenge:
-      provider: azuredns
-    storage: /data/acme.json
+    acme:
+      email: "{{ letsencrypt_email }}"
+      #caServer: https://acme-v02.api.letsencrypt.org/directory # Production server
+      caServer: https://acme-staging-v02.api.letsencrypt.org/directory # Staging server
+      dnsChallenge:
+        provider: azuredns
+      storage: /data/acme.json
 env:
   - name: AZURE_CLIENT_ID
     value: "{{ azure_dns_challenge_application_id }}"
@@ -529,11 +530,12 @@ stringData:
 persistence:
   enabled: true
   storageClass: xxx
-certResolvers:
+certificatesResolvers:
   letsencrypt:
-    dnsChallenge:
-      provider: cloudflare
-    storage: /data/acme.json
+    acme:
+      dnsChallenge:
+        provider: cloudflare
+      storage: /data/acme.json
 env:
   - name: CF_DNS_API_TOKEN
     valueFrom:
@@ -552,6 +554,9 @@ podSecurityContext:
   fsGroup: 65532
   fsGroupChangePolicy: "OnRootMismatch"
 ```
+
+>[!NOTE]
+> With Traefik Hub, certificates can be stored on Kubernetes in `Secret` with distributedAcme.
 
 # Provide default certificate with cert-manager and CloudFlare DNS
 

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -32,7 +32,7 @@ Kubernetes: `>=1.22.0-0`
 | additionalVolumeMounts | list | `[]` | Additional volumeMounts to add to the Traefik container |
 | affinity | object | `{}` | on nodes where no other traefik pods are scheduled. It should be used when hostNetwork: true to prevent port conflicts |
 | autoscaling.enabled | bool | `false` | Create HorizontalPodAutoscaler object. See EXAMPLES.md for more details. |
-| certResolvers | object | `{}` | Certificates resolvers configuration. Ref: https://doc.traefik.io/traefik/https/acme/#certificate-resolvers See EXAMPLES.md for more details. |
+| certificateResolvers | object | `{}` | Certificates resolvers configuration. Ref: https://doc.traefik.io/traefik/https/acme/#certificate-resolvers See EXAMPLES.md for more details. |
 | commonLabels | object | `{}` | Add additional label to all resources |
 | core.defaultRuleSyntax | string | `""` | Can be used to use globally v2 router syntax See https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#new-v3-syntax-notable-changes |
 | deployment.additionalContainers | list | `[]` | Additional containers (e.g. for metric offloading sidecars) |
@@ -190,7 +190,7 @@ Kubernetes: `>=1.22.0-0`
 | nodeSelector | object | `{}` | nodeSelector is the simplest recommended form of node selection constraint. |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | persistence.annotations | object | `{}` |  |
-| persistence.enabled | bool | `false` | Enable persistence using Persistent Volume Claims ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ It can be used to store TLS certificates, see `storage` in certResolvers |
+| persistence.enabled | bool | `false` | Enable persistence using Persistent Volume Claims ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ It can be used to store TLS certificates with `storage` of acme certificatesResolvers |
 | persistence.existingClaim | string | `""` |  |
 | persistence.name | string | `"data"` |  |
 | persistence.path | string | `"/data"` |  |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -685,16 +685,11 @@
               {{- end }}
             {{- end }}
           {{- end }}
-          {{- range $resolver, $config := $.Values.certResolvers }}
-          {{- range $option, $setting := $config }}
-          {{- if kindIs "map" $setting }}
-          {{- range $field, $value := $setting }}
-          - "--certificatesresolvers.{{ $resolver }}.acme.{{ $option }}.{{ $field }}={{ if kindIs "slice" $value }}{{ join "," $value }}{{ else }}{{ $value }}{{ end }}"
-          {{- end }}
-          {{- else }}
-          - "--certificatesresolvers.{{ $resolver }}.acme.{{ $option }}={{ $setting }}"
-          {{- end }}
-          {{- end }}
+          {{- $resolvers := trim (include "traefik.yaml2properties" ($.Values.certificatesResolvers)) }}
+          {{- with $resolvers }}
+           {{- range (regexSplit "\n" . -1) }}
+          - "--certificatesresolvers.{{ . }}"
+           {{- end }}
           {{- end }}
           {{- with .Values.additionalArguments }}
           {{- range . }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -336,15 +336,16 @@ tests:
           content: "--experimental.kubernetesgateway"
   - it: should have the certificate resolver options applied
     set:
-      certResolvers:
+      certificatesResolvers:
         myAcmeResolver:
-          email: email@example.com
-          dnsChallenge:
-            provider: myProvider
-            resolvers:
-              - 1.1.1.1
-              - 8.8.8.8
-          tlsChallenge: true
+          acme:
+            email: email@example.com
+            dnsChallenge:
+              provider: myProvider
+              resolvers:
+                - 1.1.1.1
+                - 8.8.8.8
+            tlsChallenge: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -358,6 +359,38 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--certificatesresolvers.myAcmeResolver.acme.tlsChallenge=true"
+
+  - it: should have the distributed acme resolver options applied
+    set:
+      certificatesResolvers:
+        my-resolver:
+          distributedAcme:
+            email: email@example.com
+            storage:
+              kubernetes: true
+            httpChallenge:
+              entrypoint: "web"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--certificatesresolvers.my-resolver.distributedAcme.email=email@example.com"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--certificatesresolvers.my-resolver.distributedAcme.storage.kubernetes=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--certificatesresolvers.my-resolver.distributedAcme.httpChallenge.entrypoint=web"
+
+  - it: should have the tailscale resolver options applied
+    set:
+      certificatesResolvers:
+        my-resolver:
+          tailscale: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--certificatesresolvers.my-resolver.tailscale=true"
+
   - it: should have prometheus annotations with specified values
     set:
       ports:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -22,7 +22,7 @@
             },
             "type": "object"
         },
-        "certResolvers": {
+        "certificateResolvers": {
             "properties": {},
             "type": "object"
         },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -781,7 +781,7 @@ autoscaling:
 persistence:
   # -- Enable persistence using Persistent Volume Claims
   # ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  # It can be used to store TLS certificates, see `storage` in certResolvers
+  # It can be used to store TLS certificates with `storage` of acme certificatesResolvers
   enabled: false
   name: data
   existingClaim: ""
@@ -797,7 +797,7 @@ persistence:
 # -- Certificates resolvers configuration.
 # Ref: https://doc.traefik.io/traefik/https/acme/#certificate-resolvers
 # See EXAMPLES.md for more details.
-certResolvers: {}
+certificateResolvers: {}
 
 # -- If hostNetwork is true, runs traefik in the host network namespace
 # To prevent unschedulabel pods due to port collisions, if hostNetwork=true


### PR DESCRIPTION
### What does this PR do?

Align syntax used in this Chart and in Traefik for certificateResolvers.

Before

```yaml
certResolvers:
  myAcmeResolver:
    email: email@example.com
    dnsChallenge:
      provider: myProvider
      resolvers:
        - 1.1.1.1
        - 8.8.8.8
    tlsChallenge: true
```

After

```yaml
certificatesResolvers:
  myAcmeResolver:
    acme: 
      email: email@example.com
      dnsChallenge:
        provider: myProvider
        resolvers:
          - 1.1.1.1
          - 8.8.8.8
      tlsChallenge: true
```

### Motivation

Nowadays, Traefik Proxy and Traefik Hub supports various certificateResolvers, not only ACME. 
Current implementation do not allow to configure `tailscale` or `distributedAcme`, for instance.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

