### PR TITLE
feat(hub): :sparkles: support apiManagement OpenAPI refresh interval

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -146,6 +146,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.secretName | string | `"hub-agent-cert"` | Certificate name of the WebHook admission server. Default: "hub-agent-cert". |
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
+| hub.apimanagement.openApi.refreshInterval | string | `""` | Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
 | hub.enabled | bool | `true` when `hub.token` is set | Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik Proxy, which requires Traefik Hub >= v3.21.0-ea. |
 | hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub >= v3.21.0-ea. |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -146,7 +146,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.secretName | string | `"hub-agent-cert"` | Certificate name of the WebHook admission server. Default: "hub-agent-cert". |
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
-| hub.apimanagement.openApi.refreshInterval | string | `""` | Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. When empty, the Traefik Hub default (`1m`) applies. |
+| hub.apimanagement.openApi.refreshInterval | string | `1m` when unset | Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
 | hub.enabled | bool | `true` when `hub.token` is set | Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik Proxy, which requires Traefik Hub >= v3.21.0-ea. |
 | hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub >= v3.21.0-ea. |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -146,7 +146,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.secretName | string | `"hub-agent-cert"` | Certificate name of the WebHook admission server. Default: "hub-agent-cert". |
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
-| hub.apimanagement.openApi.refreshInterval | string | `""` | Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies. |
+| hub.apimanagement.openApi.refreshInterval | string | `""` | Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. When empty, the Traefik Hub default (`1m`) applies. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
 | hub.enabled | bool | `true` when `hub.token` is set | Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik Proxy, which requires Traefik Hub >= v3.21.0-ea. |
 | hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub >= v3.21.0-ea. |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -145,6 +145,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.secretName | string | `"hub-agent-cert"` | Certificate name of the WebHook admission server. Default: "hub-agent-cert". |
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
+| hub.apimanagement.openApi.refreshInterval | string | `""` | Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
 | hub.enabled | bool | `true` when `hub.token` is set | Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik Proxy, which requires Traefik Hub >= v3.21.0-ea. |
 | hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub >= v3.21.0-ea. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -873,6 +873,9 @@
               {{- if .openApi.validateRequestMethodAndPath }}
           - "--hub.apiManagement.openApi.validateRequestMethodAndPath=true"
               {{- end }}
+              {{- with .openApi.refreshInterval }}
+          - "--hub.apiManagement.openApi.refreshInterval={{ . }}"
+              {{- end }}
              {{- end }}
             {{- end }}
             {{- with .aigateway }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -861,6 +861,9 @@
               {{- if .openApi.validateRequestMethodAndPath }}
           - "--hub.apiManagement.openApi.validateRequestMethodAndPath=true"
               {{- end }}
+              {{- with .openApi.refreshInterval }}
+          - "--hub.apiManagement.openApi.refreshInterval={{ . }}"
+              {{- end }}
              {{- end }}
             {{- end }}
             {{- with .aigateway }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -230,7 +230,7 @@
     {{ fail "ERROR: hub.hardened is only available for Traefik Hub >= v3.21.0-ea, set image.tag accordingly." }}
   {{- end }}
 
-  {{- if and $.Values.hub.apimanagement.openApi.refreshInterval (semverCompare "<v3.21.0-0" $hubVersion) }}
+  {{- if and $.Values.hub.apimanagement.enabled $.Values.hub.apimanagement.openApi.refreshInterval (semverCompare "<v3.21.0-0" $hubVersion) }}
     {{ fail "ERROR: hub.apimanagement.openApi.refreshInterval is only available for Traefik Hub >= v3.21.0." }}
   {{- end }}
 

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -230,6 +230,10 @@
     {{ fail "ERROR: hub.hardened is only available for Traefik Hub >= v3.21.0-ea, set image.tag accordingly." }}
   {{- end }}
 
+  {{- if and $.Values.hub.apimanagement.openApi.refreshInterval (semverCompare "<v3.21.0-0" $hubVersion) }}
+    {{ fail "ERROR: hub.apimanagement.openApi.refreshInterval is only available for Traefik Hub >= v3.21.0." }}
+  {{- end }}
+
   {{- if semverCompare "<v3.20.0-ea.7" $hubVersion }}
     {{- range $childName, $childConfig := $.Values.hub.providers.multicluster.children }}
       {{- if or (($childConfig.serversTransport).forwardingTimeouts).readTimeout (($childConfig.serversTransport).forwardingTimeouts).writeTimeout }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -230,7 +230,7 @@
     {{ fail "ERROR: hub.hardened is only available for Traefik Hub >= v3.21.0-ea, set image.tag accordingly." }}
   {{- end }}
 
-  {{- if and $.Values.hub.apimanagement.enabled $.Values.hub.apimanagement.openApi.refreshInterval (semverCompare "<v3.21.0-0" $hubVersion) }}
+  {{- if and $.Values.hub.apimanagement.openApi.refreshInterval (semverCompare "<v3.21.0-0" $hubVersion) }}
     {{ fail "ERROR: hub.apimanagement.openApi.refreshInterval is only available for Traefik Hub >= v3.21.0." }}
   {{- end }}
 

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -214,6 +214,10 @@
     {{ fail "ERROR: hub.hardened is only available for Traefik Hub >= v3.21.0-ea, set image.tag accordingly." }}
   {{- end }}
 
+  {{- if and $.Values.hub.apimanagement.openApi.refreshInterval (semverCompare "<v3.21.0-0" $hubVersion) }}
+    {{ fail "ERROR: hub.apimanagement.openApi.refreshInterval is only available for Traefik Hub >= v3.21.0." }}
+  {{- end }}
+
   {{- if semverCompare "<v3.20.0-ea.7" $hubVersion }}
     {{- range $childName, $childConfig := $.Values.hub.providers.multicluster.children }}
       {{- if or (($childConfig.serversTransport).forwardingTimeouts).readTimeout (($childConfig.serversTransport).forwardingTimeouts).writeTimeout }}

--- a/traefik/tests/hub-apigateway-config_test.yaml
+++ b/traefik/tests/hub-apigateway-config_test.yaml
@@ -139,6 +139,30 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.apiManagement.openApi.validateRequestMethodAndPath=true"
+  - it: should set the OpenAPI refresh interval
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.21.0-ea.1
+      hub:
+        apimanagement:
+          enabled: true
+          openApi:
+            refreshInterval: "5m"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.apiManagement.openApi.refreshInterval=5m"
+  - it: should not set the OpenAPI refresh interval by default
+    set:
+      hub:
+        apimanagement:
+          enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.apiManagement.openApi.refreshInterval="
   - it: api management and ai gateway should not be enabled by default
     asserts:
       - notContains:

--- a/traefik/tests/hub-apigateway-config_test.yaml
+++ b/traefik/tests/hub-apigateway-config_test.yaml
@@ -160,9 +160,8 @@ tests:
         apimanagement:
           enabled: true
     asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: "--hub.apiManagement.openApi.refreshInterval="
+      - notMatchRegexRaw:
+          pattern: "--hub\\.apiManagement\\.openApi\\.refreshInterval"
   - it: api management and ai gateway should not be enabled by default
     asserts:
       - notContains:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -877,6 +877,35 @@ tests:
                   - "prod"
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using apiManagement openApi refreshInterval on Traefik Hub < v3.21.0
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.7
+      hub:
+        token: "xxx"
+        apimanagement:
+          enabled: true
+          openApi:
+            refreshInterval: "5m"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.apimanagement.openApi.refreshInterval is only available for Traefik Hub >= v3.21.0."
+  - it: should pass when using apiManagement openApi refreshInterval on Traefik Hub >= v3.21.0
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0-ea.1
+      hub:
+        token: "xxx"
+        apimanagement:
+          enabled: true
+          openApi:
+            refreshInterval: "5m"
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -906,6 +906,20 @@ tests:
             refreshInterval: "5m"
     asserts:
       - notFailedTemplate: {}
+  - it: should pass when apiManagement openApi refreshInterval is set but apiManagement is disabled
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.7
+      hub:
+        token: "xxx"
+        apimanagement:
+          enabled: false
+          openApi:
+            refreshInterval: "5m"
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -906,20 +906,6 @@ tests:
             refreshInterval: "5m"
     asserts:
       - notFailedTemplate: {}
-  - it: should pass when apiManagement openApi refreshInterval is set but apiManagement is disabled
-    set:
-      image:
-        registry: "ghcr.io"
-        repository: "traefik/traefik-hub"
-        tag: v3.20.7
-      hub:
-        token: "xxx"
-        apimanagement:
-          enabled: false
-          openApi:
-            refreshInterval: "5m"
-    asserts:
-      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -866,6 +866,35 @@ tests:
                   - "prod"
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using apiManagement openApi refreshInterval on Traefik Hub < v3.21.0
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.7
+      hub:
+        token: "xxx"
+        apimanagement:
+          enabled: true
+          openApi:
+            refreshInterval: "5m"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.apimanagement.openApi.refreshInterval is only available for Traefik Hub >= v3.21.0."
+  - it: should pass when using apiManagement openApi refreshInterval on Traefik Hub >= v3.21.0
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0-ea.1
+      hub:
+        token: "xxx"
+        apimanagement:
+          enabled: true
+          openApi:
+            refreshInterval: "5m"
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -774,7 +774,7 @@
                             "type": "object",
                             "properties": {
                                 "refreshInterval": {
-                                    "description": "Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies.",
+                                    "description": "Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. When empty, the Traefik Hub default (`1m`) applies.",
                                     "type": "string"
                                 },
                                 "validateRequestMethodAndPath": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -774,7 +774,7 @@
                             "type": "object",
                             "properties": {
                                 "refreshInterval": {
-                                    "description": "Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. When empty, the Traefik Hub default (`1m`) applies.",
+                                    "description": "Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`.",
                                     "type": "string"
                                 },
                                 "validateRequestMethodAndPath": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -773,6 +773,10 @@
                         "openApi": {
                             "type": "object",
                             "properties": {
+                                "refreshInterval": {
+                                    "description": "Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies.",
+                                    "type": "string"
+                                },
                                 "validateRequestMethodAndPath": {
                                     "description": "When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification",
                                     "type": "boolean"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -769,6 +769,10 @@
                         "openApi": {
                             "type": "object",
                             "properties": {
+                                "refreshInterval": {
+                                    "description": "Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies.",
+                                    "type": "string"
+                                },
                                 "validateRequestMethodAndPath": {
                                     "description": "When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification",
                                     "type": "boolean"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1331,7 +1331,7 @@ hub:  # @schema additionalProperties: false
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false
-      # -- Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies.
+      # -- Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. When empty, the Traefik Hub default (`1m`) applies.
       refreshInterval: ""
 
   mcpgateway:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1331,7 +1331,7 @@ hub:  # @schema additionalProperties: false
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false
-      # -- Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. 
+      # -- Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`.
       # @default -- `1m` when unset
       refreshInterval: ""
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1331,7 +1331,8 @@ hub:  # @schema additionalProperties: false
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false
-      # -- Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. When empty, the Traefik Hub default (`1m`) applies.
+      # -- Interval to refresh the OpenAPI specification, as a Go duration. Must be at least `1m`. 
+      # @default -- `1m` when unset
       refreshInterval: ""
 
   mcpgateway:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1331,6 +1331,8 @@ hub:  # @schema additionalProperties: false
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false
+      # -- Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies.
+      refreshInterval: ""
 
   mcpgateway:
     # -- Set to true in order to enable AI MCP Gateway. Requires a valid license token.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1321,6 +1321,8 @@ hub:  # @schema additionalProperties: false
     openApi:
       # -- When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification
       validateRequestMethodAndPath: false
+      # -- Interval to refresh the OpenAPI specification, as a Go duration. When empty, the provider default (`0`, disabled) applies.
+      refreshInterval: ""
 
   mcpgateway:
     # -- Set to true in order to enable AI MCP Gateway. Requires a valid license token.


### PR DESCRIPTION
### What does this PR do?

Maps the Traefik Hub 3.21 `--hub.apiManagement.openApi.refreshInterval` flag.

Emitted only when set, so Traefik Hub keeps its `1m` default. 

Gated on `hub.apimanagement.enabled` and Traefik Hub `>= v3.21.0` in `requirements.yaml`.

### Motivation

Traefik Hub 3.21 added `--hub.apimanagement.openapi.refreshinterval` to control how often the OpenAPI specification is refreshed. The chart had no mapping for it, so the only workaround was `additionalArguments`.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
