### PR TITLE
feat: add hub offline flag

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -91,6 +91,7 @@ Kubernetes: `>=1.22.0-0`
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
 | hub.experimental.aigateway | bool | `false` | Set to true in order to enable AI Gateway. Requires a valid license token. |
 | hub.namespaces | list | `[]` | By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
+| hub.offline | bool | `false` | Disables all external network connections. |
 | hub.providers.consulCatalogEnterprise.cache | bool | `false` | Use local agent caching for catalog reads. |
 | hub.providers.consulCatalogEnterprise.connectAware | bool | `false` | Enable Consul Connect support. |
 | hub.providers.consulCatalogEnterprise.connectByDefault | bool | `false` | Consider every service as Connect capable by default. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -784,6 +784,9 @@
             {{- if and (not .apimanagement.enabled) ($.Values.hub.apimanagement.admission.listenAddr) }}
                {{- fail "ERROR: Cannot configure admission without enabling hub.apimanagement" }}
             {{- end }}
+            {{- if .offline  }}
+          - "--hub.offline"
+            {{- end }}
             {{- if .namespaces }}
           - "--hub.namespaces={{ join "," (uniq (concat (include "traefik.namespace" $ | list) .namespaces)) }}"
             {{- end }}

--- a/traefik/tests/hub-deployment-config_test.yaml
+++ b/traefik/tests/hub-deployment-config_test.yaml
@@ -18,6 +18,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.token=$(HUB_TOKEN)"
+  - it: should set the offline flag when offline is enabled
+    set:
+      hub:
+        offline: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.offline"
   - it: should set minimal required parameters when enabling Traefik Hub API Management
     set:
       hub:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -941,6 +941,8 @@ hub:
   # -- Name of `Secret` with key 'token' set to a valid license token.
   # It enables API Gateway.
   token: ""
+  # -- Disables all external network connections.
+  offline: false
   # -- By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
   namespaces: []  # @schema required:true
   apimanagement:


### PR DESCRIPTION
### What does this PR do?

This PR allows to configure Hub's `--hub.offline` flag directly using Helm chart values. 

### Motivation

Improve the user experience for Helm users

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

