### PR TITLE
Add port name template functions

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -736,7 +736,7 @@ spec:
     app.kubernetes.io/instance: traefik-traefik
   ports:
   - port: 8080
-    name: "traefik"
+    name: traefik
     targetPort: traefik
     protocol: TCP
 ```

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -93,6 +93,32 @@ are multiple namespaced releases with the same release name.
 {{- end -}}
 
 {{/*
+Change input to a valid name for a port.
+This is a best effort to convert input to a valid port name,
+which only allows lowercase alphanumeric characters and '-',
+and imposes limits on the lenght of the name.
+See also https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#containerport-v1-core.
+*/}}
+{{- define "traefik.portname" -}}
+{{- $portName := . -}}
+{{- $portName = $portName | lower -}}
+{{- $portName = $portName | trunc 15 | trimSuffix "-" -}}
+{{- print $portName -}}
+{{- end -}}
+
+{{/*
+Change input to a valid port reference.
+See also the traefik.portname helper.
+*/}}
+{{- define "traefik.portreference" -}}
+{{- if kindIs "string" . -}}
+    {{- print (include "traefik.portname" .) -}}
+{{- else -}}
+    {{- print . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Construct the path for the providers.kubernetesingress.ingressendpoint.publishedservice.
 By convention this will simply use the <namespace>/<service-name> to match the name of the
 service generated.

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -108,7 +108,7 @@
               {{- fail "ERROR: All hostPort must match their respective containerPort when `hostNetwork` is enabled" }}
             {{- end }}
           {{- end }}
-        - name: {{ $name | lower | quote }}
+        - name: {{ include "traefik.portname" $name }}
           containerPort: {{ default $config.port $config.containerPort }}
           {{- if $config.hostPort }}
           hostPort: {{ $config.hostPort }}
@@ -118,7 +118,7 @@
           {{- end }}
           protocol: {{ default "TCP" $config.protocol | quote }}
           {{- if ($config.http3).enabled }}
-        - name: "{{ $name }}-http3"
+        - name: {{ printf "%s-http3" $name | include "traefik.portname" }}
           containerPort: {{ $config.port }}
            {{- if $config.hostPort }}
           hostPort: {{ default $config.hostPort $config.http3.advertisedPort }}

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -58,8 +58,8 @@
     {{- fail (print "ERROR: Cannot create " (trim $name) " port on Service without .port or .exposedPort") }}
   {{- end }}
   - port: {{ $port }}
-    name: {{ $name | quote }}
-    targetPort: {{ default $name $config.targetPort }}
+    name: {{ include "traefik.portname" $name }}
+    targetPort: {{ default $name $config.targetPort | include "traefik.portreference" }}
     protocol: {{ default "TCP" $config.protocol }}
     {{- if $config.nodePort }}
     nodePort: {{ $config.nodePort }}
@@ -70,8 +70,8 @@
   {{- if and ($config.http3).enabled ($config.single) }}
   {{- $http3Port := default $config.exposedPort $config.http3.advertisedPort }}
   - port: {{ $http3Port }}
-    name: "{{ $name }}-http3"
-    targetPort: "{{ $name }}-http3"
+    name: {{ printf "%s-http3" $name | include "traefik.portname" }}
+    targetPort: {{ default $name $config.targetPort | include "traefik.portreference" }}
     protocol: UDP
     {{- if $config.nodePort }}
     nodePort: {{ $config.nodePort }}

--- a/traefik/templates/service-metrics.yaml
+++ b/traefik/templates/service-metrics.yaml
@@ -22,7 +22,7 @@ spec:
     {{- include "traefik.labelselector" . | nindent 4 }}
   ports:
   - port: {{ .Values.ports.metrics.port }}
-    name: "metrics"
+    name: metrics
     targetPort: metrics
     protocol: TCP
     {{- if .Values.ports.metrics.nodePort }}

--- a/traefik/tests/deployment-hub-config_test.yaml
+++ b/traefik/tests/deployment-hub-config_test.yaml
@@ -41,13 +41,13 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: "admission"
+            name: admission
             containerPort: 9943
             protocol: "TCP"
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: "apiportal"
+            name: apiportal
             containerPort: 9903
             protocol: "TCP"
   - it: should fail when trying to set admission parameters without apimanagement

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -282,14 +282,14 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: "metrics"
+            name: metrics
             containerPort: 9100
             protocol: "TCP"
         template: deployment.yaml
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: "traefik"
+            name: traefik
             containerPort: 9100
             protocol: "TCP"
         template: deployment.yaml
@@ -325,14 +325,14 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: "metrics"
+            name: metrics
             containerPort: 9100
             protocol: "TCP"
         template: deployment.yaml
       - notContains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: "traefik"
+            name: traefik
             containerPort: 9100
             protocol: "TCP"
         template: deployment.yaml

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -242,7 +242,7 @@ tests:
         path: spec.ports
         content:
           port: 443
-          name: "websecure-http3"
+          name: websecure-http3
           targetPort: websecure-http3
           protocol: UDP
   - it: should be possible to advertise a different http3 UDP port
@@ -260,7 +260,7 @@ tests:
         path: spec.ports
         content:
           port: 4443
-          name: "websecure-http3"
+          name: websecure-http3
           targetPort: websecure-http3
           protocol: UDP
   - it: should split TCP and UDP Service on http3 when single is false
@@ -278,7 +278,7 @@ tests:
         path: spec.ports
         content:
           port: 443
-          name: "websecure"
+          name: websecure
           targetPort: websecure
           protocol: TCP
       documentIndex: 0
@@ -286,7 +286,7 @@ tests:
         path: spec.ports
         content:
           port: 443
-          name: "websecure-http3"
+          name: websecure-http3
           targetPort: websecure-http3
           protocol: UDP
       documentIndex: 1
@@ -306,7 +306,7 @@ tests:
         path: spec.ports
         content:
           port: 443
-          name: "websecure"
+          name: websecure
           targetPort: websecure
           protocol: TCP
       documentIndex: 0
@@ -314,7 +314,7 @@ tests:
         path: spec.ports
         content:
           port: 4443
-          name: "websecure-http3"
+          name: websecure-http3
           targetPort: websecure-http3
           protocol: UDP
       documentIndex: 1

--- a/traefik/tests/service-metrics-config_test.yaml
+++ b/traefik/tests/service-metrics-config_test.yaml
@@ -50,6 +50,6 @@ tests:
           path: spec.ports
           content:
             port: 9100
-            name: "metrics"
+            name: metrics
             targetPort: metrics
             protocol: TCP


### PR DESCRIPTION
### What does this PR do?

Create a dedicated template function for parsing port names and references to port names.

It also removes various quotes from port names that no longer appear in template output,
although this should not change behavior as these quotes should be unused already.

Thus in practice, this should change nothing at all in chart functionality.

### Motivation

As a follow-up to #1286, this creates a dedicated helper, that allows for
- reusing more easily
- adding documentation about what we're doing and why
- easier extensibility or validation in the future 
- preventing future errors (e.g. `websecure-http3` exactly matches the allowed length of 15 characters, so we got lucky 😉)

I've not bothered with adding e.g. regex checks to the portnames, given that probably it won't serve any real-world usecase and probably Kubernetes itself will also complain already about invalid ones.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

