### PR TITLE
fix: use kubeversion to determine PDB apiVersion

### DIFF
--- a/traefik/templates/poddisruptionbudget.yaml
+++ b/traefik/templates/poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "traefik.fullname" . }}

--- a/traefik/templates/poddisruptionbudget.yaml
+++ b/traefik/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Ensure predictable templating by using `Capabilities.KubeVersion` instead of `Capabilities.ApiVersions` to determine the `apiVersion` to use for `PodDisruptionBudget`.

### Motivation

<!-- What inspired you to submit this pull request? -->
Releasing traefik through pre-rendered manifests and GitOps can produce incompatible resources, in this case seemingly limited to the PDB.

https://github.com/traefik/traefik-helm-chart/issues/2000

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

