### PR TITLE
feat: add `aliasHeadersStrategy` value

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -436,6 +436,7 @@ Kubernetes: `>=1.25.0-0`
 | ports.websecure.forwardedHeaders.notAppendXForwardedFor | bool | `false` | Disable appending RemoteAddr to X-Forwarded-For header (v3.7+). |
 | ports.websecure.forwardedHeaders.trustedIPs | list | `[]` | Trust forwarded headers information (X-Forwarded-*). |
 | ports.websecure.hostPort | int | `nil` | Use hostPort if set. |
+| ports.websecure.http.aliasHeadersStrategy | string | `nil` | Defines how request headers with non-alphanumeric characters in their names are handled (v3.7.12+). See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#aliasheadersstrategy) |
 | ports.websecure.http.encodedCharacters | object | nil | See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#encoded-character-filtering) |
 | ports.websecure.http.maxHeaderBytes | int | `nil` | Maximum size of request headers in bytes. Default: 1048576 (1 MB) |
 | ports.websecure.http.middlewares | list | `[]` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#httpmiddlewares) |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -692,6 +692,9 @@
           - "--{{$entryPoints}}.{{ $name }}.http.sanitizePath={{ . }}"
                {{- end }}
               {{- end }}
+              {{- with .aliasHeadersStrategy }}
+          - "--{{$entryPoints}}.{{ $name }}.http.aliasHeadersStrategy={{ . }}"
+              {{- end }}
               {{- with .underscoreHeadersStrategy }}
           - "--{{$entryPoints}}.{{ $name }}.http.underscoreHeadersStrategy={{ . }}"
               {{- end }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -139,6 +139,9 @@
   {{- if and $config (($config.forwardedHeaders).notAppendXForwardedFor) (semverCompare "<v3.7.0-0" $version) }}
     {{- fail "ERROR: forwardedHeaders.notAppendXForwardedFor is only available for traefik >= v3.7.0." }}
   {{- end }}
+  {{- if and $config (($config.http).aliasHeadersStrategy) (semverCompare "<v3.7.12-0" $version) }}
+    {{- fail "ERROR: http.aliasHeadersStrategy is only available for traefik >= v3.7.12." }}
+  {{- end }}
   {{- if and $config (($config.http).underscoreHeadersStrategy) (semverCompare "<v3.7.6-0" $version) }}
     {{- fail "ERROR: http.underscoreHeadersStrategy is only available for traefik >= v3.7.6." }}
   {{- end }}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -534,6 +534,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: request path security options are only available for traefik >= v3.6.4."
+  - it: should fail when using aliasHeadersStrategy on traefik < 3.7.12
+    set:
+      image:
+        tag: v3.7.5
+      ports:
+        websecure:
+          http:
+            aliasHeadersStrategy: reject
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: http.aliasHeadersStrategy is only available for traefik >= v3.7.12."
   - it: should fail when using underscoreHeadersStrategy on traefik < 3.7.6
     set:
       image:

--- a/traefik/tests/security-config_test.yaml
+++ b/traefik/tests/security-config_test.yaml
@@ -49,7 +49,20 @@ tests:
           content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=false"
       - notContains:
           path: spec.template.spec.containers[0].args
+          content: "--entryPoints.websecure.http.aliasHeadersStrategy=keep"
+      - notContains:
+          path: spec.template.spec.containers[0].args
           content: "--entryPoints.websecure.http.underscoreHeadersStrategy=keep"
+  - it: should be possible to set aliasHeadersStrategy on websecure
+    set:
+      ports:
+        websecure:
+          http:
+            aliasHeadersStrategy: reject
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.websecure.http.aliasHeadersStrategy=reject"
   - it: should be possible to set underscoreHeadersStrategy on websecure
     set:
       ports:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2303,6 +2303,19 @@
                     "http": {
                         "type": "object",
                         "properties": {
+                            "aliasHeadersStrategy": {
+                                "description": "Defines how request headers with non-alphanumeric characters in their names are handled (v3.7.12+). See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#aliasheadersstrategy)",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "keep",
+                                    "delete",
+                                    "reject",
+                                    null
+                                ]
+                            },
                             "encodedCharacters": {
                                 "description": "See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#encoded-character-filtering)",
                                 "type": "object",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1044,6 +1044,9 @@ ports:
       middlewares: []  # @schema type: [array, null]
       # -- (bool) See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#path-sanitization)
       sanitizePath:  # @schema type:[boolean, null]
+      # -- Defines how request headers with non-alphanumeric characters in their names are handled (v3.7.12+).
+      # See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#aliasheadersstrategy)
+      aliasHeadersStrategy:  # @schema enum:[keep, delete, reject, null]; type:[string, null]
       # -- Defines how request headers with underscores in their names are handled (v3.7.6+).
       # See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy)
       underscoreHeadersStrategy:  # @schema enum:[keep, delete, reject, null]; type:[string, null]


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Add an `aliasHeadersStrategy` value to allow usage with Traefik v3.7.12.

See also #1981.

### Motivation

<!-- What inspired you to submit this pull request? -->
https://doc.traefik.io/traefik/v3.7/migrate/v3/#v3712

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

