### PR TITLE
Update DigitalOcean PROXY protocol documentation

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -453,7 +453,11 @@ PROXY protocol is a protocol for sending client connection information, such as 
 ```yaml
 .DOTrustedIPs: &DOTrustedIPs
   - 127.0.0.1/32
-  - 10.120.0.0/16
+  # IP range Load Balancer is on
+  - 10.0.0.0/8
+  # IP range of private (VPC) interface - CHANGE THIS TO YOUR NETWORK SETTINGS
+  # This is needed when "externalTrafficPolicy: Cluster" is specified, as inbound traffic from the load balancer to a Traefik instance could be redirected from another cluster node on the way through.
+  - 172.16.0.0/12
 
 service:
   enabled: true


### PR DESCRIPTION
When externalTrafficPolicy is set to Cluster, inbound requests from the load balancer could go to any node in the cluster. If they arrive at a node not running Traefik, they are port forwarded on to a node that is. That port forwarding has the effect of changing the source IP address of the inbound packets. In this circumstance, the PROXY protocol headers are rejected unless the cluster nodes are in the DOTrustedIPs.

### What does this PR do?

Simple documentation update. No code change.


### Motivation

In a three node cluster with one Traefik instance, I was seeing some traffic work with PROXY protocol, but the majority of the traffic had PROXY protocol headers rejected, with the rejected address being the internal (VPC) address of one of the cluster nodes. After opening a support ticket with DigitalOcean, they diagnosed that externalTrafficPolicy=Cluster (recommended by this example for DO) was causing nodes not running Traefik to port forward to other nodes, meaning the source IP address was that of the forwarding node, not the original load balancer. It remains that of the load balancer if the traffic happens to go directly to a node that is indeed running Traefik.

Interestingly, DO initially recommended changing externalTrafficPolicy to Local, which I didn't do due to the direction a few lines below in this example. Local would have caused the traffic to only go to nodes running Traefik, removing the issue. I'm not sure if that advice is still valid or not - I'm going to assume it is still valid.

Another fix - the IP range for the Load Balancer was too narrow - the load balancers aren't always generated on 10.120.0.0/16, and I've had cases where they aren't. It's not documented exactly what that range is, so lets just grow that range to 10.0.0.0/8.