### PR TITLE
Add AKS monitor package support

### DIFF
--- a/traefik/templates/prometheusrules.yaml
+++ b/traefik/templates/prometheusrules.yaml
@@ -5,7 +5,7 @@
       {{- fail "ERROR: You have to deploy monitoring.coreos.com/v1 first" }}
     {{- end }}
   {{- end }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.metrics.prometheus.prometheusRule.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: PrometheusRule
 metadata:
   name: {{ template "traefik.fullname" . }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@
       {{- fail "ERROR: You have to deploy monitoring.coreos.com/v1 first" }}
     {{- end }}
   {{- end }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.metrics.prometheus.serviceMonitor.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "traefik.fullname" . }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -432,6 +432,7 @@ metrics:
     serviceMonitor:
       # -- Enable optional CR for Prometheus Operator. See EXAMPLES.md for more details.
       enabled: false
+      apiVersion: "monitoring.coreos.com/v1"
       metricRelabelings: []
       relabelings: []
       jobLabel: ""
@@ -447,6 +448,7 @@ metrics:
     prometheusRule:
       # -- Enable optional CR for Prometheus Operator. See EXAMPLES.md for more details.
       enabled: false
+      apiVersion: "monitoring.coreos.com/v1"
       additionalLabels: {}
       namespace: ""
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
AKS is really annoying and they for their users to set a custom name for the moniroring.coreos.com/v1 package. This PR will allow Traefik users to set the apiVersion of the `PrometheusRule` and `ServiceMonitor` objects.

`metrics.prometheus.disableAPICheck` must be set, I decided not change the checks to not pollute the charts. 

### Motivation

<!-- What inspired you to submit this pull request? -->
http://learn.microsoft.com/en-us/azure/azure-monitor/containers/prometheus-metrics-scrape-crd

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

