### PR TITLE
Prestop hook improvements

### DIFF
--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -67,18 +67,30 @@ tests:
       - equal:
           path: spec.revisionHistoryLimit
           value: 1
-  - it: should have a preStop hook with specified values
+  - it: should have a preStop command hook with specified values
     set:
       deployment:
         kind: DaemonSet
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "sleep 40"]
+              command: ["/bin/sh", "-c", "sleep 20"]
     asserts:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
-          value: ["/bin/sh", "-c", "sleep 40"]
+          value: ["/bin/sh", "-c", "sleep 20"]
+  - it: should have a preStop sleep hook with specified values
+    set:
+      deployment:
+        kind: DaemonSet
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 20
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.sleep.seconds
+          value: 20
   - it: should have a postStart hook with specified values
     set:
       deployment:

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -169,17 +169,28 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 30
-  - it: should have a preStop hook with specified values
+  - it: should have a preStop command hook with specified values
     set:
       deployment:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "sleep 40"]
+              command: ["/bin/sh", "-c", "sleep 20"]
     asserts:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
-          value: ["/bin/sh", "-c", "sleep 40"]
+          value: ["/bin/sh", "-c", "sleep 20"]
+  - it: should have a preStop sleep hook with specified values
+    set:
+      deployment:
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 20
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.sleep.seconds
+          value: 20
   - it: should have a postStart hook with specified values
     set:
       deployment:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -91,8 +91,8 @@ deployment:
   # -- Pod lifecycle actions
   lifecycle: {}
   # preStop:
-  #   exec:
-  #     command: ["/bin/sh", "-c", "sleep 40"]
+  #   sleep:
+  #     seconds: 20
   # postStart:
   #   httpGet:
   #     path: /ping


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Illustrate the usage of the new stable "Sleep Action for PreStop Hook"; see also https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3960-pod-lifecycle-sleep-action
- Update example values to prefer this new easier and slightly more robust syntax
- Replace suggested and test value of 40 with 20 given default termination period is 30s and therefore 40 is probably not a great default choice

This new syntax has two main benefits, namely:
- being (slightly) easier to grasp
- being run by `kubelet` rather than inside the container, therefore not requiring `sleep` to be present as binary in the container

Therefore I think we should encourage users to use this if anything.

### Motivation

<!-- What inspired you to submit this pull request? -->
The release of Kubernetes 1.34 yesterday; see also https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/.

### More

- [x] Yes, I updated the tests accordingly
- [] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

