### PR TITLE
fix: grant ConfigMap write verbs to namespaced role

### DIFF
--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -152,6 +152,14 @@ rules:
       - watch
   {{- if $.Values.hub.apimanagement.enabled }}
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - patch
+      - delete
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -946,6 +946,91 @@ tests:
               - update
               - patch
 
+  - it: should contain ConfigMap write permissions for hub API management in namespaced mode
+    set:
+      hub:
+        token: xxx
+        apimanagement:
+          enabled: true
+      rbac:
+        namespaced: true
+    asserts:
+      - template: rbac/role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
+
+  - it: should contain ConfigMap write permissions in every hub namespace
+    set:
+      hub:
+        token: xxx
+        namespaces:
+          - bar
+        apimanagement:
+          enabled: true
+      rbac:
+        namespaced: true
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: rbac/role.yaml
+      - template: rbac/role.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
+      - template: rbac/role.yaml
+        documentIndex: 1
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
+
+  - it: should not contain ConfigMap write permissions in namespaced mode without hub API management
+    set:
+      hub:
+        token: xxx
+        apimanagement:
+          enabled: false
+      rbac:
+        namespaced: true
+    asserts:
+      - template: rbac/role.yaml
+        notContains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - patch
+              - delete
+
   - it: should provide expected RBACS for Hub version >3.3.2 and <3.7.0
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Adds the `configmaps` write verbs (`create`, `patch`, `delete`) to the namespaced `Role`, which so far only the `ClusterRole` had.

### Motivation

API Management stores OpenAPI specs in ConfigMaps, so it fails to start with `rbac.namespaced=true`.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
