### PR TITLE
Allow mounting volume as RW

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -157,7 +157,7 @@
           {{- range .Values.volumes }}
           - name: {{ tpl (.name) $root | replace "." "-" }}
             mountPath: {{ .mountPath }}
-            readOnly: true
+            readOnly: {{ .readOnly | default(true) }}
           {{- end }}
           {{- if and (gt (len .Values.experimental.plugins) 0) (ne (include "traefik.hasPluginsVolume" .Values.deployment.additionalVolumes) "true") }}
           - name: plugins

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -157,7 +157,7 @@
           {{- range .Values.volumes }}
           - name: {{ tpl (.name) $root | replace "." "-" }}
             mountPath: {{ .mountPath }}
-            readOnly: {{ .readOnly | default(true) }}
+            readOnly: {{ .readOnly | default true }}
           {{- end }}
           {{- if and (gt (len .Values.experimental.plugins) 0) (ne (include "traefik.hasPluginsVolume" .Values.deployment.additionalVolumes) "true") }}
           - name: plugins


### PR DESCRIPTION
### What does this PR do?

Allow setting readonly property of a volume to false (currently it is hard coded to true)


### Motivation

Allow mounting a volume as RW. My primary use case would be to allow mounting the datadog APM unix socket directly into traefik without the need to add an additional socat docker image (as traefik does support pushing datadog APM traces to unix socket nowadays https://doc.traefik.io/traefik/v2.10/observability/tracing/datadog/#localagentsocket)

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ * ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

