### PR TITLE
Do not quote protocol on pod ports

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -116,7 +116,7 @@
           {{- if $config.hostIP }}
           hostIP: {{ $config.hostIP }}
           {{- end }}
-          protocol: {{ default "TCP" $config.protocol | quote }}
+          protocol: {{ default "TCP" $config.protocol }}
           {{- if ($config.http3).enabled }}
         - name: "{{ $name }}-http3"
           containerPort: {{ $config.port }}

--- a/traefik/tests/deployment-hub-config_test.yaml
+++ b/traefik/tests/deployment-hub-config_test.yaml
@@ -43,13 +43,13 @@ tests:
           content:
             name: "admission"
             containerPort: 9943
-            protocol: "TCP"
+            protocol: TCP
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
             name: "apiportal"
             containerPort: 9903
-            protocol: "TCP"
+            protocol: TCP
   - it: should fail when trying to set admission parameters without apimanagement
     set:
       hub:

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -284,14 +284,14 @@ tests:
           content:
             name: "metrics"
             containerPort: 9100
-            protocol: "TCP"
+            protocol: TCP
         template: deployment.yaml
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
             name: "traefik"
             containerPort: 9100
-            protocol: "TCP"
+            protocol: TCP
         template: deployment.yaml
       - containsDocument:
           kind: Service
@@ -327,14 +327,14 @@ tests:
           content:
             name: "metrics"
             containerPort: 9100
-            protocol: "TCP"
+            protocol: TCP
         template: deployment.yaml
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
             name: "traefik"
             containerPort: 9100
-            protocol: "TCP"
+            protocol: TCP
         template: deployment.yaml
       - containsDocument:
           kind: Service


### PR DESCRIPTION
### What does this PR do?

No longer quote the protocol value on pod ports.


### Motivation

I found that quoting of ports only happens on pods, not on services, and moreover the http3 port has an unquoted UDP as default value. When trying to mimic the http3 port configuration with some manual values to allow for smoother upgrade of my Traefik deployment, I figured I couldn't achieve the exact same result as by enabling the http3 flag due to this fact.

Note this is not breaking or blocking in any way, but mostly a slightly cleaner and more consistent output.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

