### PR TITLE
feat: deprecate `underscoreHeadersStrategy` value

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -445,7 +445,7 @@ Kubernetes: `>=1.25.0-0`
 | ports.websecure.http.tls.domains | list | `[]` |  |
 | ports.websecure.http.tls.enabled | bool | true | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#opt-http-tls) |
 | ports.websecure.http.tls.options | string | `""` |  |
-| ports.websecure.http.underscoreHeadersStrategy | string | `nil` | Defines how request headers with underscores in their names are handled (v3.7.6+). See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy) |
+| ports.websecure.http.underscoreHeadersStrategy | string | `nil` | Defines how request headers with underscores in their names are handled (v3.7.6-v3.7.11). Replaced by the aliasHeadersStrategy option for Traefik v3.7.12+. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy) |
 | ports.websecure.http3.advertisedPort | int | `nil` | Defines the UDP port to advertise as the HTTP/3 authority. |
 | ports.websecure.http3.enabled | bool | `false` | Enable HTTP/3 on the entrypoint. It also enables the http3 experimental feature. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#opt-http3). There are known limitations when trying to listen on same ports for TCP & UDP ([kubernetes#47249](https://github.com/kubernetes/kubernetes/issues/47249#issuecomment-587960741)): this chart works around it using a dual Service. |
 | ports.websecure.nodePort | int | `nil` | See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -177,3 +177,13 @@ You will need to install them yourself before deploying Traefik v3.7:
     {{- printf "\nWARNING: webhook secret %s for Traefik hub is self managed and was not found in %s namespace.\n" $.Values.hub.apimanagement.admission.secretName (include "traefik.namespace" .) -}}
   {{- end -}}
 {{- end -}}
+
+{{/* Warn about deprecated underscoreHeadersStrategy option */}}
+{{- range $name, $config := .Values.ports }}
+  {{- if and $config (($config.http).underscoreHeadersStrategy) (semverCompare ">=v3.7.12-0" $version) }}
+    {{- printf "\n" -}}
+⚠️ DEPRECATION WARNING: 'http.underscoreHeadersStrategy' is deprecated and replaced with 'http.aliasHeadersStrategy' for traefik >= v3.7.12.
+This option will be dropped from this chart in a future major version.
+    {{- printf "\n" -}}
+  {{- end -}}
+{{- end -}}

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -175,5 +175,5 @@ You will need to install them yourself before deploying Traefik v3.7:
   {{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
   {{- if not $cert }}
     {{- printf "\nWARNING: webhook secret %s for Traefik hub is self managed and was not found in %s namespace.\n" $.Values.hub.apimanagement.admission.secretName (include "traefik.namespace" .) -}}
-  {{- end -}}        
+  {{- end -}}
 {{- end -}}

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -343,3 +343,19 @@ tests:
       - equalRaw:
           value: |
             RELEASE-NAME with myrepo/traefik-hub:v3.20.4 has been deployed successfully on NAMESPACE namespace!
+
+  - it: should warn when using underscoreHeadersStrategy on traefik >= 3.7.12
+    set:
+      image:
+        tag: v3.7.12
+      ports:
+        websecure:
+          http:
+            underscoreHeadersStrategy: reject
+    asserts:
+      - equalRaw:
+          value: |
+            RELEASE-NAME with docker.io/traefik:v3.7.12 has been deployed successfully on NAMESPACE namespace!
+
+            ⚠️ DEPRECATION WARNING: 'http.underscoreHeadersStrategy' is deprecated and replaced with 'http.aliasHeadersStrategy' for traefik >= v3.7.12.
+            This option will be dropped from this chart in a future major version.

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2415,7 +2415,8 @@
                                 }
                             },
                             "underscoreHeadersStrategy": {
-                                "description": "Defines how request headers with underscores in their names are handled (v3.7.6+). See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy)",
+                                "description": "Defines how request headers with underscores in their names are handled (v3.7.6-v3.7.11). Replaced by the aliasHeadersStrategy option for Traefik v3.7.12+. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy)",
+                                "deprecated": true,
                                 "type": [
                                     "string",
                                     "null"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1047,9 +1047,10 @@ ports:
       # -- Defines how request headers with non-alphanumeric characters in their names are handled (v3.7.12+).
       # See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#aliasheadersstrategy)
       aliasHeadersStrategy:  # @schema enum:[keep, delete, reject, null]; type:[string, null]
-      # -- Defines how request headers with underscores in their names are handled (v3.7.6+).
+      # -- Defines how request headers with underscores in their names are handled (v3.7.6-v3.7.11).
+      # Replaced by the aliasHeadersStrategy option for Traefik v3.7.12+.
       # See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy)
-      underscoreHeadersStrategy:  # @schema enum:[keep, delete, reject, null]; type:[string, null]
+      underscoreHeadersStrategy:  # @schema deprecated; enum:[keep, delete, reject, null]; type:[string, null]
       tls:
         # -- See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#opt-http-tls)
         # @default -- true


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Deprecate the `underscoreHeadersStrategy` value, which has been replaced with `aliasHeadersStrategy` in Traefik v3.7.12.

The emitted deprecation notice is worded vaguely by design, so that we may freely decide on whether or not to already drop this in the next major chart release, wait a bit or even wait until Traefik v4.

Requires #1981 and #1982 to be merged first.

### Motivation

<!-- What inspired you to submit this pull request? -->
Help users keep their values up-to-date.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

