### PR TITLE
Fixed #1359: gateway.namespace value is respected now

### DIFF
--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: {{ default "traefik-gateway" .Values.gateway.name }}
-  namespace: {{ default ( template "traefik.namespace" . ) .Values.gateway.namespace }}
+  namespace: {{ default ( include "traefik.namespace" . ) .Values.gateway.namespace }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
   {{- with .Values.gateway.annotations }}

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -7,7 +7,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: {{ default "traefik-gateway" .Values.gateway.name }}
-  namespace: {{ template "traefik.namespace" . }}
+  namespace: {{ default ( template "traefik.namespace" . ) .Values.gateway.namespace }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
   {{- with .Values.gateway.annotations }}

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -98,6 +98,17 @@ tests:
       - equal:
           path: metadata.namespace
           value: "traefik-ns-override"
+  - it: should install Gateway in defined gateway namespace
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+      gateway:
+        namespace: "gateway-ns-override"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "gateway-ns-override"
   - it: should have one Gateway with the correct annotations
     set:
       providers:


### PR DESCRIPTION
### What does this PR do?

This PR includes the gateway.namespace value in the gateway template as described in VALUES.md. It fixes #1359.


### Motivation

Issue #1359 


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
  - Note:  already included in schema
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

