### PR TITLE
feat: :sparkles: restart Hub pod on admission certificate change

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -216,18 +216,21 @@ The version can comes many sources: appVersion, image.tag, override, marketplace
 {{- if $.Values.hub.apimanagement.admission.customWebhookCertificate }}
 Cert: {{ index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls.crt" }}
 Key: {{ index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls.key" }}
+Hash: {{ sha1sum (index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls.crt") }}
 {{- else -}}
     {{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
     {{- if $cert -}}
     {{/* reusing value of existing cert */}}
 Cert: {{ index $cert.data "tls.crt" }}
 Key: {{ index $cert.data "tls.key" }}
+Hash: {{ sha1sum (index $cert.data "tls.crt") }}
     {{- else -}}
     {{/* generate a new one */}}
     {{- $altNames := list ( printf "admission.%s.svc" (include "traefik.namespace" .) ) -}}
     {{- $cert := genSelfSignedCert ( printf "admission.%s.svc" (include "traefik.namespace" .) ) (list) $altNames 3650 -}}
 Cert: {{ $cert.Cert | b64enc }}
 Key: {{ $cert.Key | b64enc }}
+Hash: {{ sha1sum ($cert.Cert | b64enc) }}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -20,6 +20,10 @@
       {{- if .Values.global.azure.enabled }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
       {{- end }}
+      {{- if and .Values.hub.token .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.restartOnCertificateChange }}
+        {{- $cert := include "traefik-hub.webhook_cert" . | fromYaml }}
+        hub-cert-hash: {{ $cert.Hash }}
+      {{- end }}
     spec:
       {{- with .Values.deployment.imagePullSecrets }}
       imagePullSecrets:

--- a/traefik/tests/hub-deployment-config_test.yaml
+++ b/traefik/tests/hub-deployment-config_test.yaml
@@ -199,3 +199,13 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.namespaces=NAMESPACE,one,two"
+
+  - it: should be possible to restart pods on certificate change
+    set:
+      hub:
+        admission:
+          enabled: true
+          restartOnCertificateChange: true
+    asserts:
+      - exists:
+          path: spec.template.metadata.labels.hub-cert-hash

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -953,6 +953,8 @@ hub:
       secretName: "hub-agent-cert"
       # -- Set custom certificate for the WebHook admission server. The certificate should be specified with _tls.crt_ and _tls.key_ in base64 encoding.
       customWebhookCertificate: {}
+      # -- Set it to true if you want Traefik Hub pod to be restarted on certificate change.
+      restartOnCertificateChange: false
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false


### PR DESCRIPTION
### What does this PR do?

Adds a new boolean to restart Traefik Hub on certificate change.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

This helps people to have their Traefik Hub instance restarted on admission certificate change.

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

