### PR TITLE
[Feature] - Add capability to specify admission controller certificate from existing secret

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -808,14 +808,20 @@
           - "--hub.namespaces={{ join "," (uniq (concat (include "traefik.namespace" $ | list) .namespaces)) }}"
             {{- end }}
             {{- with .apimanagement }}
-             {{- if .enabled }}
+            {{- if .enabled }}
               {{- $listenAddr := default ":9943" .admission.listenAddr }}
           - "--hub.apimanagement"
               {{- if not $.Values.hub.offline }}
           - "--hub.apimanagement.admission.listenAddr={{ $listenAddr }}"
-                {{- with .admission.secretName }}
+                {{- if .admission.existingSecretName }}
+                  {{- with .admission.existingSecretName }}
+          - "--hub.apimanagement.admission.secretName={{ . }}"
+                  {{- end }}
+                {{- else }}
+                  {{- with .admission.secretName }}
           - "--hub.apimanagement.admission.secretName={{ . }}"
                 {{- end }}
+              {{- end }}
               {{- end }}
               {{- if .openApi.validateRequestMethodAndPath }}
           - "--hub.apiManagement.openApi.validateRequestMethodAndPath=true"

--- a/traefik/templates/hub-admission-controller.yaml
+++ b/traefik/templates/hub-admission-controller.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.hub.token -}}
 {{- if and .Values.hub.apimanagement.enabled (not .Values.hub.offline) }}
 {{- $cert := include "traefik-hub.webhook_cert" . | fromYaml }}
+{{- if not .Values.hub.apimanagement.admission.existingSecretName }}
 ---
 apiVersion: v1
 kind: Secret
@@ -13,6 +14,7 @@ metadata:
 data:
   tls.crt: {{ $cert.Cert }}
   tls.key: {{ $cert.Key  }}
+{{- end }}
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/traefik/tests/hub-admission-controler_test.yaml
+++ b/traefik/tests/hub-admission-controler_test.yaml
@@ -155,3 +155,29 @@ tests:
           path: "webhooks[*].clientConfig.caBundle"
           value: cert
         documentIndex: 1
+  - it: should be possible to specify custom webhook certificate from existing secret
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version:  "v1"
+            resource: "secrets"
+            namespaced: true
+      objects:
+        - kind: Secret
+          apiVersion: v1
+          metadata:
+            name: test
+          data:
+            tls.crt: "testcert=="
+            tls.key: "testkey=="
+    set:
+      hub:
+        apimanagement:
+          admission:
+            existingSecretName: test
+    asserts:
+      - equal:
+          path: "webhooks[*].clientConfig.caBundle"
+          value: "testcert=="
+        documentIndex: 0

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -987,6 +987,8 @@ hub:
       listenAddr: ""
       # -- Certificate name of the WebHook admission server. Default: "hub-agent-cert".
       secretName: "hub-agent-cert"
+      # -- Existing certificate secret name of the WebHook admission server.
+      existingSecretName: ""
       # -- Set custom certificate for the WebHook admission server. The certificate should be specified with _tls.crt_ and _tls.key_ in base64 encoding.
       customWebhookCertificate: {}
       # -- Set it to false if you need to disable Traefik Hub pod restart when mutating webhook certificate is updated. It's done with a label update.


### PR DESCRIPTION
### What does this PR do?

This PR adds the capacity to specify the admission controller certificate from an existing secret.

### Motivation

We have been asked by several users to manage the admission controller certificate manually through a secret instead of values.


### More

- [X] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed
