### PR TITLE
fix: 🐛 http3 with internal service

### DIFF
--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -62,6 +62,8 @@ spec:
 {{- end }}
 
 {{- if and $exposedPorts (and $udpPorts (not $service.single)) }}
+ {{- $ports := include "traefik.service-ports" (dict "ports" $udpPorts "serviceName" $name) }}
+ {{- if not (empty $ports) }}
 ---
 apiVersion: v1
 kind: Service
@@ -76,7 +78,8 @@ metadata:
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}
   ports:
-  {{- template "traefik.service-ports" (dict "ports" $udpPorts "serviceName" $name) }}
+  {{- $ports }}
+ {{- end }}
 {{- end }}
 
 {{- end -}}

--- a/traefik/tests/service-config-custom_test.yaml
+++ b/traefik/tests/service-config-custom_test.yaml
@@ -190,3 +190,35 @@ tests:
             protocol: UDP
             targetPort: websecure-http3
         documentIndex: 1
+  - it: should not provide udp Service when exposing traefik port on internal service with http3 on websecure
+    set:
+      ports:
+        web:
+          expose:
+            internal: false
+        websecure:
+          http3:
+            enabled: true
+        traefik:
+          expose:
+            internal: true
+      service:
+        additionalServices:
+          internal: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+          name: RELEASE-NAME-traefik
+        documentIndex: 0
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+          name: RELEASE-NAME-traefik-internal
+        documentIndex: 1
+

--- a/traefik/tests/service-config-multiple_test.yaml
+++ b/traefik/tests/service-config-multiple_test.yaml
@@ -155,6 +155,8 @@ tests:
         udp:
           port: 3000
           protocol: UDP
+          expose:
+            default: true
     asserts:
       - isNull:
           path: spec.ipFamilyPolicy
@@ -171,6 +173,8 @@ tests:
         udp:
           port: 3000
           protocol: UDP
+          expose:
+            default: true
     asserts:
       - equal:
           path: spec.ipFamilyPolicy
@@ -188,6 +192,8 @@ tests:
         udp:
           port: 3000
           protocol: UDP
+          expose:
+            default: true
     asserts:
       - isNull:
           path: spec.ipFamilies


### PR DESCRIPTION
### What does this PR do?

Avoid providing an UDP Service when there is no udp ports exposed.

### Motivation

Fixes #1233

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

