### PR TITLE
fix(podtemplate): calculate GOMEMLIMIT at 80% of memory limit to reduce OOM

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 35.3.0
+version: 35.4.0
 # renovate: image=traefik
 appVersion: v3.4.0
 kubeVersion: ">=1.22.0-0"

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -272,3 +272,42 @@ Key: {{ $cert.Key | b64enc }}
     {{- end }}
     {{- toYaml $diff }}
 {{- end }}
+
+{{/*
+  This helper converts the input value of memory to Bytes.
+  Input needs to be a valid value as supported by k8s memory resource field.
+ */}}
+{{- define "traefik.convertMemToBytes" }}
+  {{- $mem := lower . -}}
+   {{- if hasSuffix "e" $mem -}}
+    {{- $mem = mulf (trimSuffix "e" $mem | float64) 1e18 -}}
+  {{- else if hasSuffix "ei" $mem -}}
+    {{- $mem = mulf (trimSuffix "e" $mem | float64) 0x1p60 -}}
+  {{- else if hasSuffix "p" $mem -}}
+    {{- $mem = mulf (trimSuffix "p" $mem | float64) 1e15 -}}
+  {{- else if hasSuffix "pi" $mem -}}
+    {{- $mem = mulf (trimSuffix "pi" $mem | float64) 0x1p50 -}}
+  {{- else if hasSuffix "t" $mem -}}
+    {{- $mem = mulf (trimSuffix "t" $mem | float64) 1e12 -}}
+  {{- else if hasSuffix "ti" $mem -}}
+    {{- $mem = mulf (trimSuffix "ti" $mem | float64) 0x1p40 -}}
+  {{- else if hasSuffix "g" $mem -}}
+    {{- $mem = mulf (trimSuffix "g" $mem | float64) 1e9 -}}
+  {{- else if hasSuffix "gi" $mem -}}
+    {{- $mem = mulf (trimSuffix "gi" $mem | float64) 0x1p30 -}}
+  {{- else if hasSuffix "m" $mem -}}
+    {{- $mem = mulf (trimSuffix "m" $mem | float64) 1e6 -}}
+  {{- else if hasSuffix "mi" $mem -}}
+    {{- $mem = mulf (trimSuffix "mi" $mem | float64) 0x1p20 -}}
+  {{- else if hasSuffix "k" $mem -}}
+    {{- $mem = mulf (trimSuffix "k" $mem | float64) 1e3 -}}
+  {{- else if hasSuffix "ki" $mem -}}
+    {{- $mem = mulf (trimSuffix "ki" $mem | float64) 0x1p10 -}}
+  {{- end }}
+{{- $mem }}
+{{- end }}
+
+{{- define "traefik.gomemlimit" }}
+{{- $memlimitBytes := include "traefik.convertMemToBytes" . | mulf 0.8 -}}
+{{- printf "%dMiB" (divf $memlimitBytes 0x1p20 | floor | int64) -}}
+{{- end }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -857,10 +857,7 @@
           {{- end }}
           {{- if ($.Values.resources.limits).memory }}
           - name: GOMEMLIMIT
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.memory
-                divisor: '1'
+            value: {{ include "traefik.gomemlimit" .Values.resources.limits.memory | quote }}
           {{- end }}
           {{- with .Values.hub.token }}
           - name: HUB_TOKEN

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -19,26 +19,23 @@ tests:
               resourceFieldRef:
                 resource: limits.cpu
                 divisor: "1"
-  - it: should have set GOMEMLIMIT with cpu limit
+  - it: should have set GOMEMLIMIT with memory limit
     set:
       resources:
         limits:
-          memory: "4"
+          memory: "4Gi"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: GOMEMLIMIT
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.memory
-                divisor: "1"
+            value: "3276MiB"
   - it: should have not set GOMAXPROCS without cpu limit
     asserts:
       - notEqual:
           path: spec.template.spec.containers[0].env[0].name
           value: GOMAXPROCS
-  - it: should have not set GOMEMLIMIT without cpu limit
+  - it: should have not set GOMEMLIMIT without memory limit
     asserts:
       - notEqual:
           path: spec.template.spec.containers[0].env[0].name


### PR DESCRIPTION
### What does this PR do?
chart current pod template injects
GOMEMLIMIT = pod memory limits, it leaves no headroom for Go GC to run before the process hits the cgroup ceiling, leading to OOM kills. In my tests, I show great improvement with lower values, like 80%.


### Motivation

Multiple OOMs that were gone once we changed GOMEMLIMIT value 


### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

