### PR TITLE
feat!: Support Selector for namespace policy in Gateway API

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -72,7 +72,7 @@ Kubernetes: `>=1.22.0-0`
 | gateway.infrastructure | object | `{}` | [Infrastructure](https://kubernetes.io/blog/2023/11/28/gateway-api-ga/#gateway-infrastructure-labels) |
 | gateway.listeners | object | `{"web":{"hostname":"","namespacePolicy":null,"port":8000,"protocol":"HTTP"}}` | Define listeners |
 | gateway.listeners.web.hostname | string | `""` | Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) |
-| gateway.listeners.web.namespacePolicy | string | `nil` | Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces |
+| gateway.listeners.web.namespacePolicy | object | `nil` | Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces |
 | gateway.listeners.web.port | int | `8000` | Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. The port must match a port declared in ports section. |
 | gateway.name | string | `""` | Set a custom name to gateway |
 | gateway.namespace | string | `""` | By default, Gateway is created in the same `Namespace` than Traefik. |

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -43,7 +43,7 @@ spec:
       {{- with .namespacePolicy }}
       allowedRoutes:
         namespaces:
-          from: {{ . }}
+          {{- toYaml . | nindent 10 }}
       {{- end }}
       {{ if and (eq .protocol  "HTTPS") (not .certificateRefs) }}
         {{- fail "ERROR: certificateRefs needs to be specified using HTTPS" }}

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -20,7 +20,7 @@ tests:
       - equal:
           path: metadata.namespace
           value: "NAMESPACE"
-  - it: should configure namespacePolicy within web listener
+  - it: should configure "All" namespacePolicy within web listener
     set:
       providers:
         kubernetesGateway:
@@ -28,11 +28,34 @@ tests:
       gateway:
         listeners:
           web:
-            namespacePolicy: All
+            namespacePolicy:
+              from: All
     asserts:
       - equal:
-          path: spec.listeners[0].allowedRoutes.namespaces.from
-          value: "All"
+          path: spec.listeners[0].allowedRoutes.namespaces
+          value: 
+            from: "All"
+  - it: should configure Selector for a namespacePolicy
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+      gateway:
+        listeners:
+          web:
+            namespacePolicy:
+              from: Selector
+              selector:
+                matchLabels:
+                  shared-gateway-access: "true"
+    asserts:
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces
+          value: 
+            from: "Selector"
+            selector:
+              matchLabels:
+                shared-gateway-access: "true"
   - it: should set expected apiVersion with v3 version
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -195,7 +195,7 @@
                                 },
                                 "namespacePolicy": {
                                     "type": [
-                                        "string",
+                                        "object",
                                         "null"
                                     ]
                                 },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -159,7 +159,7 @@ gateway:
       # Specify expected protocol on this listener. See [ProtocolType](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ProtocolType)
       protocol: HTTP
       # -- Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces
-      namespacePolicy:  # @schema type:[string, null]
+      namespacePolicy:  # @schema type:[object, null]
     # websecure listener is disabled by default because certificateRefs needs to be added,
     # or you may specify TLS protocol with Passthrough mode and add "--providers.kubernetesGateway.experimentalChannel=true" in additionalArguments section.
     # websecure:


### PR DESCRIPTION
### What does this PR do?

Can now enable the Gateway API object to specify allowed namespaces based on user defined selector.

### Motivation

The current helm chart only supports enabling the Gateway for the same namespace as the gateway API or all namespaces.
This change gives more flexibility to specify allowed namespaces based on a selector. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

