### PR TITLE
chore: allow TRACE log level

### DIFF
--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -597,7 +597,8 @@
                                 "ERROR",
                                 "FATAL",
                                 "PANIC",
-                                "DEBUG"
+                                "DEBUG",
+                                "TRACE"
                             ],
                             "type": "string"
                         },


### PR DESCRIPTION
### What does this PR do?

Allow to specify log level `TRACE` which is a valid Traefik log level.
see: https://doc.traefik.io/traefik/observability/logs/#level


### Motivation

I tried to debug something and needed `TRACE` as log.level which was forbidden by this chart:

```log
Error: Failed to render chart: exit status 1: Error: values don't meet the specifications of the schema(s) in the following chart(s):
traefik:
- logs.general.level: logs.general.level must be one of the following: "INFO", "WARN", "ERROR", "FATAL", "PANIC", "DEBUG"
```


### More

- [x] ~Yes, I updated the tests accordingly~
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

