### PR TITLE
Cleanup README to remove outdated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,11 @@ microservices with ease.
 
 ## Introduction
 
-Starting with v28.x, this chart now bootstraps Traefik Proxy version 3 as a Kubernetes ingress controller,
-using Custom Resources `IngressRoute`: <https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/>.
-
-It's possible to use this chart with Traefik Proxy v2 using v27.x
-This chart support policy is aligned
-with [upstream support policy](https://doc.traefik.io/traefik/deprecation/releases/) of Traefik Proxy.
-
-See [Migration guide from v2 to v3](https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/) and upgrading section of
-this chart on CRDs.
-
-Starting with v34.x, to work
-around [Helm caveats](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations),
-it's possible to use an additional Chart dedicated to CRDs: **traefik-crds**.
-
 ### Philosophy
 
-The Traefik HelmChart is focused on Traefik deployment configuration.
+The Traefik Helm chart is focused on Traefik deployment configuration.
 
-To keep this HelmChart as generic as possible we tend
+To keep this Helm chart as generic as possible we tend
 to avoid integrating any third party solutions nor any specific use cases.
 
 Accordingly, the encouraged approach to fulfill your needs:
@@ -34,37 +20,37 @@ Accordingly, the encouraged approach to fulfill your needs:
 
 [Examples](https://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md) of common usage are provided.
 
-If needed, one may use [extraObjects](./traefik/tests/values/extra.yaml) or extend this
-Helm Chart [as a Subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/).
+If needed, one may use [`extraObjects`](./traefik/tests/values/extra.yaml) or extend this
+Helm chart [as a subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/).
+
+### Major changes
+
+Starting with v28.x, this chart now bootstraps Traefik Proxy version 3 as a Kubernetes ingress controller,
+using Custom Resources `IngressRoute`: <https://doc.traefik.io/traefik/v3.0/routing/providers/kubernetes-crd/>.
+For upgrading from chart versions prior to v28.x (using Traefik Proxy version 2), see
+- [Migration guide from v2 to v3](https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/)
+- upgrade notes in the [`README` on the v27 branch](https://github.com/traefik/traefik-helm-chart/tree/v27).
+
+Starting with v34.x, to work
+around [Helm caveats](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations),
+it's possible to use an additional Chart dedicated to CRDs: **traefik-crds**.
+See also the [deploy instructions below](#an-installation-with-additional-crds-chart).
+
+### Support for Traefik Proxy v2
+
+It's possible to use this chart with Traefik Proxy v2 using chart version v27.x.
+This chart support policy is aligned
+with [upstream support policy](https://doc.traefik.io/traefik/deprecation/releases/) of Traefik Proxy.
+You can check the [`README` on the v27 branch](https://github.com/traefik/traefik-helm-chart/tree/v27)
+for compatibility, installation instructions and older upgrade notes.
 
 ## Installing
 
 ### Prerequisites
 
-1. [x] Helm **v3 > 3.9.0** [installed](https://helm.sh/docs/using_helm/#installing-helm): `helm version`
-2. [x] Traefik's chart repository: `helm repo add traefik https://traefik.github.io/charts`
-
-### Kubernetes Version Support
-
-Due to changes in CRD version support, the following versions of the chart are usable and supported on the following
-Kubernetes versions:
-
-|                         | Kubernetes v1.15 and below | Kubernetes v1.16-v1.21 | Kubernetes v1.22 and above |
-|-------------------------|----------------------------|------------------------|----------------------------|
-| Chart v9.20.2 and below | [x]                        | [x]                    |                            |
-| Chart v10.0.0 and above |                            | [x]                    | [x]                        |
-| Chart v22.0.0 and above |                            |                        | [x]                        |
-
-### CRDs Support of Traefik Proxy
-
-Due to changes in API Group of Traefik CRDs from `containo.us` to `traefik.io`, this Chart install CRDs needed by
-default Traefik Proxy version, following this table:
-
-|                         | `containo.us` | `traefik.io` |
-|-------------------------|---------------|--------------|
-| Chart v22.0.0 and below | [x]           |              |
-| Chart v23.0.0 and above | [x]           | [x]          |
-| Chart v28.0.0 and above |               | [x]          |
+1. Kubernetes (server) version **v1.22.0 or higher**: `kubectl version`
+1. Helm **v3.9.0 or higher** [installed](https://helm.sh/docs/using_helm/#installing-helm): `helm version`
+1. Traefik's chart repository: `helm repo add traefik https://traefik.github.io/charts`
 
 ### Deploying
 
@@ -147,58 +133,6 @@ helm upgrade traefik-crds traefik/traefik
 # Upgrade Traefik
 helm upgrade traefik traefik/traefik
 ```
-
-### Upgrade up to 27.X
-
-When upgrading on Traefik Proxy v2 version, one need to stay at Traefik Helm Chart v27.x. The command to upgrade to the
-latest Traefik Proxy v2 CRD is:
-
-```bash
-kubectl apply --server-side --force-conflicts -k https://github.com/traefik/traefik-helm-chart/traefik/crds/?ref=v27
-```
-
-### Upgrading after 18.X+
-
-It's detailed in [release notes](https://github.com/traefik/traefik-helm-chart/releases).
-
-### Upgrading from 17.x to 18.x
-
-Since v18.x, this chart by default merges TCP and UDP ports into a single (LoadBalancer) `Service`.
-Load balancers with mixed protocols are available since v1.20 and in
-[beta as of Kubernetes v1.24](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types).
-Availability may depend on your Kubernetes provider.
-
-To retain the old default behavior, set `service.single` to `false` in your values.
-
-When using TCP and UDP with a single service, you may encounter
-[this issue](https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741)
-from Kubernetes.
-
-On HTTP/3, if you want to avoid this issue, you can set
-`ports.websecure.http3.advertisedPort` to an other value than `443`
-
-If you were previously using HTTP/3, you should update your values as follows:
-
-- Replace the old value (`true`) of `ports.websecure.http3` with a key `enabled: true`
-- Remove `experimental.http3.enabled=true` entry
-
-### Upgrading from 16.x to 17.x
-
-Since v17.x, this chart provides unified labels following
-[Kubernetes recommendation](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
-
-This version needs to change an immutable field, which is not supported by
-Kubernetes and Helm, see [this issue](https://github.com/helm/helm/issues/7350)
-for more details.
-So you will have to delete your `Service`,  `Deployment` or `DaemonSet` in
-order to be able to upgrade.
-
-You may also upgrade by deploying another Traefik to a different namespace and
-removing after your first Traefik.
-
-Alternatively, since version 20.3.0 of this chart, you may set `instanceLabelOverride` to the previous value of that
-label.
-This will override the new `Release.Name-Release.Namespace` pattern to avoid any (longer) downtime.
 
 ## Contributing
 

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -926,9 +926,6 @@
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
-      {{- if (semverCompare "<v1.19.0-0" .Capabilities.KubeVersion.Version) }}
-        {{- fail "ERROR: topologySpreadConstraints are supported only on kubernetes >= v1.19" -}}
-      {{- end }}
       topologySpreadConstraints:
         {{- tpl (toYaml .Values.topologySpreadConstraints) . | nindent 8 }}
       {{- end }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -141,10 +141,7 @@ tests:
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0]
           value: whatever
-  - it: should set a topologySpreadConstraints on kubernetes >= 1.19
-    capabilities:
-      majorVersion: 1
-      minorVersion: 19
+  - it: should set a topologySpreadConstraints
     set:
       topologySpreadConstraints:
       - labelSelector:
@@ -159,10 +156,7 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.app
           value: whatever
-  - it: should set a templated topologySpreadConstraints on kubernetes >= 1.19
-    capabilities:
-      majorVersion: 1
-      minorVersion: 19
+  - it: should set a templated topologySpreadConstraints
     set:
       topologySpreadConstraints:
       - labelSelector:
@@ -177,17 +171,6 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels.app
           value: traefik
-  - it: should set fail to set topologySpreadConstraints on kubernetes 1.18
-    capabilities:
-      majorVersion: 1
-      minorVersion: 18
-    set:
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-    asserts:
-      - failedTemplate:
-          errorMessage: "ERROR: topologySpreadConstraints are supported only on kubernetes >= v1.19"
   - it: should set instance label to release.name-release.namespace if no override is set
     asserts:
       - isSubset:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Per discussion on https://github.com/traefik/traefik-helm-chart/pull/1035#discussion_r1570255164, I think we should prefer to have a clean and relevant `README` to encourage users to properly read all of its contents. Given that [v2 has now moved to security support only](https://doc.traefik.io/traefik/deprecation/releases/), with v3 being released over a year ago, I think it is appropriate to replace the old content with a few clear pointers to the old documentation for those who still need it.

I've also slightly restructured the order of content in the `README` which of course is a bit opinionated, so I would like to hear your feedback on that.

While working on this, I also spotted an outdated server capability version check for v1.19, while we already require a higher version in our prerequisites, which I've removed.

### Motivation

<!-- What inspired you to submit this pull request? -->
Having a clean `README`.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

