### PR TITLE
fix(KubernetesCRD): 🐛 IngressClass should be readable even when kubernetesIngress is disabled

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -105,6 +105,17 @@ rules:
       - update
   {{- end -}}
   {{- if .Values.providers.kubernetesCRD.enabled }}
+   {{- if not .Values.providers.kubernetesIngress.enabled }}
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+   {{- end }}
   - apiGroups:
       - traefik.io
     resources:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -124,6 +124,25 @@ tests:
               verbs:
                 - update
         template: rbac/clusterrole.yaml
+  - it: ClusterRole should be able to read ingressclass when only kubernetesCRD is enabled
+    set:
+      providers:
+        kubernetesIngress:
+          enabled: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingressclasses
+            verbs:
+              - get
+              - list
+              - watch
+        template: rbac/clusterrole.yaml
   - it: ClusterRole should not be able to read CRDs when kubernetesCRD is disabled
     set:
       providers:


### PR DESCRIPTION
### What does this PR do?

Add a required Cluster rbac when only KubernetesCRD is enabled.

### Motivation

Fix issue found in lab.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

