### PR TITLE
feat: ability to disable Prometheus scraping while keeping the metrics endpoint enabled

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -237,6 +237,7 @@ Kubernetes: `>=1.22.0-0`
 | metrics.prometheus.serviceMonitor.namespaceSelector | object | `{}` |  |
 | metrics.prometheus.serviceMonitor.relabelings | list | `[]` |  |
 | metrics.prometheus.serviceMonitor.scrapeTimeout | string | `""` |  |
+| metrics.prometheus.scrape | bool | `true` | Set prometheus.io/scrape annotation value. Default: true  |
 | namespaceOverride | string | `""` | This field override the default Release Namespace for Helm. It will not affect optional CRDs such as `ServiceMonitor` and `PrometheusRules` |
 | nodeSelector | object | `{}` | nodeSelector is the simplest recommended form of node selection constraint. |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -7,7 +7,7 @@
       {{- end }}
       {{- if .Values.metrics }}
       {{- if and (.Values.metrics.prometheus) (not (.Values.metrics.prometheus.serviceMonitor).enabled) }}
-        prometheus.io/scrape: "true"
+        prometheus.io/scrape: {{ .Values.metrics.prometheus.scrape | quote}}
         prometheus.io/path: "/metrics"
         prometheus.io/port: {{ quote (index .Values.ports .Values.metrics.prometheus.entryPoint).port }}
       {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -433,6 +433,22 @@ tests:
             prometheus.io/path: /metrics
             prometheus.io/port: "9100"
             prometheus.io/scrape: "true"
+  - it: should disable prometheus scrape if requested
+    set:
+      ports:
+        metrics:
+          port: 9100
+      metrics:
+        prometheus:
+          entryPoint: metrics
+          scrape: false
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9100"
+            prometheus.io/scrape: "false"
   - it: should have prometheus addRoutersLabels enabled
     set:
       metrics:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -990,6 +990,9 @@
                             },
                             "type": "object"
                         },
+                        "scrape": {
+                            "type": "boolean"
+                        },
                         "service": {
                             "properties": {
                                 "annotations": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -415,6 +415,8 @@ metrics:
     manualRouting: false
     # -- Add HTTP header labels to metrics. See EXAMPLES.md or upstream doc for usage.
     headerLabels: {}  # @schema type:[object, null]
+    # -- Set prometheus.io/scrape annotation value. Default: true
+    scrape: true
     service:
       # -- Create a dedicated metrics service to use with ServiceMonitor
       enabled: false


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Adds a `metrics.prometheus.scrape` value to be able to configure the value of the `prometheus.io/scrape` annotation, set it as true by default to keep existing behavior

### Motivation

<!-- What inspired you to submit this pull request? -->
Sometimes it may be useful to be able to enable the metrics endpoint without actually enabling metrics collection.
However, currently, the chart enables both the endpoint and the metrics collection by default, and the only option offered is to disable both at once by setting `metrics.prometheus` to `null`.

In my specific use case, Traefik is deployed on an infrastructure where a monitoring tool is configured to automatically collect all metrics from pods with the `prometheus.io/scrape` annotation set to `true` (which is pretty standard so far). But I need to be able to set the annotation value to `false` to disable this generic collection and use another specific collector that will route the metrics differently.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

