### PR TITLE
fix(Traefik Hub): custom certificate name for WebHook

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -84,7 +84,7 @@ Kubernetes: `>=1.22.0-0`
 | globalArguments | list | `["--global.checknewversion","--global.sendanonymoususage"]` | Global command arguments to be passed to all traefik's pods |
 | hostNetwork | bool | `false` | If hostNetwork is true, runs traefik in the host network namespace To prevent unschedulable pods due to port collisions, if hostNetwork=true and replicas>1, a pod anti-affinity is recommended and will be set if the affinity is left as default. |
 | hub.apimanagement.admission.listenAddr | string | `""` | WebHook admission server listen address. Default: "0.0.0.0:9943". |
-| hub.apimanagement.admission.secretName | string | `""` | Certificate of the WebHook admission server. Default: "hub-agent-cert". |
+| hub.apimanagement.admission.secretName | string | `"hub-agent-cert"` | Certificate name of the WebHook admission server. Default: "hub-agent-cert". |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
 | hub.experimental.aigateway | bool | `false` | Set to true in order to enable AI Gateway. Requires a valid license token. |

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -213,7 +213,7 @@ The version can comes many sources: appVersion, image.tag, override, marketplace
 
 {{/* Generate/load self-signed certificate for admission webhooks */}}
 {{- define "traefik-hub.webhook_cert" -}}
-{{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) "hub-agent-cert" -}}
+{{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
 {{- if $cert -}}
 {{/* reusing value of existing cert */}}
 Cert: {{ index $cert.data "tls.crt" }}

--- a/traefik/templates/hub-admission-controller.yaml
+++ b/traefik/templates/hub-admission-controller.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: hub-agent-cert
+  name: {{ .Values.hub.apimanagement.admission.secretName }}
   namespace: {{ template "traefik.namespace" . }}
   labels:
   {{- include "traefik.labels" . | nindent 4 }}

--- a/traefik/tests/hub-admission-controler_test.yaml
+++ b/traefik/tests/hub-admission-controler_test.yaml
@@ -34,6 +34,17 @@ tests:
       - equal:
           path: metadata.name
           value: hub-agent-cert
+  - it: should be possible to specify custom webhook certificate secret name
+    set:
+      hub:
+        apimanagement:
+          admission:
+            secretName: test
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: "metadata.name"
+          value: test
   - it: should render hub-acp webhook
     documentIndex: 1
     asserts:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -949,8 +949,8 @@ hub:
     admission:
       # -- WebHook admission server listen address. Default: "0.0.0.0:9943".
       listenAddr: ""
-      # -- Certificate of the WebHook admission server. Default: "hub-agent-cert".
-      secretName: ""
+      # -- Certificate name of the WebHook admission server. Default: "hub-agent-cert".
+      secretName: "hub-agent-cert"
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false


### PR DESCRIPTION
### What does this PR do?

Allows user to set a custom certificate secret name.

### Motivation

It was not working as expected.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

