### PR TITLE
Allow changing automountServiceAccountToken in PodSpec via values.yaml

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -23,7 +23,7 @@
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "traefik.serviceAccountName" . }}
-      automountServiceAccountToken: true
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ default 60 .Values.deployment.terminationGracePeriodSeconds }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.deployment.dnsPolicy }}

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1533,6 +1533,9 @@
             "properties": {
                 "name": {
                     "type": "string"
+                },
+		"automountServiceAccountToken": {
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -838,6 +838,10 @@ serviceAccount:  # @schema additionalProperties: false
   # If not set, a service account is created automatically using the fullname template
   name: ""
 
+  # Automounting the service account is disabled by default on the service account itself
+  # setting this to false disables automounting of the service account in the PodSpec in the Deployment
+  automountServiceAccountToken: true
+
 # -- Additional serviceAccount annotations (e.g. for oidc authentication)
 serviceAccountAnnotations: {}
 


### PR DESCRIPTION
### What does this PR do?

This PR adds serviceAccount.automountServiceAccountToken to values.yaml and thus allows changing automountServiceAccountToken in the PodSpec, which is true by default. This PR does not change the default behavior.

### Motivation

automountServiceAccountToken is set to false in the actual service account definition, but in environments that have policies that require automountServiceAccountToken to be false in the actual Podspec this isn't good enough. Ideally the same value would change automountServiceAccountToken in both the service account definition and in the podspec, but since they are respectively true and false by default this would effectively change the default behaviour if both were set by this one value so I opted to only have this value control the attribute in the podspec.

This is the issue described in https://github.com/traefik/traefik-helm-chart/issues/1254
### More

- [X ] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed
