### PR TITLE
Fix: Allow using the traefik-crds chart as a subchart/dependency

### DIFF
--- a/traefik-crds/values.schema.json
+++ b/traefik-crds/values.schema.json
@@ -4,6 +4,16 @@
     "additionalProperties": false,
     "description": "The Cloud Native Application Proxy",
     "properties": {
+        "enabled": {
+            "default": true,
+            "description": "Field that can be used as a condition when this chart is a dependency. This definition is only here as a placeholder such that it is included in the JSON schema. See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for more info.",
+            "type": "boolean"
+        },
+        "global": {
+            "description": "Global values shared across all (sub)charts",
+            "type": "object",
+            "additionalProperties": true
+        },
         "deleteOnUninstall": {
             "type": "boolean"
         },


### PR DESCRIPTION
### What does this PR do?
Fixes #1311
Superseeds #1334
TL:DR Allows the usage of the traefik-crds chart as a subchart/dependency.

### Motivation
To use the traefik-crds Helm Chart as a dependency in your projects, the validation needs to be slightly looser to support the usage of the chart. Helm passes specific values by default (`global` in this case), causing the Schema Validation to give an error.

In line with other Helm Charts (like cert-manager), it would be beneficial to allow users to set:
- `global` to fix the error that will always be caused by Helm passing the `global` values
- `enabled` to provide users with the default (recommended) flag for conditions on Helm Charts

The one thing that I did, that is more opinionated and would like the opinion of Traefik's maintainer on is the usage of `additionalProperties` on the `global` object. Cert-manager specifically provides a set of variables, defeating part of the feature's purpose (in my opinion).
https://github.com/cert-manager/cert-manager/blob/23d3aea079ce88cec6f9394f4a4027720f8d7c2a/deploy/charts/cert-manager/values.schema.json#L686

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed