### PR TITLE
feat: add serviceName for otlp metrics

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -211,6 +211,7 @@ Kubernetes: `>=1.22.0-0`
 | metrics.otlp.http.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
 | metrics.otlp.http.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
 | metrics.otlp.pushInterval | string | `""` | Interval at which metrics are sent to the OpenTelemetry Collector. Default: 10s |
+| metrics.otlp.serviceName | string | `nil` | Service name used in OTLP backend. Default: traefik. |
 | metrics.prometheus.addEntryPointsLabels | string | `nil` | Enable metrics on entry points. Default: true |
 | metrics.prometheus.addRoutersLabels | string | `nil` | Enable metrics on routers. Default: false |
 | metrics.prometheus.addServicesLabels | string | `nil` | Enable metrics on services. Default: true |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -328,6 +328,9 @@
            {{- with .pushInterval }}
           - "--metrics.otlp.pushInterval={{ . }}"
            {{- end }}
+           {{- with .serviceName }}
+          - "--metrics.otlp.serviceName={{ . }}"
+           {{- end }}
            {{- with .http }}
             {{- if .enabled }}
           - "--metrics.otlp.http=true"

--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -303,6 +303,7 @@ tests:
             - "1.2"
             - "5.0"
           pushInterval: 10s
+          serviceName: traefikTest
           http:
             enabled: true
             endpoint: "http://localhost:4318/v1/metrics"
@@ -345,6 +346,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.pushInterval=10s"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--metrics.otlp.serviceName=traefikTest"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.http=true"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -932,6 +932,12 @@
                         },
                         "pushInterval": {
                             "type": "string"
+                        },
+                        "serviceName": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
                         }
                     },
                     "type": "object"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -504,6 +504,8 @@ metrics:
     explicitBoundaries: []
     # -- Interval at which metrics are sent to the OpenTelemetry Collector. Default: 10s
     pushInterval: ""
+    # -- Service name used in OTLP backend. Default: traefik.
+    serviceName:  # @schema type:[string, null]
     http:
       # -- Set to true in order to send metrics to the OpenTelemetry Collector using HTTP.
       enabled: false


### PR DESCRIPTION
### What does this PR do?

Adds support to specify serviceName for OpenTelemetry metrics. This support was [introduced](https://github.com/traefik/traefik/pull/10917) with Traefik v3.2.

### Motivation

Found the lack of ability to set serviceName for OpenTelemetry metrics directly with the Traefik Helm Chart.

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

