### PR TITLE
fix: :bug: abortOnPluginFailure not released yet

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -448,7 +448,7 @@
           - "--experimental.plugins.{{ $pluginName }}.moduleName={{ $plugin.moduleName }}"
           - "--experimental.plugins.{{ $pluginName }}.version={{ $plugin.version }}"
           {{- end }}
-          {{- if and (semverCompare ">=3.2.1-0" $version) (.Values.experimental.abortOnPluginFailure)}}
+          {{- if and (semverCompare ">=3.3.0-0" $version) (.Values.experimental.abortOnPluginFailure)}}
           - "--experimental.abortonpluginfailure={{ .Values.experimental.abortOnPluginFailure }}"
           {{- end }}
           {{- if .Values.providers.kubernetesCRD.enabled }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -31,3 +31,7 @@
     {{- fail "ERROR: namespaced rbac requires Kubernetes CRD or Kubernetes Ingress provider." }}
   {{- end }}
 {{- end }}
+
+{{- if and (semverCompare "<3.3.0-0" $version) (.Values.experimental.abortOnPluginFailure)}}
+  {{- fail "ERROR: abortOnPluginFailure is an experimental feature only available for traefik >= 3.3.0." }}
+{{- end }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -201,8 +201,10 @@ tests:
             - --providers.kubernetesingress.ingressendpoint.publishedservice=NAMESPACE/RELEASE-NAME-traefik
             - --entryPoints.websecure.http.tls=true
             - --log.level=INFO
-  - it: should have abortOnPluginFailure, when enabled
+  - it: should have abortOnPluginFailure, when enabled on traefik >=3.3.0
     set:
+      image:
+        tag: v3.3.0
       experimental:
         abortOnPluginFailure: true
     asserts:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -101,4 +101,10 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: certResolvers setting has been removed. See v33.0.0 Changelog."
-
+  - it: shouldn't have abortOnPluginFailure, when enabled on traefik < 3.3.0
+    set:
+      experimental:
+        abortOnPluginFailure: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: abortOnPluginFailure is an experimental feature only available for traefik >= 3.3.0."


### PR DESCRIPTION
### What does this PR do?

This PR fixes the use of abortOnPluginFailure which was available as an RC feature but not released on traefik (and we released the helm chart in the mean time).


### Motivation

Users may be lost by this.


### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

