### PR TITLE
fix: headerLabels does not exist for metrics.prometheus

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -102,7 +102,7 @@ kubectl port-forward $(kubectl get pods --selector "app.kubernetes.io/name=traef
 
 This command makes the dashboard accessible on the url: http://127.0.0.1:8080/dashboard/
 
-# Redirect permanently traffic from http to https
+# Redirect permanently traffic from http to https
 
 It's possible to redirect all incoming requests on an entrypoint to an other entrypoint.
 
@@ -855,6 +855,10 @@ metrics:
       jobLabel: traefik
       interval: 30s
       honorLabels: true
+    # Add HTTP header labels to metrics
+    headerLabels:
+      user_id: X-User-Id
+      tenant: X-Tenant
     prometheusRule:
       enabled: true
       rules:

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -216,6 +216,7 @@ Kubernetes: `>=1.22.0-0`
 | metrics.prometheus.buckets | string | `""` |  |
 | metrics.prometheus.disableAPICheck | string | `nil` | When set to true, it won't check if Prometheus Operator CRDs are deployed |
 | metrics.prometheus.entryPoint | string | `"metrics"` | Entry point used to expose metrics. |
+| metrics.prometheus.headerLabels | object | `{}` | Add HTTP header labels to metrics. Example: headerLabels: { label: headerKey } |
 | metrics.prometheus.manualRouting | bool | `false` |  |
 | metrics.prometheus.prometheusRule.additionalLabels | object | `{}` |  |
 | metrics.prometheus.prometheusRule.enabled | bool | `false` | Enable optional CR for Prometheus Operator. See EXAMPLES.md for more details. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -272,6 +272,11 @@
           {{- if .Values.metrics.prometheus.manualRouting }}
           - "--metrics.prometheus.manualrouting=true"
           {{- end }}
+          {{- if .Values.metrics.prometheus.headerLabels }}
+          {{- range $label, $headerKey := .Values.metrics.prometheus.headerLabels }}
+          - "--metrics.prometheus.headerlabels.{{ $label }}={{ $headerKey }}"
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- with .Values.metrics.statsd }}
           - "--metrics.statsd=true"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -968,6 +968,12 @@
                         "manualRouting": {
                             "type": "boolean"
                         },
+                        "headerLabels": {
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
                         "prometheusRule": {
                             "properties": {
                                 "additionalLabels": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -413,6 +413,10 @@ metrics:
     ## When manualRouting is true, it disables the default internal router in
     ## order to allow creating a custom router for prometheus@internal service.
     manualRouting: false
+    ## Add HTTP header labels to metrics
+    ## Example: headerLabels:
+    ##            label: headerKey
+    headerLabels: {}  # @schema type:[object, null]
     service:
       # -- Create a dedicated metrics service to use with ServiceMonitor
       enabled: false


### PR DESCRIPTION
### What does this PR do?

Fixes headerLabels that does not exist for metrics.prometheus

### Motivation

Issue #1292

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

