### PR TITLE
feat: remove APIAccess resource

### DIFF
--- a/traefik-crds/kustomization.yaml
+++ b/traefik-crds/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   # curl -o crds-files/gatewayAPI/gateway-standard-install.yaml -L https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
   - crds-files/gatewayAPI/gateway-standard-install.yaml
   - crds-files/hub/hub.traefik.io_accesscontrolpolicies.yaml
-  - crds-files/hub/hub.traefik.io_apiaccesses.yaml
   - crds-files/hub/hub.traefik.io_apicatalogitems.yaml
   - crds-files/hub/hub.traefik.io_managedsubscriptions.yaml
   - crds-files/hub/hub.traefik.io_apiportals.yaml

--- a/traefik-crds/tests/crds_test.yaml
+++ b/traefik-crds/tests/crds_test.yaml
@@ -26,7 +26,7 @@ tests:
       hub: true
     asserts:
       - hasDocuments:
-          count: 11
+          count: 10
       - isKind:
           of: CustomResourceDefinition
       - equal:
@@ -34,7 +34,7 @@ tests:
           value: hub.traefik.io
       - matchRegex:
           path: spec.names.kind
-          pattern: ^(AccessControlPolicy|AIService|APIAccess|APIBundle|APICatalogItem|APIPlan|APIPortal|APIRateLimit|API|APIVersion|ManagedSubscription)$
+          pattern: ^(AccessControlPolicy|AIService|APIBundle|APICatalogItem|APIPlan|APIPortal|APIRateLimit|API|APIVersion|ManagedSubscription)$
       - equal:
           path: metadata.annotations["helm.sh/resource-policy"]
           value: keep

--- a/traefik/crds/kustomization.yaml
+++ b/traefik/crds/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   # curl -o gateway-standard-install.yaml -L https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
   - gateway-standard-install.yaml
   - hub.traefik.io_accesscontrolpolicies.yaml
-  - hub.traefik.io_apiaccesses.yaml
   - hub.traefik.io_apicatalogitems.yaml
   - hub.traefik.io_managedsubscriptions.yaml
   - hub.traefik.io_apiportals.yaml

--- a/traefik/templates/hub-admission-controller.yaml
+++ b/traefik/templates/hub-admission-controller.yaml
@@ -94,27 +94,6 @@ webhooks:
           - v1alpha1
         resources:
           - apis
-  - name: hub-agent.traefik.access
-    clientConfig:
-      service:
-        name: admission
-        namespace: {{ template "traefik.namespace" . }}
-        path: /api-access
-      caBundle: {{ $cert.Cert }}
-    sideEffects: None
-    admissionReviewVersions:
-      - v1
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-          - DELETE
-        apiGroups:
-          - hub.traefik.io
-        apiVersions:
-          - v1alpha1
-        resources:
-          - apiaccesses
   - name: hub-agent.traefik.catalog-item
     clientConfig:
       service:

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -235,7 +235,6 @@ rules:
       - hub.traefik.io
     resources:
       - accesscontrolpolicies
-      - apiaccesses
       - apiportals
       - apiratelimits
       - apis

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -956,7 +956,6 @@ tests:
               - hub.traefik.io
             resources:
               - accesscontrolpolicies
-              - apiaccesses
               - apiportals
               - apiratelimits
               - apis


### PR DESCRIPTION
### What does this PR do?

This PR removes the APIAccess CRD and its related webhook admission controller and RBAC.
It also bumps `traefik/hub-crds` into v1.18.0

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

