### PR TITLE
fix: :bug: support specifying plugins storage

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -475,18 +475,28 @@ experimental:
       version: v1.3.5
 ```
 
-When persistence is needed, this `emptyDir` can be replaced with a PVC:
+When persistence is needed, this `emptyDir` can be replaced with a PVC by adding:
 
 ```yaml
 deployment:
   additionalVolumes:
   - name: plugins
+    persistentVolumeClaim:
+      claimName: my-plugins-vol
 additionalVolumeMounts:
 - name: plugins
   mountPath: /plugins-storage
-additionalArguments:
-- "--experimental.plugins.bouncer.moduleName=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
-- "--experimental.plugins.bouncer.version=v1.3.5"
+extraObjects:
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: my-plugins-vol
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
 ```
 
 # Use Traefik native Let's Encrypt integration, without cert-manager

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -176,3 +176,13 @@ Key: {{ $cert.Key | b64enc }}
       {{ printf "- \"%s\"\n" . }}
     {{- end -}}
 {{- end -}}
+
+{{- define "traefik.hasPluginsVolume" -}}
+    {{- $found := false -}}
+    {{- range . -}}
+       {{- if eq .name "plugins" -}}
+           {{ $found = true }}
+       {{- end -}}
+    {{- end -}}
+    {{- $found -}}
+{{- end -}}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -156,7 +156,7 @@
             mountPath: {{ .mountPath }}
             readOnly: true
           {{- end }}
-          {{- if gt (len .Values.experimental.plugins) 0 }}
+          {{- if and (gt (len .Values.experimental.plugins) 0) (ne (include "traefik.hasPluginsVolume" .Values.deployment.additionalVolumes) "true") }}
           - name: plugins
             mountPath: "/plugins-storage"
           {{- end }}
@@ -812,7 +812,7 @@
         {{- if .Values.deployment.additionalVolumes }}
           {{- toYaml .Values.deployment.additionalVolumes | nindent 8 }}
         {{- end }}
-        {{- if gt (len .Values.experimental.plugins) 0 }}
+        {{- if and (gt (len .Values.experimental.plugins) 0) (ne (include "traefik.hasPluginsVolume" .Values.deployment.additionalVolumes) "true") }}
         - name: plugins
           emptyDir: {}
         {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -238,6 +238,41 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--experimental.plugins.demo.version=v0.2.1"
 
+  - it: should be possible to configure a customized plugin storage
+    set:
+      experimental:
+        plugins:
+          demo:
+            moduleName: github.com/traefik/plugindemo
+            version: v0.2.1
+      deployment:
+        additionalVolumes:
+          - name: plugins
+            hostPath:
+              path: /data/
+              type: Directory
+      additionalVolumeMounts:
+        - name: plugins
+          mountPath: /plugins-storage
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[2]
+          value:
+            hostPath:
+              path: /data/
+              type: Directory
+            name: plugins
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: plugins
+            mountPath: "/plugins-storage"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.plugins.demo.moduleName=github.com/traefik/plugindemo"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.plugins.demo.version=v0.2.1"
   - it: should fail gracefully when using old syntax
     set:
       experimental:


### PR DESCRIPTION
### What does this PR do?

This PR adds the support of custom plugins storage.


### Motivation

Adding `plugins` volume to the current chart make duplicates in volumes.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

