### PR TITLE
feat(ingressClass): make controller value configurable

### DIFF
--- a/traefik/templates/ingressclass.yaml
+++ b/traefik/templates/ingressclass.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "traefik.labels" . | nindent 4 }}
   name: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
 spec:
-  controller: traefik.io/ingress-controller
+  controller: {{ .Values.ingressClass.controller }}
 {{- end -}}

--- a/traefik/tests/ingressclass-config_test.yaml
+++ b/traefik/tests/ingressclass-config_test.yaml
@@ -42,3 +42,24 @@ tests:
       - equal:
           path: metadata.name
           value: nondefaultname
+  - it: should use default controller value
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.controller
+          value: traefik.io/ingress-controller
+  - it: should be possible to provide a custom controller value
+    set:
+      ingressClass:
+        controller: traefik.io/ingress-controller-internal
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.controller
+          value: traefik.io/ingress-controller-internal

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1501,6 +1501,11 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "controller": {
+                    "description": "The controller value for the IngressClass. This allows running multiple Traefik instances with different IngressClasses.",
+                    "type": "string",
+                    "default": "traefik.io/ingress-controller"
                 }
             },
             "additionalProperties": false

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -128,6 +128,9 @@ ingressClass:  # @schema additionalProperties: false
   enabled: true
   isDefaultClass: true
   name: ""
+  # -- The controller value for the IngressClass. This allows running multiple Traefik instances with different IngressClasses.
+  # @default -- `traefik.io/ingress-controller`
+  controller: traefik.io/ingress-controller
 
 core:  # @schema additionalProperties: false
   # -- Can be used to use globally v2 router syntax. Deprecated since v3.4 /!\.


### PR DESCRIPTION
## Description

This PR makes the IngressClass controller value configurable via `values.yaml`, enabling users to run multiple Traefik instances with isolated IngressClass routing in the same cluster.

## Problem

Currently, the IngressClass controller value is hardcoded as `traefik.io/ingress-controller` in the Helm chart template. This prevents users from running multiple Traefik instances (e.g., Internal and External) with proper traffic segregation, as both instances discover and process ALL ingresses regardless of the IngressClass name.

Fixes #13733

## Solution

Added a new `ingressClass.controller` field in `values.yaml` with a default value of `traefik.io/ingress-controller` to maintain backward compatibility. Users can now override this value to create unique controller identifiers for each Traefik instance.

## Changes

- **values.yaml**: Added `controller` field to `ingressClass` section with default value and documentation
- **templates/ingressclass.yaml**: Updated to use `{{ .Values.ingressClass.controller }}` instead of hardcoded value
- **values.schema.json**: Added `controller` property with appropriate schema definition
- **tests/ingressclass-config_test.yaml**: Added tests for default and custom controller values

## Example Usage

### Default Behavior (Backward Compatible)
```yaml
ingressClass:
  enabled: true
  name: traefik
  controller: traefik.io/ingress-controller  # default
```

### Multiple Traefik Instances with Isolated Routing
```yaml
# Traefik Internal Instance
ingressClass:
  enabled: true
  name: traefik-internal
  controller: traefik.io/ingress-controller-internal

# Traefik External Instance  
ingressClass:
  enabled: true
  name: traefik-external
  controller: traefik.io/ingress-controller-external
```

With this change, each Traefik instance will only process ingresses that reference its specific IngressClass, enabling proper traffic segregation.

## Testing

- ✅ All existing ingressClass tests pass
- ✅ Added test: "should use default controller value"
- ✅ Added test: "should be possible to provide a custom controller value"
- ✅ Backward compatible - default behavior unchanged

```bash
helm unittest -f 'tests/ingressclass-config_test.yaml' traefik

### Chart [ traefik ] traefik
 PASS  IngressClass configuration
Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```

## Checklist

- [x] Follows conventional commit format
- [x] Added documentation comments following helm-docs conventions
- [x] Updated values.schema.json
- [x] Added unit tests
- [x] All tests pass
- [x] Backward compatible

## Related Issues

- Fixes #13733
- Related to discussion in #7896 and #13402