### PR TITLE
Fix support for entrypoint option allowACMEByPass

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -599,7 +599,7 @@
               {{- if (semverCompare "<3.1.3-0" $version) }}
                 {{- fail "ERROR: allowACMEByPass has been introduced with Traefik v3.1.3+" -}}
               {{- end }}
-          - "--entryPoints.name.allowACMEByPass=true"
+          - "--entryPoints.{{ $entrypoint }}.allowACMEByPass=true"
             {{- end }}
             {{- if $config.forwardedHeaders }}
               {{- if $config.forwardedHeaders.trustedIPs }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -687,7 +687,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.name.allowACMEByPass=true"
+          content: "--entryPoints.websecure.allowACMEByPass=true"
   - it: should fail when setting ACME bypass with Proxy v3.1.0
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Allow allowACMEByPass to be used on entrypoints other than `name`.

### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes https://github.com/traefik/traefik-helm-chart/issues/1245

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

