### PR TITLE
feat(Traefik Proxy): add support for experimental FastProxy

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -63,6 +63,8 @@ Kubernetes: `>=1.22.0-0`
 | env | list | See _values.yaml_ | Additional Environment variables to be passed to Traefik's binary |
 | envFrom | list | `[]` | Environment variables to be passed to Traefik's binary from configMaps or secrets |
 | experimental.abortOnPluginFailure | bool | `false` | Defines whether all plugins must be loaded successfully for Traefik to start |
+| experimental.fastProxy.debug | bool | `false` | Enable debug mode for the FastProxy implementation. |
+| experimental.fastProxy.enabled | bool | `false` | Enables the FastProxy implementation. |
 | experimental.kubernetesGateway.enabled | bool | `false` | Enable traefik experimental GatewayClass CRD |
 | experimental.plugins | object | `{}` | Enable traefik experimental plugins |
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template)  In some cases, it can avoid the need for additional, extended or adhoc deployments. See #595 for more details and traefik/tests/values/extra.yaml for example. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -468,6 +468,14 @@
            {{- end }}
           {{- end }}
           {{- end }}
+          {{- with .Values.experimental.fastProxy }}
+            {{- if .enabled }}
+          - "--experimental.fastProxy"
+            {{- end }}
+            {{- if .debug }}
+          - "--experimental.fastProxy.debug"
+            {{- end }}
+          {{- end }}
           {{- range $pluginName, $plugin := .Values.experimental.plugins }}
           {{- if or (ne (typeOf $plugin) "map[string]interface {}") (not (hasKey $plugin "moduleName")) (not (hasKey $plugin "version")) }}
             {{- fail  (printf "ERROR: plugin %s is missing moduleName/version keys !" $pluginName) }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -32,6 +32,10 @@
   {{- end }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.2.0-0" $version) (.Values.experimental.fastProxy.enabled)}}
+  {{- fail "ERROR: fastProxy is an experimental feature only available for traefik >= v3.2.0." }}
+{{- end }}
+
 {{- if and (semverCompare "<v3.3.0-0" $version) (.Values.experimental.abortOnPluginFailure)}}
   {{- fail "ERROR: abortOnPluginFailure is an experimental feature only available for traefik >= v3.3.0." }}
 {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -319,10 +319,25 @@ tests:
       experimental:
         kubernetesGateway:
           enabled: true
+        fastProxy:
+          enabled: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--experimental.kubernetesgateway"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.fastProxy"
+  - it: should have debug experimental flag on fastProxy when set
+    set:
+      experimental:
+        fastProxy:
+          debug: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.fastProxy.debug"
+
   - it: shouldn't have experimental flag when >= 3.1.0
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -114,11 +114,23 @@ tests:
           errorMessage: "ERROR: certResolvers setting has been removed. See v33.0.0 Changelog."
   - it: shouldn't have abortOnPluginFailure, when enabled on traefik < 3.3.0
     set:
+      image:
+        tag: v3.2.0
       experimental:
         abortOnPluginFailure: true
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: abortOnPluginFailure is an experimental feature only available for traefik >= v3.3.0."
+  - it: shouldn't have fastProxy, when enabled on traefik < 3.2.0
+    set:
+      image:
+        tag: v3.1.0
+      experimental:
+        fastProxy:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: fastProxy is an experimental feature only available for traefik >= v3.2.0."
   - it: shouldn't have safeQueryParams, when enabled on traefik < 3.1.0
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -152,6 +152,17 @@
                 "abortOnPluginFailure": {
                     "type": "boolean"
                 },
+                "fastProxy": {
+                    "properties": {
+                        "debug": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
                 "kubernetesGateway": {
                     "properties": {
                         "enabled": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -122,14 +122,19 @@ core:  # @schema additionalProperties: false
 experimental:
   # -- Defines whether all plugins must be loaded successfully for Traefik to start
   abortOnPluginFailure: false
+  fastProxy:
+    # -- Enables the FastProxy implementation.
+    enabled: false
+    # -- Enable debug mode for the FastProxy implementation.
+    debug: false
+  kubernetesGateway:
+    # -- Enable traefik experimental GatewayClass CRD
+    enabled: false
   # -- Enable traefik experimental plugins
   plugins: {}
   # demo:
   #   moduleName: github.com/traefik/plugindemo
   #   version: v0.2.1
-  kubernetesGateway:
-    # -- Enable traefik experimental GatewayClass CRD
-    enabled: false
 
 gateway:
   # -- When providers.kubernetesGateway.enabled, deploy a default gateway


### PR DESCRIPTION
### What does this PR do?

Add support for [experimental FastProxy](https://doc.traefik.io/traefik/user-guides/fastproxy/).

### Motivation

It's available since Traefik v3.2. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

