### PR TITLE
fix: make RBAC and supporting templates nil-safe for optional provider and hub blocks

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -16,7 +16,7 @@
 
 
 {{/* Warn about non-standard Traefik Hub versions (pre-release or minor/patch above supported range) */}}
-{{- if .Values.hub.token -}}
+{{- if (.Values.hub).token -}}
 {{- $hubVersion := include "traefik.hubVersion" $ -}}
 {{- $hubMaxVersion := index .Chart.Annotations "traefik.io/hub-max-version" -}}
 {{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (eq (include "traefik.isAboveMaxVersion" (dict "version" $hubVersion "max" $hubMaxVersion)) "true") -}}
@@ -41,7 +41,7 @@ for more info. 🚨
 
 
 {{/* Warn about non-matching potential labelSelector mismatch for CRD provider */}}
-{{- with .Values.providers.kubernetesCRD.labelSelector -}}
+{{- with (.Values.providers.kubernetesCRD).labelSelector -}}
   {{- $labelsApplied := include "traefik.labels" $ -}}
   {{- $labelSelectors := regexSplit "," . -1 }}
   {{- range $labelSelectors -}}
@@ -57,7 +57,7 @@ for more info. 🚨
 
 
 {{/* Warn about non-matching potential labelSelector mismatch for Ingress provider */}}
-{{- with .Values.providers.kubernetesIngress.labelSelector -}}
+{{- with (.Values.providers.kubernetesIngress).labelSelector -}}
   {{- $labelsApplied := include "traefik.labels" $ -}}
   {{- $labelSelectors := regexSplit "," . -1 -}}
   {{- range $labelSelectors -}}
@@ -85,7 +85,7 @@ for more info. 🚨
 
 
 {{/* Warn about hub not watching namespaces configured in providers */}}
-{{- if and .Values.hub.token (and .Values.rbac.enabled .Values.rbac.namespaced) }}
+{{- if and (.Values.hub).token (and .Values.rbac.enabled .Values.rbac.namespaced) }}
     {{- if .Values.hub.namespaces -}}
         {{- range (list "kubernetesCRD" "kubernetesGateway" "kubernetesIngress") }}
             {{- $provider := . -}}
@@ -141,7 +141,7 @@ You will need to install them yourself before deploying Traefik v3.7:
 
 
 {{/* Warn about missing secret when enabling managed certificate with Hub admission controller */}}
-{{- if and .Values.hub.token .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.selfManagedCertificate }}
+{{- if and (.Values.hub).token ((.Values.hub).apimanagement).enabled (((.Values.hub).apimanagement).admission).selfManagedCertificate }}
   {{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
   {{- if not $cert }}
     {{- printf "\nWARNING: webhook secret %s for Traefik hub is self managed and was not found in %s namespace.\n" $.Values.hub.apimanagement.admission.secretName (include "traefik.namespace" .) -}}

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -131,7 +131,7 @@ Migration example:
 
 
 {{/* Warn about Gateway API CRDs no longer shipped with this chart in future versions */}}
-{{- if .Values.providers.kubernetesGateway.enabled }}
+{{- if (.Values.providers.kubernetesGateway).enabled }}
 {{- printf "\n" -}}
 ⚠️ DEPRECATION WARNING: Gateway API CRDs will no longer be shipped with this chart in a future major version.
 You will need to install them yourself before deploying Traefik v3.7:

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -19,15 +19,15 @@ Image defaults. An explicit image value always wins; otherwise the chart picks t
 Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwise.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token))) -}}
+{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty (.Values.hub).token))) -}}
 {{- end -}}
 
 {{- define "traefik.imageRepository" -}}
-{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token))) -}}
+{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (not (empty (.Values.hub).token))) -}}
 {{- end -}}
 
 {{- define "traefik.defaultTag" -}}
-{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (not (empty .Values.hub.token)) -}}
+{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (not (empty (.Values.hub).token)) -}}
 {{- end -}}
 
 {{/*
@@ -35,13 +35,13 @@ Create the chart image name.
 */}}
 {{- define "traefik.image-name" -}}
 {{- if .Values.oci_meta.enabled -}}
- {{- if .Values.hub.token -}}
+ {{- if (.Values.hub).token -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.hub.image .Values.oci_meta.images.hub.tag }}
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.proxy.image .Values.oci_meta.images.proxy.tag }}
  {{- end -}}
 {{- else if .Values.global.azure.enabled -}}
- {{- if .Values.hub.token -}}
+ {{- if (.Values.hub).token -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.hub.registry .Values.global.azure.images.hub.image .Values.global.azure.images.hub.tag }}
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.proxy.registry .Values.global.azure.images.proxy.image .Values.global.azure.images.proxy.tag }}
@@ -273,8 +273,8 @@ The version can comes many sources: appVersion, image.tag, override, marketplace
 */}}
 {{- define "traefik.proxyVersion" -}}
  {{- if $.Values.versionOverride }}
-  {{- include "traefik.proxyVersionFromHub" (dict "Version" $.Values.versionOverride "Hub" $.Values.hub.token) }}
- {{- else if $.Values.hub.token -}}
+  {{- include "traefik.proxyVersionFromHub" (dict "Version" $.Values.versionOverride "Hub" ($.Values.hub).token) }}
+ {{- else if ($.Values.hub).token -}}
   {{- $version := ($.Values.oci_meta.enabled | ternary $.Values.oci_meta.images.hub.tag $.Values.image.tag) -}}
   {{- $version = ($.Values.global.azure.enabled | ternary $.Values.global.azure.images.hub.tag $version) -}}
   {{- include "traefik.proxyVersionFromHub" (dict "Version" $version "Hub" true) }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -20,7 +20,7 @@
       {{- if .Values.global.azure.enabled }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
       {{- end }}
-      {{- if and .Values.hub.token .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.restartOnCertificateChange }}
+      {{- if and (.Values.hub).token ((.Values.hub).apimanagement).enabled (((.Values.hub).apimanagement).admission).restartOnCertificateChange }}
         {{- $cert := include "traefik-hub.webhook_cert" . | fromYaml }}
         hub-cert-hash: {{ $cert.Hash }}
       {{- end }}
@@ -137,7 +137,7 @@
           {{- end }}
          {{- end }}
         {{- end }}
-        {{- if .Values.hub.token }}
+        {{- if (.Values.hub).token }}
           {{- if not .Values.hub.offline }}
           {{- $listenAddr := default ":9943" .Values.hub.apimanagement.admission.listenAddr }}
         - name: admission
@@ -162,7 +162,7 @@
             {{- end }}
           - name: tmp
             mountPath: /tmp
-          {{- if .Values.hub.token }}
+          {{- if (.Values.hub).token }}
           - name: hub-token
             mountPath: {{ .Values.hub.tokenMountPath }}
             readOnly: true
@@ -176,7 +176,7 @@
           - name: plugins
             mountPath: "/plugins-storage"
           {{- end }}
-          {{- if .Values.providers.file.enabled }}
+          {{- if (.Values.providers.file).enabled }}
           - name: traefik-extra-config
             mountPath: "/etc/traefik/dynamic"
           {{- end }}
@@ -482,7 +482,7 @@
           {{- with .Values.providers.precedence }}
           - "--providers.precedence={{ join "," . }}"
           {{- end }}
-          {{- if .Values.providers.kubernetesCRD.enabled }}
+          {{- if (.Values.providers.kubernetesCRD).enabled }}
           - "--providers.kubernetescrd"
            {{- if .Values.providers.kubernetesCRD.labelSelector }}
           - "--providers.kubernetescrd.labelSelector={{ .Values.providers.kubernetesCRD.labelSelector }}"
@@ -511,7 +511,7 @@
           - "--providers.kubernetescrd.nativeLBByDefault=true"
            {{- end }}
           {{- end }}
-          {{- if .Values.providers.kubernetesIngress.enabled }}
+          {{- if (.Values.providers.kubernetesIngress).enabled }}
           - "--providers.kubernetesingress"
            {{- if .Values.providers.kubernetesIngress.allowExternalNameServices }}
           - "--providers.kubernetesingress.allowExternalNameServices=true"
@@ -1004,7 +1004,7 @@
           {{- end }}
         - name: tmp
           emptyDir: {}
-        {{- if .Values.hub.token }}
+        {{- if (.Values.hub).token }}
         - name: hub-token
           secret:
             secretName: {{ le (len .Values.hub.token) 64 | ternary .Values.hub.token "traefik-hub-license" }}
@@ -1046,7 +1046,7 @@
         - name: plugins
           emptyDir: {}
         {{- end }}
-        {{- if .Values.providers.file.enabled }}
+        {{- if (.Values.providers.file).enabled }}
         - name: traefik-extra-config
           configMap:
             name: {{ template "traefik.fullname" . }}-file-provider

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -31,7 +31,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- if and .Values.providers.file.enabled (not .Values.providers.file.watch) }}
+  {{- if and (.Values.providers.file).enabled (not (.Values.providers.file).watch) }}
     checksum/traefik-dynamic-conf: {{ include (print $.Template.BasePath "/provider-file-cm.yaml") . | sha256sum }}
   {{- end }}
   {{- with .Values.deployment.annotations }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -28,7 +28,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-  {{- if and .Values.providers.file.enabled (not .Values.providers.file.watch) }}
+  {{- if and (.Values.providers.file).enabled (not (.Values.providers.file).watch) }}
     checksum/traefik-dynamic-conf: {{ include (print $.Template.BasePath "/provider-file-cm.yaml") . | sha256sum }}
   {{- end }}
   {{- with .Values.deployment.annotations }}

--- a/traefik/templates/hub-admission-controller.yaml
+++ b/traefik/templates/hub-admission-controller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hub.token -}}
+{{- if (.Values.hub).token -}}
 {{- if and .Values.hub.apimanagement.enabled (not .Values.hub.offline) }}
 {{- $cert := include "traefik-hub.webhook_cert" . | fromYaml }}
 {{- if or (not .Values.hub.apimanagement.admission.selfManagedCertificate) .Values.hub.apimanagement.admission.customWebhookCertificate}}

--- a/traefik/templates/hub-apiportal.yaml
+++ b/traefik/templates/hub-apiportal.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hub.apimanagement.enabled }}
+{{- if ((.Values.hub).apimanagement).enabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/traefik/templates/hub-license.yaml
+++ b/traefik/templates/hub-license.yaml
@@ -1,4 +1,4 @@
-{{- if ge (len (.Values.hub.token | default "")) 65 }}
+{{- if ge (len ((.Values.hub).token | default "")) 65 }}
 ---
 apiVersion: v1
 kind: Secret

--- a/traefik/templates/provider-file-cm.yaml
+++ b/traefik/templates/provider-file-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.providers.file.enabled -}}
+{{- if (.Values.providers.file).enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -42,7 +42,7 @@ rules:
       - get
       - list
       - watch
-    {{- if and .Values.hub.token }}
+    {{- if (.Values.hub).token }}
       - update
       - create
       - delete
@@ -156,7 +156,7 @@ rules:
     verbs:
       - update
   {{- end }}
-  {{- if .Values.hub.token }}
+  {{- if (.Values.hub).token }}
   - apiGroups:
       - coordination.k8s.io
     resources:

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -48,7 +48,7 @@ rules:
       - delete
       - deletecollection
     {{- end }}
-  {{- if or .Values.providers.kubernetesIngress.enabled .Values.providers.kubernetesIngressNGINX.enabled }}
+  {{- if or (.Values.providers.kubernetesIngress).enabled (.Values.providers.kubernetesIngressNGINX).enabled }}
   - apiGroups:
       - extensions
       - networking.k8s.io
@@ -74,8 +74,8 @@ rules:
       - list
       - watch
   {{- end -}}
-  {{- if .Values.providers.kubernetesCRD.enabled }}
-   {{- if not .Values.providers.kubernetesIngress.enabled }}
+  {{- if (.Values.providers.kubernetesCRD).enabled }}
+   {{- if not (.Values.providers.kubernetesIngress).enabled }}
   - apiGroups:
       - extensions
       - networking.k8s.io

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -47,7 +47,7 @@ rules:
       - get
       - list
       - watch
-{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($.Values.providers.kubernetesIngressNGINX.enabled) }}
+{{- if or (and (has . $ingressNamespaces) ($.Values.providers.kubernetesIngress).enabled) (($.Values.providers.kubernetesIngressNGINX).enabled) }}
   - apiGroups:
       - extensions
       - networking.k8s.io
@@ -65,7 +65,7 @@ rules:
     verbs:
       - update
 {{- end -}}
-{{- if (and (has . $CRDNamespaces) $.Values.providers.kubernetesCRD.enabled) }}
+{{- if (and (has . $CRDNamespaces) ($.Values.providers.kubernetesCRD).enabled) }}
   - apiGroups:
       - traefik.io
     resources:
@@ -84,7 +84,7 @@ rules:
       - list
       - watch
 {{- end -}}
-{{- if (and (has . $knativeNamespaces) $.Values.providers.knative.enabled) }}
+{{- if (and (has . $knativeNamespaces) ($.Values.providers.knative).enabled) }}
   - apiGroups:
       - networking.internal.knative.dev
     resources:

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -1,8 +1,8 @@
 {{- $version := include "traefik.proxyVersion" $ }}
-{{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
-{{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
-{{- $knativeNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.knative.namespaces -}}
-{{- $hubNamespaces := concat (include "traefik.namespace" . | list) .Values.hub.namespaces -}}
+{{- $ingressNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.kubernetesIngress).namespaces) -}}
+{{- $CRDNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.kubernetesCRD).namespaces) -}}
+{{- $knativeNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.knative).namespaces) -}}
+{{- $hubNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.hub).namespaces) -}}
 {{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $hubNamespaces $knativeNamespaces)) -}}
 
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced -}}

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -100,7 +100,7 @@ rules:
     verbs:
       - update
 {{- end }}
-{{- if (and (has . $hubNamespaces) $.Values.hub.token) }}
+{{- if (and (has . $hubNamespaces) ($.Values.hub).token) }}
   - apiGroups:
       - ""
     resources:

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -1,8 +1,8 @@
-{{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
-{{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
-{{- $gatewayNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.kubernetesGateway).namespaces) -}}
-{{- $knativeNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.knative).namespaces) -}}
-{{- $hubNamespaces := concat (include "traefik.namespace" . | list) .Values.hub.namespaces -}}
+{{- $ingressNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.kubernetesIngress).namespaces) -}}
+{{- $CRDNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.kubernetesCRD).namespaces) -}}
+{{- $gatewayNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.kubernetesGateway).namespaces) -}}
+{{- $knativeNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.providers.knative).namespaces) -}}
+{{- $hubNamespaces := concat (include "traefik.namespace" . | list) (default list (.Values.hub).namespaces) -}}
 {{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $gatewayNamespaces $knativeNamespaces $hubNamespaces)) -}}
 
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -19,15 +19,15 @@
   {{- fail "ERROR: Knative is experimental. Enable it by setting experimental.knative to true" -}}
 {{- end }}
 
-{{- if and (.Values.providers.kubernetesGateway.enabled) (.Values.gateway.defaultScope) (not .Values.providers.kubernetesGateway.experimentalChannel) }}
+{{- if and ((.Values.providers.kubernetesGateway).enabled) (.Values.gateway.defaultScope) (not (.Values.providers.kubernetesGateway).experimentalChannel) }}
   {{- fail "ERROR: The Gateway 'defaultScope' field is experimental. Enable it by setting providers.kubernetesGateway.experimentalChannel=true" }}
 {{- end }}
 
 {{- if .Values.rbac.namespaced }}
-  {{- if .Values.providers.kubernetesGateway.enabled }}
+  {{- if (.Values.providers.kubernetesGateway).enabled }}
     {{- fail "ERROR: Kubernetes Gateway provider requires ClusterRole. RBAC cannot be namespaced." }}
   {{- end }}
-  {{- if and (not .Values.providers.kubernetesIngress.enabled) (not .Values.providers.kubernetesCRD.enabled) }}
+  {{- if and (not (.Values.providers.kubernetesIngress).enabled) (not (.Values.providers.kubernetesCRD).enabled) }}
     {{- fail "ERROR: namespaced rbac requires Kubernetes CRD or Kubernetes Ingress provider." }}
   {{- end }}
 {{- end }}
@@ -36,7 +36,7 @@
   {{- fail "ERROR: Kubernetes Ingress NGINX provider is only available for traefik >= v3.6.2." }}
 {{- end }}
 
-{{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
+{{- if and ((.Values.providers.kubernetesIngressNGINX).modsec).enabled (not $.Values.hub.token) }}
   {{- fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub." }}
 {{- end }}
 
@@ -95,16 +95,16 @@
 {{- end }}
 
 {{- if and (semverCompare "<v3.7.1-0" $version) (or
-    (not (empty .Values.providers.kubernetesCRD.crossProviderNamespaces))
-    (not (empty .Values.providers.kubernetesIngress.crossProviderNamespaces))
-    (not (empty .Values.providers.kubernetesGateway.crossProviderNamespaces))
+    (not (empty (.Values.providers.kubernetesCRD).crossProviderNamespaces))
+    (not (empty (.Values.providers.kubernetesIngress).crossProviderNamespaces))
+    (not (empty (.Values.providers.kubernetesGateway).crossProviderNamespaces))
     ) }}
   {{- fail "ERROR: providers.kubernetes{CRD,Ingress,Gateway}.crossProviderNamespaces is only available for traefik >= v3.7.1" }}
 {{- end }}
 
 {{- if and (semverCompare "<v3.7.3-0" $version) (or
-    (not (empty .Values.providers.kubernetesGateway.qps))
-    (not (empty .Values.providers.kubernetesGateway.burst))
+    (not (empty (.Values.providers.kubernetesGateway).qps))
+    (not (empty (.Values.providers.kubernetesGateway).burst))
     ) }}
   {{- fail "ERROR: providers.kubernetesGateway.qps and .burst are only available for traefik >= v3.7.3." }}
 {{- end }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -11,7 +11,7 @@
   {{- end }}
 {{- end }}
 
-{{- if and .Values.hub.token (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
+{{- if and (.Values.hub).token (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
   {{- fail "ERROR: traefik-hub image is required when enabling Traefik Hub" -}}
 {{- end }}
 
@@ -130,7 +130,7 @@
   {{- fail "ERROR: request path security options are only available for traefik >= v3.6.4." }}
 {{- end }}
 
-{{- if $.Values.hub.token -}}
+{{- if ($.Values.hub).token -}}
   {{- $hubVersion := include "traefik.hubVersion" $ }}
   {{- if not $hubVersion }}
     {{- if $.Values.image.digest }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1100,3 +1100,19 @@ tests:
       - hasDocuments:
           count: 1
         template: rbac/rolebinding.yaml
+  - it: should render when optional provider and hub blocks are nil
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesGateway: ~
+        knative: ~
+        file: ~
+        kubernetesIngressNGINX: ~
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac/role.yaml
+      - isKind:
+          of: RoleBinding
+        template: rbac/rolebinding.yaml

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1074,3 +1074,29 @@ tests:
               - get
               - list
               - watch
+  - it: should render Role and RoleBinding when provider namespaces are nil
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngress:
+          namespaces: ~
+        kubernetesCRD:
+          namespaces: ~
+        kubernetesGateway:
+          namespaces: ~
+        knative:
+          namespaces: ~
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac/role.yaml
+      - isKind:
+          of: RoleBinding
+        template: rbac/rolebinding.yaml
+      - hasDocuments:
+          count: 1
+        template: rbac/role.yaml
+      - hasDocuments:
+          count: 1
+        template: rbac/rolebinding.yaml


### PR DESCRIPTION
### What does this PR do?

Several templates dereference `.Values.providers.*` and `.Values.hub.*` without guarding the parent map, so rendering panics with `nil pointer evaluating interface {}.X` whenever a user-supplied values file omits or nulls an optional block. The pre-existing `((.x).y)` "nil-safe" form in `rolebinding.yaml` was also broken in a different way: it returned `nil` (not `list`) and `concat` panicked on the nil argument.

### Motivation

Running into this issue while trying to deploy the helm chart


### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed
