### PR TITLE
Only render --global.checkNewVersion if it differs from default

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -182,8 +182,8 @@
           {{- end }}
         args:
           {{- with .Values.global }}
-           {{- if ne .checkNewVersion nil }}
-          - "--global.checkNewVersion={{ .checkNewVersion | toString }}"
+           {{- if not .checkNewVersion }}
+          - "--global.checkNewVersion=false"
            {{- end }}
            {{- if .sendAnonymousUsage }}
           - "--global.sendAnonymousUsage"

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -232,7 +232,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args
           value:
-            - --global.checkNewVersion=true
             - --entryPoints.metrics.address=:9100/tcp
             - --entryPoints.traefik.address=:8080/tcp
             - --entryPoints.web.address=:8000/tcp


### PR DESCRIPTION
### What does this PR do?

Follow up of https://github.com/traefik/traefik-helm-chart/pull/1489#issuecomment-3160112717

Parameters should only be rendered if they differ from the default configuration of Traefik. 

### Motivation

Conclusion of discussion in https://github.com/traefik/traefik-helm-chart/pull/1489#issuecomment-3160212846


### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

