### PR TITLE
feat(Traefik Proxy): add `tracing`parameters to helm chart values

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -383,6 +383,34 @@
           - "--tracing.addinternals"
           {{- end }}
 
+          {{- with .Values.tracing }}
+          {{- with .sampleRate }}
+          - "--tracing.sampleRate={{ . }}"
+          {{- end }}
+
+          {{- with .serviceName }}
+          - "--tracing.serviceName={{ . }}"
+          {{- end }}
+
+          {{- range $name, $value := .globalAttributes }}
+          - "--tracing.globalAttributes.{{ $name }}={{ $value }}"
+          {{- end }}
+
+          {{- range $index, $value := .capturedRequestHeaders }}
+          - "--tracing.capturedRequestHeaders[{{ $index }}]={{ $value }}"
+          {{- end }}
+
+          {{- range $index, $value := .capturedResponseHeaders }}
+          - "--tracing.capturedResponseHeaders[{{ $index }}]={{ $value }}"
+          {{- end }}
+
+          {{- if gt (len .safeQueryParams) 0 }}
+
+          - "--tracing.safeQueryParams={{- .safeQueryParams | join "," -}}"
+          {{- end }}
+
+          {{- end }}
+
           {{- with .Values.tracing.otlp }}
           {{- if .enabled }}
           - "--tracing.otlp=true"

--- a/traefik/tests/tracing-config_test.yaml
+++ b/traefik/tests/tracing-config_test.yaml
@@ -9,6 +9,18 @@ tests:
     set:
       tracing:
         addInternals: true
+        sampleRate: 0.5
+        serviceName: my-service-name
+        globalAttributes:
+          attr1: foo
+          attr2: bar
+        capturedRequestHeaders:
+          - X-CustomHeader
+        capturedResponseHeaders:
+          - X-CustomHeader
+        safeQueryParams:
+          - bar
+          - buz
         otlp:
           enabled: true
           http:
@@ -38,6 +50,27 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--tracing.addinternals"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.sampleRate=0.5"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.serviceName=my-service-name"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.globalAttributes.attr1=foo"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.globalAttributes.attr2=bar"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.capturedRequestHeaders[0]=X-CustomHeader"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.capturedResponseHeaders[0]=X-CustomHeader"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--tracing.safeQueryParams=bar,buz"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--tracing.otlp.http=true"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1568,6 +1568,22 @@
                 "addInternals": {
                     "type": "boolean"
                 },
+                "capturedRequestHeaders": {
+                    "type": [
+                        "array"
+                    ]
+                },
+                "capturedResponseHeaders": {
+                    "type": [
+                        "array"
+                    ]
+                },
+                "globalAttributes": {
+                    "properties": {},
+                    "type": [
+                        "object"
+                    ]
+                },
                 "otlp": {
                     "properties": {
                         "enabled": {
@@ -1638,6 +1654,25 @@
                         }
                     },
                     "type": "object"
+                },
+                "safeQueryParams": {
+                    "type": [
+                        "array"
+                    ]
+                },
+                "sampleRate": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "serviceName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -533,6 +533,18 @@ metrics:
 tracing:  # @schema additionalProperties: false
   # -- Enables tracing for internal resources. Default: false.
   addInternals: false
+  # -- Service name used in selected backend. Default: traefik.
+  serviceName: # @schema type:[string, null]
+  # -- Applies a list of shared key:value attributes on all spans.
+  globalAttributes: {} # @schema type:[object]
+  # -- Defines the list of request headers to add as attributes. It applies to client and server kind spans.
+  capturedRequestHeaders: [] # @schema type:[array]
+  # -- Defines the list of response headers to add as attributes. It applies to client and server kind spans.
+  capturedResponseHeaders: [] # @schema type:[array]
+  # -- By default, all query parameters are redacted. Defines the list of query parameters to not redact.
+  safeQueryParams: [] # @schema type:[array]
+  # -- The proportion of requests to trace, specified between 0.0 and 1.0. Default: 1.0.
+  sampleRate: # @schema type:[number, null]; minimum:0; maximum:1
   otlp:
     # -- See https://doc.traefik.io/traefik/v3.0/observability/tracing/opentelemetry/
     enabled: false


### PR DESCRIPTION
### What does this PR do?

This PR adds the option to specify all tracing parameters in the chart values
(sorry i unintentionally closed the first PR)

### Motivation

he tracing samplingRate was not exposed in the values, meaning that we have to specify it directly in CLI options if needed.
solves https://github.com/traefik/traefik-helm-chart/issues/1269

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

