### PR TITLE
chore(release): 🚀 publish 41.5.0

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 41.5.0  ![AppVersion: v3.7.13](https://img.shields.io/static/v1?label=AppVersion&message=v3.7.13&color=success&logo=) ![Kubernetes: >=1.25.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.25.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2026-09-07
+
+* fix: grant ConfigMap write verbs to namespaced role
+* feat(deps): update traefik docker tag to v3.7.13
+* feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.13
+* feat(CRDs): update Traefik Hub to v1.34.0
+* chore(release): 🚀 publish 41.5.0
+
+
+
 ## 41.4.0  ![AppVersion: v3.7.12](https://img.shields.io/static/v1?label=AppVersion&message=v3.7.12&color=success&logo=) ![Kubernetes: >=1.25.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.25.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2026-08-27

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 41.4.0
+version: 41.5.0
 # renovate: image=traefik
 appVersion: v3.7.13
 kubeVersion: '>=1.25.0-0'
@@ -28,16 +28,10 @@ annotations:
   traefik.io/hub-max-version: v3.20.13
   artifacthub.io/changes: |
     - kind: fixed
-      description: "fix: hub/proxy mapping"
-    - kind: fixed
-      description: "fix(rbac): restore secretResourceNames for namespaced role"
+      description: "fix: grant ConfigMap write verbs to namespaced role"
     - kind: added
-      description: "feat: deprecate `underscoreHeadersStrategy` value"
+      description: "feat(deps): update traefik docker tag to v3.7.13"
     - kind: added
-      description: "feat: add `aliasHeadersStrategy` value"
+      description: "feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.13"
     - kind: added
-      description: "feat(hub): support apiManagement OpenAPI refresh interval"
-    - kind: added
-      description: "feat(deps): update traefik docker tag to v3.7.12"
-    - kind: added
-      description: "feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.12"
+      description: "feat(CRDs): update Traefik Hub to v1.34.0"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 41.4.0](https://img.shields.io/badge/Version-41.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.13](https://img.shields.io/badge/AppVersion-v3.7.13-informational?style=flat-square)
+![Version: 41.5.0](https://img.shields.io/badge/Version-41.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.13](https://img.shields.io/badge/AppVersion-v3.7.13-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Release a new version of this Chart.

### Motivation

Support of Traefik proxy v3.7.13 and Traefik-Hub v3.20.13.
