### PR TITLE
fix: reorder source urls

### DIFF
--- a/traefik-crds/Chart.yaml
+++ b/traefik-crds/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - networking
 home: https://traefik.io/
 sources:
-  - https://github.com/traefik/traefik
   - https://github.com/traefik/traefik-helm-chart
+  - https://github.com/traefik/traefik
 maintainers:
   - name: mloiseleur
     email: michel.loiseleur@traefik.io

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -12,8 +12,8 @@ keywords:
   - networking
 home: https://traefik.io/
 sources:
-  - https://github.com/traefik/traefik
   - https://github.com/traefik/traefik-helm-chart
+  - https://github.com/traefik/traefik
 maintainers:
   - name: mloiseleur
     email: michel.loiseleur@traefik.io


### PR DESCRIPTION
### What does this PR do?

Set the chart repo url as first source url.
<!-- A brief description of the change being made with this pull request. -->


### Motivation
Helm sets the first source url as `org.opencontainers.image.source` annotation when publishing as oci chart.
This is currently the main traefik repo. So tools like renovate don't find the source repo.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

