### PR TITLE
feat: update helm template to provide a spec that users can define fo…

### DIFF
--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -26,7 +26,10 @@
   loadBalancerClass: {{ . }}
   {{- end}}
   {{- with .service.spec }}
-  {{- toYaml . | nindent 2 }}
+  {{- $specWithoutPorts := omit . "ports" }}
+  {{- if $specWithoutPorts }}
+  {{- toYaml $specWithoutPorts | nindent 2 }}
+  {{- end }}
   {{- end }}
   selector:
     {{- include "traefik.labelselector" .root | nindent 4 }}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -54,7 +54,7 @@ metadata:
   {{- end }}
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}
-  {{- if $service.spec.ports }}
+  {{- if and $service.spec $service.spec.ports }}
   ports:
   {{- toYaml $service.spec.ports | nindent 2 }}
   {{- else }}
@@ -82,7 +82,7 @@ metadata:
   {{- end }}
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}
-  {{- if $service.spec.ports }}
+  {{- if and $service.spec $service.spec.ports }}
   ports:
   {{- toYaml $service.spec.ports | nindent 2 }}
   {{- else }}

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -54,11 +54,16 @@ metadata:
   {{- end }}
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}
+  {{- if $service.spec.ports }}
+  ports:
+  {{- toYaml $service.spec.ports | nindent 2 }}
+  {{- else }}
   ports:
   {{- template "traefik.service-ports" (dict "ports" $tcpPorts "serviceName" $name) }}
-{{- if $service.single }}
+  {{- if $service.single }}
   {{- template "traefik.service-ports" (dict "ports" $udpPorts "serviceName" $name) }}
-{{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if and $exposedPorts (and $udpPorts (not $service.single)) }}
@@ -77,8 +82,13 @@ metadata:
   {{- end }}
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}
+  {{- if $service.spec.ports }}
+  ports:
+  {{- toYaml $service.spec.ports | nindent 2 }}
+  {{- else }}
   ports:
   {{- $ports }}
+  {{- end }}
  {{- end }}
 {{- end }}
 


### PR DESCRIPTION
…r a service

### What does this PR do?

This PR creates a way for users to define `spec.ports` under the `service` key for overriding the default `ports`.


### Motivation

The motivation of this change is to fully support automated workflows for `NodePort` services. My use case is that I provision infrastructure for a `kubeadm` cluster on cloud providers and I need for a way to know what `NodePort` traefik is listening on up front so that I can run automated configuration (Terraform in this case) for cloud load balancers to forward traffic onto traefik.

Currently, since the `NodePort` is selected randomly, once the `Service` is created in a Kubernetes cluster, I have to opt for provisioning my cloud load balancer after all my other infrastructure is provisioned once the `NodePort` is chosen, and that can be quite cumbersome.


My values look like this:

```
gateway:
  listeners:
    websecure:
      port: 8443
      protocol: HTTPS
      namespacePolicy: All
      mode: Terminate
      certificateRefs:
        - name: yoofionline-tls
          namespace: default
providers:
  kubernetesIngress:
    enabled: false
  kubernetesGateway:
    enabled: true
service:
  type: NodePort
  spec:
    ports:
    - nodePort: 31000
      name: web
      targetPort: web
      protocol: TCP
    - nodePort: 31500
      name: websecure
      targetPort: websecure
      protocol: TCP
```

And with that I can know that `web` and `websecure` are listening on known ports which is useful for the automation.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

