### PR TITLE
feat(rbac): grant configmaps write for hub api management

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -188,6 +188,14 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - patch
+      - delete
     {{- end }}
   - apiGroups:
       - ""

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -688,6 +688,18 @@ tests:
               - pods
             verbs:
               - get
+      - template: rbac/clusterrole.yaml
+        notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
 
   - it: should provide expected role rbac
     set:
@@ -717,6 +729,18 @@ tests:
       hub:
         token: xxx
     asserts:
+      - template: rbac/clusterrole.yaml
+        notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
       - template: rbac/clusterrole.yaml
         contains:
           path: rules
@@ -849,6 +873,18 @@ tests:
         apimanagement:
           enabled: true
     asserts:
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
       - template: rbac/clusterrole.yaml
         contains:
           path: rules


### PR DESCRIPTION
### What does this PR do?

Grants `create`, `patch` and `delete` verbs on `configmaps` in the Traefik ClusterRole when Traefik Hub API management is enabled (`hub.apimanagement.enabled`). The permission is added through a dedicated rule so the default cluster role stays read-only and `nodes`/`services` keep only `get`/`list`/`watch`


### Motivation

Traefik Hub API management needs write access to configmaps to operate, but that access should not be granted by default nor extended to other core resources. Gating it behind `hub.apimanagement.enabled` keeps the cluster role least-privilege for every other configuration.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

