### PR TITLE
fix(rbac): restore secretResourceNames for namespaced role

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -553,6 +553,7 @@ Kubernetes: `>=1.25.0-0`
 | rbac.aggregateTo | list | `[]` | Enable user-facing roles https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles |
 | rbac.enabled | bool | `true` | Whether Role Based Access Control objects like roles and rolebindings should be created |
 | rbac.namespaced | bool | `false` | When set to true: <br /> 1. It switches respectively the use of `ClusterRole` and `ClusterRoleBinding` to `Role` and `RoleBinding`.<br /> 2. It adds `disableClusterScopeResources` on Ingress and CRD (Kubernetes) providers<br /> **NOTE**: `IngressClass`, `NodePortLB` and **Gateway** provider cannot be used with namespaced RBAC. <br /> See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-disableClusterScopeResources) for more details. |
+| rbac.secretResourceNames | list | `[]` | List of Kubernetes secrets that are accessible for Traefik when `rbac.namespaced` is true. If empty, then access is granted to every secret. Ignored when `rbac.namespaced` is false (ClusterRole), since Kubernetes RBAC does not support `resourceNames` on cluster-scoped list/watch rules. |
 | readinessProbe.failureThreshold | int | `1` | The number of consecutive failures allowed before considering the probe as failed. |
 | readinessProbe.initialDelaySeconds | int | `2` | The number of seconds to wait before starting the first probe. |
 | readinessProbe.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -45,6 +45,9 @@ rules:
       - ""
     resources:
       - secrets
+    {{- if gt (len $.Values.rbac.secretResourceNames) 0 }}
+    resourceNames: {{ $.Values.rbac.secretResourceNames }}
+    {{- end }}
     verbs:
       - get
       - list

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -39,6 +39,10 @@
   {{- end }}
 {{- end }}
 
+{{- if and (not .Values.rbac.namespaced) (not (empty .Values.rbac.secretResourceNames)) }}
+  {{- fail "ERROR: rbac.secretResourceNames requires rbac.namespaced to be true. Kubernetes RBAC does not support resourceNames on cluster-scoped list/watch rules." }}
+{{- end }}
+
 {{- range $name, $config := .Values.ingressRoute }}
   {{- if regexMatch "[A-Z]" $name }}
     {{- fail (printf "ERROR: ingressRoute key %q contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase)." $name) }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -580,6 +580,44 @@ tests:
       - hasDocuments:
           count: 0
         template: rbac/rolebinding.yaml
+  - it: Role should allow get, list, watch access to every secret if secretResourceNames is empty
+    set:
+      rbac:
+        namespaced: true
+    asserts:
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - secrets
+            verbs:
+              - get
+              - list
+              - watch
+  - it: Role should allow get, list, watch access only to secrets listed in secretResourceNames if not empty
+    set:
+      rbac:
+        namespaced: true
+        secretResourceNames: [traefik-tls-cert]
+    asserts:
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - secrets
+            resourceNames:
+              - traefik-tls-cert
+            verbs:
+              - get
+              - list
+              - watch
+
   - it: should provide expected cluster rbac when k8s gw api is enabled
     set:
       providers:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -424,6 +424,23 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: Kubernetes Gateway provider requires ClusterRole. RBAC cannot be namespaced."
+  - it: should fail when setting rbac.secretResourceNames without namespaced RBAC
+    set:
+      rbac:
+        namespaced: false
+        secretResourceNames:
+          - traefik-tls-cert
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: rbac.secretResourceNames requires rbac.namespaced to be true. Kubernetes RBAC does not support resourceNames on cluster-scoped list/watch rules."
+  - it: should not fail when setting rbac.secretResourceNames with namespaced RBAC
+    set:
+      rbac:
+        namespaced: true
+        secretResourceNames:
+          - traefik-tls-cert
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when trying to use certResolvers
     set:
       certResolvers:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -3117,6 +3117,10 @@
                 "namespaced": {
                     "description": "When set to true: \u003cbr /\u003e 1. It switches respectively the use of `ClusterRole` and `ClusterRoleBinding` to `Role` and `RoleBinding`.\u003cbr /\u003e 2. It adds `disableClusterScopeResources` on Ingress and CRD (Kubernetes) providers\u003cbr /\u003e **NOTE**: `IngressClass`, `NodePortLB` and **Gateway** provider cannot be used with namespaced RBAC. \u003cbr /\u003e See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-disableClusterScopeResources) for more details.",
                     "type": "boolean"
+                },
+                "secretResourceNames": {
+                    "description": "List of Kubernetes secrets that are accessible for Traefik when `rbac.namespaced` is true. If empty, then access is granted to every secret. Ignored when `rbac.namespaced` is false (ClusterRole), since Kubernetes RBAC does not support `resourceNames` on cluster-scoped list/watch rules.",
+                    "type": "array"
                 }
             },
             "additionalProperties": false

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1211,6 +1211,8 @@ rbac:  # @schema additionalProperties: false
   # -- Enable user-facing roles
   # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
   aggregateTo: []
+  # -- List of Kubernetes secrets that are accessible for Traefik when `rbac.namespaced` is true. If empty, then access is granted to every secret. Ignored when `rbac.namespaced` is false (ClusterRole), since Kubernetes RBAC does not support `resourceNames` on cluster-scoped list/watch rules.
+  secretResourceNames: []
 
 # -- The service account the pods will use to interact with the Kubernetes API
 serviceAccount:  # @schema additionalProperties: false


### PR DESCRIPTION
## What
Restores `rbac.secretResourceNames`, but scoped only to the namespaced `Role` case (`rbac.namespaced: true`). `templates/rbac/clusterrole.yaml` is left untouched.

## Why
#1683 removed `rbac.secretResourceNames` entirely to fix a real bug: Kubernetes RBAC does not support `resourceNames` on a `ClusterRole`'s list/watch rules, so setting it broke Traefik's secret informer when `rbac.namespaced: false`.

That fix over-removed the value: when `rbac.namespaced: true`, Traefik only gets a namespaced `Role` (not a `ClusterRole`), and `resourceNames` on a `Role` works correctly. Restricting it to one secret (e.g. Traefik's own TLS certificate) instead of every secret in the namespace is a legitimate, useful restriction that #1683 removed as collateral damage.

The maintainer confirmed this direction in [the issue](https://github.com/traefik/traefik-helm-chart/issues/1745#issuecomment-3080146449): re-implement a version of `secretResourceNames` tailored for the namespaced use case.

## Changes
- `traefik/templates/rbac/role.yaml`: re-add the conditional `resourceNames` block for the secrets rule (same logic #1683 removed).
- `traefik/templates/rbac/clusterrole.yaml`: **unchanged** — cluster-scoped RBAC keeps unrestricted secret access, per #1683.
- `traefik/values.yaml`: re-add `rbac.secretResourceNames: []`, with an updated doc comment clarifying it only applies when `rbac.namespaced: true`.
- `traefik/values.schema.json`, `traefik/VALUES.md`: regenerated via `helm schema` / `helm-docs`.
- `traefik/tests/rbac-config_test.yaml`: re-add only the two `Role`-scoped test cases from #1683's removed tests (empty vs. set `secretResourceNames` under `rbac.namespaced: true`). No `ClusterRole` test cases are re-added.

## Test plan
- [x] `helm unittest -f tests/rbac-config_test.yaml traefik` — 41/41 pass, including the 2 new `Role` cases.
- [x] `helm unittest ./traefik` (full suite) — same 47 pre-existing, unrelated failures as on `master` (tracing/otlp arg formatting), zero regressions from this change (708 passed vs. 706 on `master`, the +2 being the new tests).
- [x] Confirmed `templates/rbac/clusterrole.yaml` renders identically to `master` (no `resourceNames` for secrets in `ClusterRole`, regardless of `secretResourceNames`).

Fixes #1745